### PR TITLE
Implement hitSlop property

### DIFF
--- a/AndroidNativeExample/app/src/main/java/com/swmansion/gesturehandler/example/MainActivity.java
+++ b/AndroidNativeExample/app/src/main/java/com/swmansion/gesturehandler/example/MainActivity.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.ScrollView;
 import android.widget.SeekBar;
+import android.widget.Switch;
 import android.widget.Toast;
 
 import com.swmansion.gesturehandler.GestureHandler;
@@ -24,6 +25,7 @@ public class MainActivity extends AppCompatActivity {
   private Button button;
   private SeekBar seekBar;
   private View block;
+  private Switch switchView;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -35,6 +37,7 @@ public class MainActivity extends AppCompatActivity {
     button = (Button) findViewById(R.id.button);
     seekBar = (SeekBar) findViewById(R.id.seekbar);
     block = findViewById(R.id.block);
+    switchView = (Switch) findViewById(R.id.switchView);
 
     // Native click events should work as expected assuming the view is wrapped with
     // NativeViewGestureHandler
@@ -52,12 +55,12 @@ public class MainActivity extends AppCompatActivity {
     registry.registerHandlerForView(seekBar, new NativeViewGestureHandler())
             .setShouldActivateOnStart(true)
             .setShouldCancelWhenOutside(false);
+    registry.registerHandlerForView(switchView, new NativeViewGestureHandler()).setHitSlop(20);
 
     registry.registerHandlerForView(block, new LongPressGestureHandler())
             .setOnTouchEventListener(new OnTouchEventListener<LongPressGestureHandler>() {
               @Override
               public void onTouchEvent(LongPressGestureHandler handler, MotionEvent event) {
-
               }
 
               @Override
@@ -74,7 +77,6 @@ public class MainActivity extends AppCompatActivity {
             .setOnTouchEventListener(new OnTouchEventListener<TapGestureHandler>() {
               @Override
               public void onTouchEvent(TapGestureHandler handler, MotionEvent event) {
-
               }
 
               @Override
@@ -90,7 +92,6 @@ public class MainActivity extends AppCompatActivity {
             .setOnTouchEventListener(new OnTouchEventListener<TapGestureHandler>() {
               @Override
               public void onTouchEvent(TapGestureHandler handler, MotionEvent event) {
-
               }
 
               @Override

--- a/AndroidNativeExample/app/src/main/res/layout/activity_main.xml
+++ b/AndroidNativeExample/app/src/main/res/layout/activity_main.xml
@@ -30,6 +30,11 @@
                 android:layout_height="50dp"
                 android:layout_gravity="center"
                 android:background="#ff0000" />
+            <Switch
+                android:id="@+id/switchView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"/>
             <TextView
                 android:text="@string/lorem_ipsum"
                 android:layout_width="wrap_content"

--- a/Example/index.android.js
+++ b/Example/index.android.js
@@ -1,20 +1,21 @@
 import React, { Component } from 'react';
 import {
+  Animated,
   AppRegistry,
   StyleSheet,
+  Switch,
   Text,
-  View,
-  Animated,
   ToastAndroid,
+  View,
 } from 'react-native';
 
 import {
   LongPressGestureHandler,
+  NativeViewGestureHandler,
   PanGestureHandler,
   ScrollView,
   Slider,
   State,
-  Switch,
   TapGestureHandler,
   TextInput,
   ToolbarAndroid,
@@ -148,7 +149,11 @@ class ControlledSwitch extends React.Component {
     this.props.onValueChange && this.props.onValueChange(value);
   }
   render() {
-    return <Switch {...this.props} value={this.state.value} onValueChange={this._onValueChange} />
+    return (
+      <NativeViewGestureHandler hitSlop={20}>
+        <Switch {...this.props} value={this.state.value} onValueChange={this._onValueChange} />
+      </NativeViewGestureHandler>
+    );
   }
 }
 

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -24,6 +24,17 @@ const GestureHandlerPropTypes = {
   shouldCancelWhenOutside: PropTypes.bool,
   shouldCancelOthersWhenActivated: PropTypes.bool,
   shouldBeRequiredByOthersToFail: PropTypes.bool,
+  hitSlop: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.shape({
+      left: PropTypes.number,
+      top: PropTypes.number,
+      right: PropTypes.number,
+      bottom: PropTypes.number,
+      vertical: PropTypes.number,
+      horizontal: PropTypes.number,
+    }),
+  ]),
   onGestureEvent: PropTypes.func,
   onHandlerStateChange: PropTypes.func,
 }

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Last available element exported by the library is a dictionary of constants used
  - `shouldCancelWhenOutside`
  - `shouldCancelOthersWhenActivated`
  - `shouldBeRequiredByOthersToFail`
+ - `hitSlop`
  - `onGestureEvent`
  - `onHandlerStateChange`
 
@@ -104,6 +105,7 @@ Last available element exported by the library is a dictionary of constants used
 ## Roadmap
 
  - Build one more gesture recognizer: `FlingGestureHandler`
+ - Interop with standard ways of handling touch in react-native
  - Send out necessary updates to RN core for native animated event support
  - Support for multi-touch events (build `PinchGestureHandler`)
  - iOS port

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
@@ -2,7 +2,6 @@ package com.swmansion.gesturehandler;
 
 import android.graphics.Matrix;
 import android.graphics.PointF;
-import android.graphics.Rect;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -19,7 +18,6 @@ public class GestureHandlerOrchestrator {
   private static final float[] sMatrixTransformCoords = new float[2];
   private static final Matrix sInverseMatrix = new Matrix();
   private static final float[] sTempCoords = new float[2];
-  private static final Rect sTempRect = new Rect();
 
   private final ViewGroup mWrapperView;
   private final GestureHandlerRegistry mHandlerRegistry;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.UIManagerModule;
@@ -33,6 +34,13 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
           "shouldCancelOthersWhenActivated";
   private static final String KEY_SHOULD_BE_REQUIRED_BY_OTHERS_TO_FAIL =
           "shouldBeRequiredByOthersToFail";
+  private static final String KEY_HIT_SLOP = "hitSlop";
+  private static final String KEY_HIT_SLOP_LEFT = "left";
+  private static final String KEY_HIT_SLOP_TOP = "left";
+  private static final String KEY_HIT_SLOP_RIGHT = "right";
+  private static final String KEY_HIT_SLOP_BOTTOM = "bottom";
+  private static final String KEY_HIT_SLOP_VERTICAL = "vertical";
+  private static final String KEY_HIT_SLOP_HORIZONTAL = "horizontal";
   private static final String KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START = "shouldActivateOnStart";
   private static final String KEY_TAP_NUMBER_OF_TAPS = "numberOfTaps";
   private static final String KEY_TAP_MAX_DURATION_MS = "maxDurationMs";
@@ -60,6 +68,9 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
       if (config.hasKey(KEY_SHOULD_BE_REQUIRED_BY_OTHERS_TO_FAIL)) {
         handler.setShouldBeRequiredByOthersToFail(
                 config.getBoolean(KEY_SHOULD_BE_REQUIRED_BY_OTHERS_TO_FAIL));
+      }
+      if (config.hasKey(KEY_HIT_SLOP)) {
+        handleHitSlopProperty(handler, config);
       }
     }
   }
@@ -292,5 +303,36 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
             translationX,
             translationY);
     eventDispatcher.dispatchEvent(event);
+  }
+
+  private static void handleHitSlopProperty(GestureHandler handler, ReadableMap config) {
+    if (config.getType(KEY_HIT_SLOP) == ReadableType.Number) {
+      float hitSlop = PixelUtil.toPixelFromDIP(config.getDouble(KEY_HIT_SLOP));
+      handler.setHitSlop(hitSlop, hitSlop, hitSlop, hitSlop);
+    } else {
+      ReadableMap hitSlop = config.getMap(KEY_HIT_SLOP);
+      float left = 0, top = 0, right = 0, bottom = 0;
+      if (hitSlop.hasKey(KEY_HIT_SLOP_HORIZONTAL)) {
+        float horizontalPad = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_HORIZONTAL));
+        left = right = horizontalPad;
+      }
+      if (hitSlop.hasKey(KEY_HIT_SLOP_VERTICAL)) {
+        float verticalPad = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_VERTICAL));
+        top = bottom = verticalPad;
+      }
+      if (hitSlop.hasKey(KEY_HIT_SLOP_LEFT)) {
+        left  = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_LEFT));
+      }
+      if (hitSlop.hasKey(KEY_HIT_SLOP_TOP)) {
+        top = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_TOP));
+      }
+      if (hitSlop.hasKey(KEY_HIT_SLOP_RIGHT)) {
+        right = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_RIGHT));
+      }
+      if (hitSlop.hasKey(KEY_HIT_SLOP_BOTTOM)) {
+        bottom = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_BOTTOM));
+      }
+      handler.setHitSlop(left, top, right, bottom);
+    }
   }
 }


### PR DESCRIPTION
This merge request introduces hitSlop property support. This property allows for extending touchable area of the gesture handler. It is added to the base gesturehandler class which means that it can be used for all gesture handlers (including native component wrapper handler)