### PR TITLE
Change "react" peerDep version from >= 16 to > 15 to allow prereleases

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/kmagiera/react-native-gesture-handler#readme",
   "dependencies": {},
   "peerDependencies": {
-    "react": ">= 16.0.0",
+    "react": "> 15.0.0",
     "react-native": ">= 0.47.0"
   },
   "jest": {


### PR DESCRIPTION
`>= 16` doesn't include `16.0.0-alpha.12`, for example, while `> 15` does (but excludes 15.x releases).