### PR TITLE
[Swipeable] Fix crash on iOS 8.x

### DIFF
--- a/Swipeable.js
+++ b/Swipeable.js
@@ -16,6 +16,13 @@ import {
 
 const DRAG_TOSS = 0.05;
 
+// Math.sign polyfill for iOS 8.x
+if (!Math.sign) {
+  Math.sign = function(x) {
+    return ((x > 0) - (x < 0)) || +x;
+  };
+}
+
 export type PropType = {
   children: any,
   friction: number,


### PR DESCRIPTION
Math.sign polyfill from https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Math/sign

PS: This fixes a crash but Swipeable feature is still not fully working
Related: #81 