### PR TITLE
Implement shouldBeRequiredByOthersToFail

### DIFF
--- a/AndroidNativeExample/app/src/main/java/com/swmansion/gesturehandler/example/MainActivity.java
+++ b/AndroidNativeExample/app/src/main/java/com/swmansion/gesturehandler/example/MainActivity.java
@@ -12,6 +12,7 @@ import android.widget.Toast;
 import com.swmansion.gesturehandler.GestureHandler;
 import com.swmansion.gesturehandler.GestureHandlerRegistryImpl;
 import com.swmansion.gesturehandler.GestureHandlerViewWrapper;
+import com.swmansion.gesturehandler.LongPressGestureHandler;
 import com.swmansion.gesturehandler.NativeViewGestureHandler;
 import com.swmansion.gesturehandler.OnTouchEventListener;
 import com.swmansion.gesturehandler.TapGestureHandler;
@@ -52,9 +53,23 @@ public class MainActivity extends AppCompatActivity {
             .setShouldActivateOnStart(true)
             .setShouldCancelWhenOutside(false);
 
+    registry.registerHandlerForView(block, new LongPressGestureHandler())
+            .setOnTouchEventListener(new OnTouchEventListener<LongPressGestureHandler>() {
+              @Override
+              public void onTouchEvent(LongPressGestureHandler handler, MotionEvent event) {
+
+              }
+
+              @Override
+              public void onStateChange(LongPressGestureHandler handler, int newState, int oldState) {
+                if (newState == GestureHandler.STATE_ACTIVE) {
+                  Toast.makeText(MainActivity.this, "Long press", Toast.LENGTH_SHORT).show();
+                }
+              }
+            });
+
     registry.registerHandlerForView(block, new TapGestureHandler())
             .setNumberOfTaps(2)
-            .setMaxDurationMs(5000)
             .setShouldBeRequiredByOthersToFail(true)
             .setOnTouchEventListener(new OnTouchEventListener<TapGestureHandler>() {
               @Override
@@ -72,7 +87,6 @@ public class MainActivity extends AppCompatActivity {
 
     registry.registerHandlerForView(block, new TapGestureHandler())
             .setNumberOfTaps(1)
-            .setMaxDurationMs(5000)
             .setOnTouchEventListener(new OnTouchEventListener<TapGestureHandler>() {
               @Override
               public void onTouchEvent(TapGestureHandler handler, MotionEvent event) {

--- a/AndroidNativeExample/app/src/main/java/com/swmansion/gesturehandler/example/MainActivity.java
+++ b/AndroidNativeExample/app/src/main/java/com/swmansion/gesturehandler/example/MainActivity.java
@@ -14,7 +14,7 @@ import com.swmansion.gesturehandler.GestureHandlerRegistryImpl;
 import com.swmansion.gesturehandler.GestureHandlerViewWrapper;
 import com.swmansion.gesturehandler.NativeViewGestureHandler;
 import com.swmansion.gesturehandler.OnTouchEventListener;
-import com.swmansion.gesturehandler.PanGestureHandler;
+import com.swmansion.gesturehandler.TapGestureHandler;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -49,24 +49,59 @@ public class MainActivity extends AppCompatActivity {
     registry.registerHandlerForView(scrollView, new NativeViewGestureHandler());
     registry.registerHandlerForView(button, new NativeViewGestureHandler());
     registry.registerHandlerForView(seekBar, new NativeViewGestureHandler())
+            .setShouldActivateOnStart(true)
             .setShouldCancelWhenOutside(false);
 
-    registry.registerHandlerForView(block, new PanGestureHandler())
-            .setShouldCancelOthersWhenActivated(true)
-            .setMinDy(2)
-            .setCanStartHandlingWithDownEventOnly(true)
-            .setOnTouchEventListener(new OnTouchEventListener<PanGestureHandler>() {
+    registry.registerHandlerForView(block, new TapGestureHandler())
+            .setNumberOfTaps(2)
+            .setMaxDurationMs(5000)
+            .setShouldBeRequiredByOthersToFail(true)
+            .setOnTouchEventListener(new OnTouchEventListener<TapGestureHandler>() {
               @Override
-              public void onTouchEvent(PanGestureHandler handler, MotionEvent event) {
-                if (handler.getState() == GestureHandler.STATE_ACTIVE) {
-                  block.setTranslationX(handler.getTranslationX());
-                  block.setTranslationY(handler.getTranslationY());
-                }
+              public void onTouchEvent(TapGestureHandler handler, MotionEvent event) {
+
               }
 
               @Override
-              public void onStateChange(PanGestureHandler handler, int newState, int oldState) {
+              public void onStateChange(TapGestureHandler handler, int newState, int oldState) {
+                if (newState == GestureHandler.STATE_ACTIVE) {
+                  Toast.makeText(MainActivity.this, "I'm d0able tapped", Toast.LENGTH_SHORT).show();
+                }
               }
             });
+
+    registry.registerHandlerForView(block, new TapGestureHandler())
+            .setNumberOfTaps(1)
+            .setMaxDurationMs(5000)
+            .setOnTouchEventListener(new OnTouchEventListener<TapGestureHandler>() {
+              @Override
+              public void onTouchEvent(TapGestureHandler handler, MotionEvent event) {
+
+              }
+
+              @Override
+              public void onStateChange(TapGestureHandler handler, int newState, int oldState) {
+                if (newState == GestureHandler.STATE_ACTIVE) {
+                  Toast.makeText(MainActivity.this, "I'm tapped once", Toast.LENGTH_SHORT).show();
+                }
+              }
+            });
+//    registry.registerHandlerForView(block, new PanGestureHandler())
+//            .setShouldCancelOthersWhenActivated(true)
+//            .setMinDy(2)
+//            .setCanStartHandlingWithDownEventOnly(true)
+//            .setOnTouchEventListener(new OnTouchEventListener<PanGestureHandler>() {
+//              @Override
+//              public void onTouchEvent(PanGestureHandler handler, MotionEvent event) {
+//                if (handler.getState() == GestureHandler.STATE_ACTIVE) {
+//                  block.setTranslationX(handler.getTranslationX());
+//                  block.setTranslationY(handler.getTranslationY());
+//                }
+//              }
+//
+//              @Override
+//              public void onStateChange(PanGestureHandler handler, int newState, int oldState) {
+//              }
+//            });
   }
 }

--- a/Example/index.android.js
+++ b/Example/index.android.js
@@ -111,16 +111,26 @@ class PressBox extends Component {
       ToastAndroid.show("I'm being pressed for so long", ToastAndroid.SHORT);
     }
   }
-  _onTap = (event) => {
+  _onSingleTap = (event) => {
     if (event.nativeEvent.state === State.ACTIVE) {
       ToastAndroid.show("I'm touched", ToastAndroid.SHORT);
+    }
+  }
+  _onDoubleTap = (event) => {
+    if (event.nativeEvent.state === State.ACTIVE) {
+      ToastAndroid.show("D0able tap, good job!", ToastAndroid.SHORT);
     }
   }
   render() {
     return (
       <LongPressGestureHandler onHandlerStateChange={this._onHandlerStateChange}>
-        <TapGestureHandler onHandlerStateChange={this._onTap}>
-          <View style={styles.box}/>
+        <TapGestureHandler onHandlerStateChange={this._onSingleTap}>
+          <TapGestureHandler
+            onHandlerStateChange={this._onDoubleTap}
+            numberOfTaps={2}
+            shouldBeRequiredByOthersToFail={true}>
+            <View style={styles.box}/>
+          </TapGestureHandler>
         </TapGestureHandler>
       </LongPressGestureHandler>
     );

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -9,8 +9,6 @@ import {
   WebView,
 } from 'react-native';
 
-
-
 import NativeModules from 'NativeModules';
 import findNodeHandle from 'react/lib/findNodeHandle';
 
@@ -25,7 +23,7 @@ let handlerTag = 1
 const GestureHandlerPropTypes = {
   shouldCancelWhenOutside: PropTypes.bool,
   shouldCancelOthersWhenActivated: PropTypes.bool,
-  canStartHandlingWithDownEventOnly: PropTypes.bool,
+  shouldBeRequiredByOthersToFail: PropTypes.bool,
   onGestureEvent: PropTypes.func,
   onHandlerStateChange: PropTypes.func,
 }
@@ -90,7 +88,6 @@ function createHandler(handlerName, propTypes = null) {
     }
 
     render() {
-      console.log("Redner", handlerName, Object.keys(this.props));
       const child = React.Children.only(this.props.children);
       return React.cloneElement(child, {
         ref: CHILD_REF,
@@ -103,8 +100,14 @@ function createHandler(handlerName, propTypes = null) {
   return Handler;
 }
 
-const NativeViewGestureHandler = createHandler('NativeViewGestureHandler');
-const TapGestureHandler = createHandler('TapGestureHandler');
+const NativeViewGestureHandler = createHandler('NativeViewGestureHandler', {
+  shouldActivateOnStart: PropTypes.bool,
+});
+const TapGestureHandler = createHandler('TapGestureHandler', {
+  maxDurationMs: PropTypes.number,
+  maxDelayMs: PropTypes.number,
+  numberOfTaps: PropTypes.number,
+});
 const LongPressGestureHandler = createHandler('LongPressGestureHandler', {
   minDurationMs: PropTypes.number,
 });
@@ -140,7 +143,7 @@ function createNativeWrapper(Component, config = {}) {
 }
 
 const WrappedScrollView = createNativeWrapper(ScrollView);
-const WrappedSlider = createNativeWrapper(Slider, { shouldCancelWhenOutside: false });
+const WrappedSlider = createNativeWrapper(Slider, { shouldCancelWhenOutside: false, shouldActivateOnStart: true });
 const WrappedSwitch = createNativeWrapper(Switch);
 const WrappedTextInput = createNativeWrapper(TextInput);
 const WrappedToolbarAndroid = createNativeWrapper(ToolbarAndroid);

--- a/README.md
+++ b/README.md
@@ -69,14 +69,25 @@ Last available element exported by the library is a dictionary of constants used
  - `State.BEGAN`
  - `State.CANCELLED`
  - `State.ACTIVE`
+ - `State.END`
 
 #### Common `GestureHandler` properties
 
  - `shouldCancelWhenOutside`
  - `shouldCancelOthersWhenActivated`
- - `canStartHandlingWithDownEventOnly`
+ - `shouldBeRequiredByOthersToFail`
  - `onGestureEvent`
  - `onHandlerStateChange`
+
+#### `TapGestureHandler` extra properties
+
+ - `maxDurationMs`
+ - `maxDelayMs`
+ - `numberOfTaps`
+
+#### `NativeViewGestureHandler` extra properties
+
+ - `shouldActivateOnStart`
 
 #### `LongPressGestureHandler` extra properties
 
@@ -92,7 +103,7 @@ Last available element exported by the library is a dictionary of constants used
 
 ## Roadmap
 
- - Build two more gesture recognizers: `DoubleTapGestuerHandler`, `FlingGestureHandler`
+ - Build one more gesture recognizer: `FlingGestureHandler`
  - Send out necessary updates to RN core for native animated event support
  - Support for multi-touch events (build `PinchGestureHandler`)
  - iOS port

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.java
@@ -91,6 +91,7 @@ public class GestureHandler<T extends GestureHandler> {
     if (mState == STATE_ACTIVE) {
       if (mShouldCancelWhenOutside && !isWithinBounds(event)) {
         cancel();
+        return;
       }
     }
     onHandle(event);

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.java
@@ -10,19 +10,32 @@ public class GestureHandler<T extends GestureHandler> {
   public static final int STATE_BEGAN = 3;
   public static final int STATE_CANCELLED = 4;
   public static final int STATE_ACTIVE = 5;
+  public static final int STATE_END = 6;
 
   private int mTag;
   private View mView;
   private int mState = STATE_UNDETERMINED;
-  private boolean mHasStarted = false;
   private float mX, mY;
 
   private boolean mShouldCancelWhenOutside;
   private boolean mShouldCancelOthersWhenActivated;
-  private boolean mCanStartHandlingWithDownEventOnly;
+  private boolean mShouldBeRequiredByOthersToFail;
 
   private GestureHandlerOrchestrator mOrchestrator;
   private OnTouchEventListener<T> mListener;
+  /*package*/ boolean mIsActive; // set and accessed only by the orchestrator
+
+  /*package*/ void dispatchStateChange(int newState, int prevState) {
+    if (mListener != null) {
+      mListener.onStateChange((T) this, newState, prevState);
+    }
+  }
+
+  /*package*/ void dispatchTouchEvent(MotionEvent event) {
+    if (mListener != null) {
+      mListener.onTouchEvent((T) this, event);
+    }
+  }
 
   public T setShouldCancelWhenOutside(boolean shouldCancelWhenOutside) {
     mShouldCancelWhenOutside = shouldCancelWhenOutside;
@@ -34,8 +47,8 @@ public class GestureHandler<T extends GestureHandler> {
     return (T) this;
   }
 
-  public T setCanStartHandlingWithDownEventOnly(boolean canStartHandlingWithDownEventOnly) {
-    mCanStartHandlingWithDownEventOnly = canStartHandlingWithDownEventOnly;
+  public T setShouldBeRequiredByOthersToFail(boolean shouldBeRequiredByOthersToFail) {
+    mShouldBeRequiredByOthersToFail = shouldBeRequiredByOthersToFail;
     return (T) this;
   }
 
@@ -63,56 +76,52 @@ public class GestureHandler<T extends GestureHandler> {
     if (mView != null || mOrchestrator != null) {
       throw new IllegalStateException("Already prepared or hasn't been reset");
     }
+    mState = STATE_UNDETERMINED;
+
     mView = view;
     mOrchestrator = orchestrator;
   }
 
   public final void handle(MotionEvent event) {
-    if (mState == STATE_CANCELLED || mState == STATE_FAILED) {
+    if (mState == STATE_CANCELLED || mState == STATE_FAILED || mState == STATE_END) {
       return;
     }
     mX = event.getX();
     mY = event.getY();
-    if (mCanStartHandlingWithDownEventOnly && !mHasStarted &&
-            event.getActionMasked() != MotionEvent.ACTION_DOWN) {
-      moveToState(STATE_FAILED);
-    } else {
-      mHasStarted = true;
-      if (mState == STATE_ACTIVE) {
-        if (mShouldCancelWhenOutside && !isWithinBounds(event)) {
-          cancel();
-        }
+    if (mState == STATE_ACTIVE) {
+      if (mShouldCancelWhenOutside && !isWithinBounds(event)) {
+        cancel();
       }
-      onHandle(event);
     }
-    if (mListener != null) {
-      mListener.onTouchEvent((T) this, event);
-    }
+    onHandle(event);
   }
 
-  public void moveToState(int newState) {
+  private void moveToState(int newState) {
     if (mState == newState) {
       return;
     }
     int oldState = mState;
     mState = newState;
-    if (newState == STATE_ACTIVE) {
-      if (mShouldCancelOthersWhenActivated) {
-        mOrchestrator.cancelOtherGestureHandlers(this);
-      }
-    }
-    onStateChange(oldState, newState);
-    if (mListener != null) {
-      mListener.onStateChange((T) this, newState, oldState);
-    }
+
+    mOrchestrator.onHandlerStateChange(this, newState, oldState);
+
+    onStateChange(newState, oldState);
   }
 
   public boolean wantEvents() {
-    return mState != STATE_FAILED && mState != STATE_CANCELLED;
+    return mState != STATE_FAILED && mState != STATE_CANCELLED && mState != STATE_END;
   }
 
   public int getState() {
     return mState;
+  }
+
+  public boolean isRequiredByHandlerToFail(GestureHandler handler) {
+    return handler != this && mShouldBeRequiredByOthersToFail;
+  }
+
+  public boolean isRequiredToCancelUponHandlerActivation(GestureHandler handler) {
+    return handler != this && handler.mShouldCancelOthersWhenActivated;
   }
 
   protected boolean isWithinBounds(MotionEvent event) {
@@ -128,34 +137,57 @@ public class GestureHandler<T extends GestureHandler> {
     }
   }
 
+  public final void fail() {
+    if (mState == STATE_ACTIVE || mState == STATE_UNDETERMINED || mState == STATE_BEGAN) {
+      moveToState(STATE_FAILED);
+    }
+  }
+
+  public final void activate() {
+    if (mState == STATE_UNDETERMINED || mState == STATE_BEGAN) {
+      moveToState(STATE_ACTIVE);
+    }
+  }
+
+  public final void begin() {
+    if (mState == STATE_UNDETERMINED) {
+      moveToState(STATE_BEGAN);
+    }
+  }
+
+  public final void end() {
+    if (mState == STATE_BEGAN || mState == STATE_ACTIVE) {
+      moveToState(STATE_END);
+    }
+  }
+
   protected void onHandle(MotionEvent event) {
     moveToState(STATE_FAILED);
   }
 
-  protected void onCancel() {
+  protected void onStateChange(int newState, int previousState) {
   }
 
   protected void onReset() {
   }
 
-  protected void onStateChange(int previousState, int newState) {
+  protected void onCancel() {
   }
 
   public final void reset() {
-    onReset();
-    moveToState(STATE_UNDETERMINED);
     mView = null;
     mOrchestrator = null;
-    mHasStarted = false;
+    onReset();
   }
 
-  protected static String stateToString(int state) {
+  public static String stateToString(int state) {
     switch (state) {
       case STATE_UNDETERMINED: return "UNDETERMINED";
       case STATE_ACTIVE: return "ACTIVE";
       case STATE_FAILED: return "FAILED";
       case STATE_BEGAN: return "BEGIN";
       case STATE_CANCELLED: return "CANCELLED";
+      case STATE_END: return "END";
     }
     return null;
   }
@@ -163,5 +195,10 @@ public class GestureHandler<T extends GestureHandler> {
   public GestureHandler setOnTouchEventListener(OnTouchEventListener<T> listener) {
     mListener = listener;
     return this;
+  }
+
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName() + "@" + mView;
   }
 }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.java
@@ -9,11 +9,9 @@ public class LongPressGestureHandler extends GestureHandler<LongPressGestureHand
   private static final long DEFAULT_MIN_DURATION_MS = 1000; // 1 sec
 
   private long mMinDurationMs = DEFAULT_MIN_DURATION_MS;
-  private long mStarted;
   private Handler mHandler;
 
   public LongPressGestureHandler() {
-    setCanStartHandlingWithDownEventOnly(true);
     setShouldCancelWhenOutside(true);
     setShouldCancelOthersWhenActivated(true);
   }
@@ -25,34 +23,27 @@ public class LongPressGestureHandler extends GestureHandler<LongPressGestureHand
   @Override
   protected void onHandle(MotionEvent event) {
     if (getState() == STATE_UNDETERMINED) {
-      moveToState(STATE_BEGAN);
-      mStarted = SystemClock.uptimeMillis();
+      begin();
       mHandler = new Handler();
       mHandler.postDelayed(new Runnable() {
         @Override
         public void run() {
-          moveToState(STATE_ACTIVE);
+          activate();
+          end();
         }
       }, mMinDurationMs);
     }
-    if (getState() == STATE_BEGAN) {
-      long elapsed = SystemClock.uptimeMillis() - mStarted;
-      if (elapsed > mMinDurationMs) {
-        moveToState(STATE_ACTIVE);
+    if (event.getActionMasked() == MotionEvent.ACTION_UP) {
+      if (mHandler != null) {
+        mHandler.removeCallbacksAndMessages(null);
+        mHandler = null;
       }
+      fail();
     }
   }
 
   @Override
-  protected void onStateChange(int previousState, int newState) {
-    if (mHandler != null) {
-      mHandler.removeCallbacksAndMessages(null);
-      mHandler = null;
-    }
-  }
-
-  @Override
-  protected void onReset() {
+  protected void onStateChange(int newState, int previousState) {
     if (mHandler != null) {
       mHandler.removeCallbacksAndMessages(null);
       mHandler = null;

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/NativeViewGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/NativeViewGestureHandler.java
@@ -9,35 +9,61 @@ import com.swmansion.gesturehandler.GestureHandler;
 
 public class NativeViewGestureHandler extends GestureHandler<NativeViewGestureHandler> {
 
+  private boolean mShouldActivateOnStart;
+
   public NativeViewGestureHandler() {
     setShouldCancelOthersWhenActivated(true);
-    setCanStartHandlingWithDownEventOnly(true);
     setShouldCancelWhenOutside(true);
+  }
+
+  public NativeViewGestureHandler setShouldActivateOnStart(boolean shouldActivateOnStart) {
+    mShouldActivateOnStart = shouldActivateOnStart;
+    return this;
   }
 
   @Override
   protected void onHandle(MotionEvent event) {
+    View view = getView();
+    if (view instanceof ViewGroup) {
+      onHandleForViewGroup((ViewGroup) view, event);
+    } else {
+      onHandleForView(view, event);
+    }
+  }
+
+  private void onHandleForView(View view, MotionEvent event) {
+    if (getState() == STATE_UNDETERMINED) {
+      begin();
+    }
+    int action = event.getActionMasked();
+    if (mShouldActivateOnStart && action == MotionEvent.ACTION_DOWN) {
+      activate();
+    } else if (action ==  MotionEvent.ACTION_UP) {
+      activate();
+      end();
+    }
+    view.onTouchEvent(event);
+  }
+
+  private void onHandleForViewGroup(ViewGroup view, MotionEvent event) {
     int state = getState();
-    boolean shouldCallOnIntercept = (getView() instanceof ViewGroup);
-    if ((state == STATE_UNDETERMINED || state == STATE_BEGAN)) {
-      if (shouldCallOnIntercept) {
-        if (((ViewGroup) getView()).onInterceptTouchEvent(event)) {
-          moveToState(STATE_ACTIVE);
-        } else if (state != STATE_BEGAN) {
-          moveToState(STATE_BEGAN);
-        }
-      } else {
-        moveToState(STATE_ACTIVE);
+    if (state == STATE_UNDETERMINED || state == STATE_BEGAN) {
+      if (view.onInterceptTouchEvent(event)) {
+        activate();
+      } else if (state != STATE_BEGAN) {
+        begin();
       }
     }
     if (getState() == STATE_ACTIVE) {
-      getView().onTouchEvent(event);
+      view.onTouchEvent(event);
+    }
+    if (event.getActionMasked() == MotionEvent.ACTION_UP) {
+      end();
     }
   }
 
   @Override
   protected void onCancel() {
-//    int restoreAction = event.getAction();
     long time = SystemClock.uptimeMillis();
     MotionEvent event = MotionEvent.obtain(time, time, MotionEvent.ACTION_CANCEL, 0, 0, 0);
     event.setAction(MotionEvent.ACTION_CANCEL);

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
@@ -52,7 +52,13 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
       mStartY = mLastY;
       mVelocityTracker = VelocityTracker.obtain();
       mVelocityTracker.addMovement(event);
-      moveToState(STATE_BEGAN);
+      begin();
+    } else if (event.getActionMasked() == MotionEvent.ACTION_UP) {
+      if (state == STATE_ACTIVE) {
+        end();
+      } else {
+        fail();
+      }
     } else if (state == STATE_BEGAN) {
       float dx = Math.abs(mStartX - mLastX);
       float dy = Math.abs(mStartY - mLastY);
@@ -64,7 +70,7 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
       float velocitySq = velocityX * velocityX + velocityY * velocityY;
       if (velocitySq < mMaxVelocitySq &&
               (distSq > mMinDistSq || dx > mMinDeltaX || dy > mMinDeltaY)) {
-        moveToState(STATE_ACTIVE);
+        activate();
       }
     }
   }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -1,21 +1,100 @@
 package com.swmansion.gesturehandler;
 
+import android.os.Handler;
 import android.view.MotionEvent;
 
 public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
 
+  private static final long DEFAULT_MAX_DURATION_MS = 500;
+  private static final long DEFAULT_MAX_DELAY_MS = 500;
+  private static final int DEFAULT_NUMBER_OF_TAPS= 1;
+
+  private long mMaxDurationMs = DEFAULT_MAX_DURATION_MS;
+  private long mMaxDelayMs = DEFAULT_MAX_DELAY_MS;
+  private int mNumberOfTaps = DEFAULT_NUMBER_OF_TAPS;
+
+  private Handler mHandler;
+  private int mTapsSoFar;
+
+  private final Runnable mFailDelayed = new Runnable() {
+    @Override
+    public void run() {
+      fail();
+    }
+  };
+
+  public TapGestureHandler setNumberOfTaps(int numberOfTaps) {
+    mNumberOfTaps = numberOfTaps;
+    return this;
+  }
+
+  public TapGestureHandler setMaxDelayMs(long maxDelayMs) {
+    mMaxDelayMs = maxDelayMs;
+    return this;
+  }
+
+  public TapGestureHandler setMaxDurationMs(long maxDurationMs) {
+    mMaxDurationMs = maxDurationMs;
+    return this;
+  }
+
   public TapGestureHandler() {
-    setCanStartHandlingWithDownEventOnly(true);
     setShouldCancelWhenOutside(true);
+  }
+
+  private void startTap() {
+    if (mHandler == null) {
+      mHandler = new Handler();
+    } else {
+      mHandler.removeCallbacksAndMessages(null);
+    }
+    mHandler.postDelayed(mFailDelayed, mMaxDurationMs);
+  }
+
+  private void endTap() {
+    if (mHandler == null) {
+      mHandler = new Handler();
+    } else {
+      mHandler.removeCallbacksAndMessages(null);
+    }
+    if (++mTapsSoFar == mNumberOfTaps) {
+      activate();
+      end();
+    } else {
+      mHandler.postDelayed(mFailDelayed, mMaxDelayMs);
+    }
   }
 
   @Override
   protected void onHandle(MotionEvent event) {
-    if (getState() == STATE_UNDETERMINED) {
-      moveToState(STATE_BEGAN);
+    int state = getState();
+    if (state == STATE_UNDETERMINED) {
+      begin();
+      mTapsSoFar = 0;
+      startTap();
     }
-    if (getState() == STATE_BEGAN && event.getActionMasked() == MotionEvent.ACTION_UP) {
-      moveToState(STATE_ACTIVE);
+    if (state == STATE_BEGAN) {
+      int action = event.getActionMasked();
+      if (action == MotionEvent.ACTION_UP) {
+        endTap();
+      } else if (action == MotionEvent.ACTION_DOWN) {
+        startTap();
+      }
+    }
+  }
+
+  @Override
+  protected void onCancel() {
+    if (mHandler != null) {
+      mHandler.removeCallbacksAndMessages(null);
+    }
+  }
+
+  @Override
+  protected void onReset() {
+    mTapsSoFar = 0;
+    if (mHandler != null) {
+      mHandler.removeCallbacksAndMessages(null);
     }
   }
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -31,8 +31,12 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
   private static final String KEY_SHOULD_CANCEL_WHEN_OUTSIDE = "shouldCancelWhenOutside";
   private static final String KEY_SHOULD_CANCEL_OTHERS_WHEN_ACTIVATED =
           "shouldCancelOthersWhenActivated";
-  private static final String KEY_CAN_START_HANDLING_WITH_DOWN_EVENT_ONLY =
-          "canStartHandlingWithDownEventOnly";
+  private static final String KEY_SHOULD_BE_REQUIRED_BY_OTHERS_TO_FAIL =
+          "shouldBeRequiredByOthersToFail";
+  private static final String KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START = "shouldActivateOnStart";
+  private static final String KEY_TAP_NUMBER_OF_TAPS = "numberOfTaps";
+  private static final String KEY_TAP_MAX_DURATION_MS = "maxDurationMs";
+  private static final String KEY_TAP_MAX_DELAY_MS = "maxDelayMs";
   private static final String KEY_LONG_PRESS_MIN_DURATION_MS = "minDurationMs";
   private static final String KEY_PAN_MIN_DELTA_X = "minDeltaX";
   private static final String KEY_PAN_MIN_DELTA_Y = "minDeltaY";
@@ -53,9 +57,9 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
         handler.setShouldCancelOthersWhenActivated(
                 config.getBoolean(KEY_SHOULD_CANCEL_OTHERS_WHEN_ACTIVATED));
       }
-      if (config.hasKey(KEY_CAN_START_HANDLING_WITH_DOWN_EVENT_ONLY)) {
-        handler.setCanStartHandlingWithDownEventOnly(
-                config.getBoolean(KEY_CAN_START_HANDLING_WITH_DOWN_EVENT_ONLY));
+      if (config.hasKey(KEY_SHOULD_BE_REQUIRED_BY_OTHERS_TO_FAIL)) {
+        handler.setShouldBeRequiredByOthersToFail(
+                config.getBoolean(KEY_SHOULD_BE_REQUIRED_BY_OTHERS_TO_FAIL));
       }
     }
   }
@@ -71,6 +75,15 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
     public NativeViewGestureHandler create() {
       return new NativeViewGestureHandler();
     }
+
+    @Override
+    public void configure(NativeViewGestureHandler handler, ReadableMap config) {
+      super.configure(handler, config);
+      if (config.hasKey(KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START)) {
+        handler.setShouldActivateOnStart(
+                config.getBoolean(KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START));
+      }
+    }
   }
 
   private static class TapGestureHandlerFactory extends HandlerFactory<TapGestureHandler> {
@@ -82,6 +95,20 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
     @Override
     public TapGestureHandler create() {
       return new TapGestureHandler();
+    }
+
+    @Override
+    public void configure(TapGestureHandler handler, ReadableMap config) {
+      super.configure(handler, config);
+      if (config.hasKey(KEY_TAP_NUMBER_OF_TAPS)) {
+        handler.setNumberOfTaps(config.getInt(KEY_TAP_NUMBER_OF_TAPS));
+      }
+      if (config.hasKey(KEY_TAP_MAX_DURATION_MS)) {
+        handler.setMaxDurationMs(config.getInt(KEY_TAP_MAX_DURATION_MS));
+      }
+      if (config.hasKey(KEY_TAP_MAX_DELAY_MS)) {
+        handler.setMaxDelayMs(config.getInt(KEY_TAP_MAX_DELAY_MS));
+      }
     }
   }
 
@@ -198,7 +225,8 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
             "BEGAN", GestureHandler.STATE_BEGAN,
             "ACTIVE", GestureHandler.STATE_ACTIVE,
             "CANCELLED", GestureHandler.STATE_CANCELLED,
-            "FAILED", GestureHandler.STATE_FAILED
+            "FAILED", GestureHandler.STATE_FAILED,
+            "END", GestureHandler.STATE_END
     ));
   }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.java
@@ -1,6 +1,5 @@
 package com.swmansion.gesturehandler.react;
 
-import android.util.Log;
 import android.util.SparseArray;
 import android.view.View;
 
@@ -22,7 +21,6 @@ public class RNGestureHandlerRegistry implements GestureHandlerRegistry {
     } else {
       listToAdd.add(handler);
     }
-    Log.e("CAT", "Register " + listToAdd.size() + " @ " + viewTag);
   }
 
   public void dropHandlersForViewWithTag(int viewTag) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gesture-handler",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Experimental implementation of a new declarative API for gesture handling in react-native",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
This merge request introduce one new parameter that can be used across all gesture handlers – shouldBeRequiredByOthersToFail
It can be used to make other gesture handlers to hold off with recognising configured gestures for the handler marked with that flag. Unless that handler makes the decision other handlers won't switch into an "active" state.
To support this feature there is some major refactoring of the orchestrator code as well as a new state has been introduced (END) that can be now used to mark gesture handler as being finished but without immediately switching to UNDETERMINED state.