### PR TITLE
Don't warn when user passes in Animated.event with useNativeDriver: true to onGestureEvent

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -51,7 +51,10 @@ const GestureHandlerPropTypes = {
       horizontal: PropTypes.number,
     }),
   ]),
-  onGestureEvent: PropTypes.func,
+  onGestureEvent: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.object,
+  ]),
   onHandlerStateChange: PropTypes.func,
 }
 


### PR DESCRIPTION
I thought about validating the shape but I'm not sure if we want to depend on internal properties in the object shape, it feels brittle, so just used PropTypes.object instead.