### PR TITLE
Remove extra wrapper view for BorderlessButton on iOS

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -423,6 +423,8 @@ class BaseButton extends React.Component {
   }
 }
 
+const AnimatedBaseButton = Animated.createAnimatedComponent(BaseButton);
+
 const btnStyles = StyleSheet.create({
   underlay: {
     position: 'absolute',
@@ -480,20 +482,15 @@ class BorderlessButton extends React.Component {
         this._opacity.setValue(active ? this.props.activeOpacity : 1);
       };
   render() {
-    const { children, ...rest } = this.props;
-    const content =
-      Platform.OS === 'android'
-        ? children
-        : <Animated.View style={{ opacity: this._opacity }}>
-            {children}
-          </Animated.View>;
+    const { children, style, ...rest } = this.props;
     return (
-      <BaseButton
+      <AnimatedBaseButton
         borderless={true}
         {...rest}
-        onActiveStateChange={this._handleActiveStateChange}>
-        {content}
-      </BaseButton>
+        onActiveStateChange={this._handleActiveStateChange}
+        style={[style, Platform.OS === 'ios' && { opacity: this._opacity }]}>
+        {children}
+      </AnimatedBaseButton>
     );
   }
 }


### PR DESCRIPTION
This removes an extra wrapper view on iOS that made styling of BorderlessButton's content hard. I hit this problem when I had some layout that required `flex: 1` on the button child to match the button size but that extra wrapper view caused issue.

It's actually possible to just remove it by setting the opacity on the actual button view.

Tested that it works well in an app I'm working on and also tested the demo app.