### PR TITLE
Re-export Swipeable and DrawerLayout from GestureHandler.js

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -21,6 +21,8 @@ import deepEqual from 'fbjs/lib/areEqual';
 import PropTypes from 'prop-types';
 
 import gestureHandlerRootHOC from './gestureHandlerRootHOC';
+import Swipeable from './Swipeable';
+import DrawerLayout from './DrawerLayout';
 
 const RNGestureHandlerModule = NativeModules.RNGestureHandlerModule;
 
@@ -587,4 +589,6 @@ export {
   /* Other */
   FlatListWithGHScroll as FlatList,
   gestureHandlerRootHOC,
+  Swipeable,
+  DrawerLayout,
 };


### PR DESCRIPTION
## Description
Re-exports `Swipeable` and `DrawerLayout` components from `GestureHandler.js`
so that they can now be imported with:
```js
import { Swipeable, DrawerLayout } from 'react-native-gesture-handler' 
```


Old import style, that is:
```js
import Swipeable from 'react-native-gesture-handler/Swipeable'
```
still works the same