### PR TITLE
[chore] - remove unused modules from Swipeable component

### DIFF
--- a/Swipeable.js
+++ b/Swipeable.js
@@ -5,7 +5,7 @@
 // to move faster and fix possible issues quicker
 
 import React, { Component } from 'react';
-import { Animated, StyleSheet, View, Keyboard, StatusBar } from 'react-native';
+import { Animated, StyleSheet, View } from 'react-native';
 
 import {
   PanGestureHandler,


### PR DESCRIPTION
:wave:

Expo 22 SDK came with .28. I noticed in .29 the Swipeable issue I've been trying to track down was fixed. I copied the file into my own project and eslint picked up a few issues so I decided to fix them.

Thanks