### PR TITLE
Fix issues with disabled handler being registered and with cleaning up dropped handlers from the orchestrator

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.java
@@ -52,6 +52,11 @@ public class GestureHandler<T extends GestureHandler> {
   }
 
   public T setEnabled(boolean enabled) {
+    if (mView != null) {
+      // If view is set then handler is in "active" state. In that case we want to "cancel" handler
+      // when it changes enabled state so that it gets cleared from the orchestrator
+      cancel();
+    }
     mEnabled = enabled;
     return (T) this;
   }
@@ -143,7 +148,7 @@ public class GestureHandler<T extends GestureHandler> {
   }
 
   public boolean wantEvents() {
-    return mState != STATE_FAILED && mState != STATE_CANCELLED && mState != STATE_END;
+    return mEnabled && mState != STATE_FAILED && mState != STATE_CANCELLED && mState != STATE_END;
   }
 
   public int getState() {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
@@ -361,7 +361,7 @@ public class GestureHandlerOrchestrator {
     if (handlers != null) {
       for (int i = 0, size = handlers.size(); i < size; i++) {
         GestureHandler handler = handlers.get(i);
-        if (handler.isWithinBounds(view, coords[0], coords[1])) {
+        if (handler.isEnabled() && handler.isWithinBounds(view, coords[0], coords[1])) {
           recordGestureHandler(handlers.get(i), view);
           found = true;
         }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.java
@@ -62,6 +62,12 @@ public class RNGestureHandlerRegistry implements GestureHandlerRegistry {
         }
       }
     }
+    if (handler.getView() != null) {
+      // Handler is in "prepared" state which means it is registered in the orchestrator and can
+      // receive touch events. This means that before we remove it from the registry we need to
+      // "cancel" it so that orchestrator does no longer keep a reference to it.
+      handler.cancel();
+    }
   }
 
   public void dropHandler(int handlerTag) {


### PR DESCRIPTION
Thanks to the issue reported in #48 and investigation done by @osdnk in #49 I discovered two problems in Android implementation that this PR is fixing:
 1) When handler gets dropped and in "active" state it doesn't get wiped away from the orchestrator. This results in crash as in many cases the view attached to such handler gets removed from the hierarchy.
 2) Views in "disabled" state were getting registered in the orchestrator as we weren't checking for "enabled" flag while registering handlers. On top of that we would never wipe such a handler from the orchestrator as "enabled" flag would prevent it from processing events so they'd never leav "UNDETERMINE" state