### PR TITLE
Implement maxDeltaY for PanGestureHandler on (for iOS only currently)

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -196,6 +196,7 @@ const LongPressGestureHandler = createHandler('LongPressGestureHandler', {
 const PanGestureHandler = createHandler('PanGestureHandler', {
   minDeltaX: PropTypes.number,
   minDeltaY: PropTypes.number,
+  maxDeltaX: PropTypes.number,
   minOffsetX: PropTypes.number,
   minOffsetY: PropTypes.number,
   minDist: PropTypes.number,


### PR DESCRIPTION
No need to use this exact implementation, it was quick to just get a proof of concept working. It does seem like a valuable prop to add, however. I was able to implement SwipeActions like this:

```javascript
render() {
  const translateX = this.state._translateX;

  return (
    <View>
      <PanGestureHandler
        id={this.props.gestureId}
        minDeltaX={50}
        maxDeltaY={5}
        onGestureEvent={this._onGestureEvent}
        onHandlerStateChange={this._onHandlerStateChange}>
        <Animated.View
          style={{ transform: [{ translateX: translateX }] }}
          onLayout={this._onLayoutChildren}>
          {this.props.children}
        </Animated.View>
      </PanGestureHandler>

      {this._renderButtons()}
    </View>
  );
}
```

And on the parent `ScrollView` I wait for the pan gestures to fail.