### PR TITLE
Fix PropTypes for waitFor and simultaneousHandlers

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -42,8 +42,14 @@ const handlerIDToTag = {};
 
 const GestureHandlerPropTypes = {
   id: PropTypes.string,
-  waitFor: PropTypes.oneOf(PropTypes.string),
-  simultaneousHandlers: PropTypes.oneOf(PropTypes.string),
+  waitFor: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
+  simultaneousHandlers: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
   shouldCancelWhenOutside: PropTypes.bool,
   hitSlop: PropTypes.oneOfType([
     PropTypes.number,


### PR DESCRIPTION
This fixes a couple of warnings: "Warning: Invalid argument supplied to oneOf, expected an instance of array."