### PR TITLE
Fix replaceState and isMounted warnings

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -281,6 +281,9 @@ function createNativeWrapper(Component, config = {}) {
 
       // bind native component's methods
       for (let methodName in node) {
+        if (methodName === 'replaceState' || methodName === 'isMounted') {
+          continue;
+        }
         const method = node[methodName];
         if (
           !methodName.startsWith('_') &&


### PR DESCRIPTION
Those warning are probably implemented using getters so just getting a ref of those methods triggers it. Just bail out early for the 2 methods.