### PR TITLE
Remove absolute positioning from BorderlessButton Animated container

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -341,11 +341,6 @@ const btnStyles = StyleSheet.create({
     top: 0,
   },
   borderlessContainer: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    bottom: 0,
-    top: 0,
   }
 });
 


### PR DESCRIPTION
Seems like it was a copypasta bug 😄 
Try with and without the patch on https://github.com/brentvatne/swipe-action-gesture-handler-experiment to see what I mean.