### PR TITLE
Fix android "parent null" issue and scrolling in example app.

### DIFF
--- a/Example/combo/index.js
+++ b/Example/combo/index.js
@@ -108,7 +108,7 @@ class ControlledSwitch extends React.Component {
 class Combo extends Component {
   _onClick = () => {
     Alert.alert("I'm so touched");
-    this._scrollView.scrollTo(200);
+    this._scrollView.scrollTo({ y: 200 });
   };
   render() {
     const { ScrollViewComponent } = this.props;

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
@@ -314,8 +314,11 @@ public class GestureHandlerOrchestrator {
       outputCoords[1] = event.getY();
       return;
     }
-    if (view == null || !(view.getParent() instanceof ViewGroup)) {
-      throw new IllegalArgumentException("Parent is null? View is no longer in the tree");
+    if (!(view.getParent() instanceof ViewGroup)) {
+      return;
+    }
+    if (view == null) {
+      throw new IllegalArgumentException("View is no longer in the tree");
     }
     ViewGroup parent = (ViewGroup) view.getParent();
     extractCoordsForView(parent, event, outputCoords);

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
@@ -119,7 +119,7 @@ public class GestureHandlerOrchestrator {
     boolean shouldCleanEmptyCells = false;
     for (int i = mGestureHandlersCount - 1; i >= 0; i--) {
       GestureHandler handler = mGestureHandlers[i];
-      if (isFinished(handler.getState()) && !handler.mIsAwaiting) {
+      if ((isFinished(handler.getState()) || handler.getState()==GestureHandler.STATE_UNDETERMINED)  && !handler.mIsAwaiting) {
         mGestureHandlers[i] = null;
         shouldCleanEmptyCells = true;
         handler.reset();
@@ -315,7 +315,7 @@ public class GestureHandlerOrchestrator {
       return;
     }
     if (!(view.getParent() instanceof ViewGroup)) {
-      return;
+      throw new IllegalArgumentException("Parent View is no longer in the tree");
     }
     if (view == null) {
       throw new IllegalArgumentException("View is no longer in the tree");


### PR DESCRIPTION
Remove parent null exception on Android (throw when component was removed 'externally') and change deprecated way of scrolling in example app