### PR TITLE
Add TS types definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "Swipeable.js",
     "DrawerLayout.js",
     "gestureHandlerRootHOC.android.js",
-    "gestureHandlerRootHOC.ios.js"
+    "gestureHandlerRootHOC.ios.js",
+    "react-native-gesture-handler.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "react-native-gesture-handler",
   "version": "1.0.0-alpha.35",
-  "description":
-    "Experimental implementation of a new declarative API for gesture handling in react-native",
+  "description": "Experimental implementation of a new declarative API for gesture handling in react-native",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest",
     "precommit": "lint-staged"
   },
   "main": "GestureHandler.js",
+  "types": "react-native-gesture-handler.d.ts",
   "files": [
     "android/build.gradle",
     "android/src/main/AndroidManifest.xml",
@@ -39,8 +39,8 @@
   },
   "homepage": "https://github.com/kmagiera/react-native-gesture-handler#readme",
   "dependencies": {
-    "prop-types": "^15.5.10",
-    "invariant": "^2.2.2"
+    "invariant": "^2.2.2",
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
     "react": "> 15.0.0",
@@ -50,17 +50,19 @@
     "preset": "jest-react-native"
   },
   "devDependencies": {
+    "@types/react": "^16.0.31",
+    "@types/react-native": "^0.51.3",
     "babel-jest": "16.0.0",
     "babel-preset-react-native": "1.9.0",
+    "flow-bin": "^0.56.0",
     "husky": "^0.14.3",
     "jest": "16.0.2",
     "jest-react-native": "16.0.0",
     "lint-staged": "^4.0.3",
     "prettier": "^1.7.0",
-    "react-test-renderer": "15.3.2",
     "react": "^16.0.0",
     "react-native": "^0.50.1",
-    "flow-bin": "^0.56.0"
+    "react-test-renderer": "15.3.2"
   },
   "lint-staged": {
     "*.js": [

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -1,6 +1,4 @@
-// Type definitions for react-native-gesture-handler 1.0.0-alpha.35
 // Project: https://github.com/kmagiera/react-native-gesture-handler
-// Definitions by: Krzysztof Ciombor <https://github.com/krzysztofciombor>
 // TypeScript Version: 2.6.2
 
 import * as React from 'react';

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -1,0 +1,373 @@
+// Type definitions for react-native-gesture-handler 1.0.0-alpha.35
+// Project: https://github.com/kmagiera/react-native-gesture-handler
+// Definitions by: Krzysztof Ciombor <https://github.com/krzysztofciombor>
+// TypeScript Version: 2.6.2
+
+import * as React from 'react';
+import {
+  Animated,
+  FlatListProperties,
+  ScrollViewProperties,
+  SliderProperties,
+  SwitchProperties,
+  TextInputProperties,
+  WebViewProperties,
+  ToolbarAndroidProperties,
+  ViewPagerAndroidProperties,
+  DrawerLayoutAndroidProperties,
+  TouchableWithoutFeedbackProperties,
+  Insets,
+} from 'react-native';
+
+/* GESTURE HANDLER STATE */
+
+export enum State {
+  UNDETERMINED = 0,
+  FAILED,
+  BEGAN,
+  CANCELLED,
+  ACTIVE,
+  END,
+}
+
+/* STATE CHANGE EVENTS */
+
+export interface GestureHandlerGestureEventNativeEvent {
+  handlerTag: number;
+  state: State;
+}
+
+export interface GestureHandlerStateChangeNativeEvent {
+  handlerTag: number;
+  state: State;
+  oldState: State;
+}
+
+export interface GestureHandlerStateChangeEvent {
+  nativeEvent: GestureHandlerStateChangeNativeEvent;
+}
+
+export interface GestureHandlerGestureEvent {
+  nativeEvent: GestureHandlerGestureEventNativeEvent;
+}
+
+interface NativeViewGestureHandlerEventExtra {
+  pointerInside: boolean;
+}
+
+export interface NativeViewGestureHandlerStateChangeEvent
+  extends GestureHandlerStateChangeEvent {
+  nativeEvent: GestureHandlerStateChangeNativeEvent &
+    NativeViewGestureHandlerEventExtra;
+}
+
+export interface NativeViewGestureHandlerGestureEvent
+  extends GestureHandlerGestureEvent {
+  nativeEvent: GestureHandlerGestureEventNativeEvent &
+    NativeViewGestureHandlerEventExtra;
+}
+
+interface TapGestureHandlerEventExtra {
+  x: number;
+  y: number;
+  absoluteX: number;
+  absoluteY: number;
+}
+
+export interface TapGestureHandlerStateChangeEvent
+  extends GestureHandlerStateChangeEvent {
+  nativeEvent: GestureHandlerStateChangeNativeEvent &
+    TapGestureHandlerEventExtra;
+}
+
+export interface TapGestureHandlerGestureEvent
+  extends GestureHandlerGestureEvent {
+  nativeEvent: GestureHandlerGestureEventNativeEvent &
+    TapGestureHandlerEventExtra;
+}
+
+interface PanGestureHandlerEventExtra {
+  x: number;
+  y: number;
+  absoluteX: number;
+  absoluteY: number;
+  translationX: number;
+  translationY: number;
+  velocityX: number;
+  velocityY: number;
+}
+
+export interface PanGestureHandlerStateChangeEvent
+  extends GestureHandlerStateChangeEvent {
+  nativeEvent: GestureHandlerStateChangeNativeEvent &
+    PanGestureHandlerEventExtra;
+}
+
+export interface PanGestureHandlerGestureEvent
+  extends GestureHandlerGestureEvent {
+  nativeEvent: GestureHandlerGestureEventNativeEvent &
+    PanGestureHandlerEventExtra;
+}
+
+interface PinchGestureHandlerEventExtra {
+  scale: number;
+  focalX: number;
+  focalY: number;
+  velocity: number;
+}
+
+export interface PinchGestureHandlerStateChangeEvent
+  extends GestureHandlerStateChangeEvent {
+  nativeEvent: GestureHandlerStateChangeNativeEvent &
+    PinchGestureHandlerEventExtra;
+}
+
+export interface PinchGestureHandlerGestureEvent
+  extends GestureHandlerGestureEvent {
+  nativeEvent: GestureHandlerGestureEventNativeEvent &
+    PinchGestureHandlerEventExtra;
+}
+
+interface RotationGestureHandlerEventExtra {
+  rotation: number;
+  anchorX: number;
+  anchorY: number;
+  velocity: number;
+}
+
+export interface RotationGestureHandlerStateChangeEvent
+  extends GestureHandlerStateChangeEvent {
+  nativeEvent: GestureHandlerStateChangeNativeEvent &
+    RotationGestureHandlerEventExtra;
+}
+
+export interface RotationGestureHandlerGestureEvent
+  extends GestureHandlerGestureEvent {
+  nativeEvent: GestureHandlerGestureEventNativeEvent &
+    RotationGestureHandlerEventExtra;
+}
+
+/* GESTURE HANDLERS PROPERTIES */
+
+export interface GestureHandlerProperties {
+  id?: string;
+  enabled?: boolean;
+  waitFor?: string | string[];
+  simultaneousHandlers?: string | string[];
+  shouldCancelWhenOutside?: boolean;
+  hitSlop?:
+    | number
+    | {
+        left?: number;
+        right?: number;
+        top?: number;
+        bottom?: number;
+        vertical?: number;
+        horizontal?: number;
+      };
+  onGestureEvent?: (event: GestureHandlerGestureEvent) => void;
+  onHandlerStateChange?: (event: GestureHandlerStateChangeEvent) => void;
+}
+
+export interface NativeViewGestureHandlerProperties
+  extends GestureHandlerProperties {
+  shouldActivateOnStart?: boolean;
+  disallowInterruption?: boolean;
+  onGestureEvent?: (event: NativeViewGestureHandlerGestureEvent) => void;
+  onHandlerStateChange?: (
+    event: NativeViewGestureHandlerStateChangeEvent,
+  ) => void;
+}
+
+export interface TapGestureHandlerProperties extends GestureHandlerProperties {
+  maxDurationMs?: number;
+  maxDelayMs?: number;
+  numberOfTaps?: number;
+  onGestureEvent?: (event: TapGestureHandlerGestureEvent) => void;
+  onHandlerStateChange?: (event: TapGestureHandlerStateChangeEvent) => void;
+}
+
+export interface LongPressGestureHandlerProperties
+  extends GestureHandlerProperties {
+  minDurationMs?: number;
+}
+
+export interface PanGestureHandlerProperties extends GestureHandlerProperties {
+  minDeltaX?: number;
+  minDeltaY?: number;
+  maxDeltaX?: number;
+  maxDeltaY?: number;
+  minOffsetX?: number;
+  minOffsetY?: number;
+  minDist?: number;
+  minVelocity?: number;
+  minVelocityX?: number;
+  minVelocityY?: number;
+  minPointers?: number;
+  maxPointers?: number;
+  avgTouches?: boolean;
+  onGestureEvent?: (event: PanGestureHandlerGestureEvent) => void;
+  onHandlerStateChange?: (event: PanGestureHandlerStateChangeEvent) => void;
+}
+
+export interface PinchGestureHandlerProperties
+  extends GestureHandlerProperties {
+  onGestureEvent?: (event: PinchGestureHandlerGestureEvent) => void;
+  onHandlerStateChange?: (event: PinchGestureHandlerStateChangeEvent) => void;
+}
+
+export interface RotationGestureHandlerProperties
+  extends GestureHandlerProperties {
+  onGestureEvent?: (event: RotationGestureHandlerGestureEvent) => void;
+  onHandlerStateChange?: (
+    event: RotationGestureHandlerStateChangeEvent,
+  ) => void;
+}
+
+/* GESTURE HANDLERS CLASSES */
+
+export class NativeViewGestureHandler extends React.Component<
+  NativeViewGestureHandlerProperties
+> {}
+
+export class TapGestureHandler extends React.Component<
+  TapGestureHandlerProperties
+> {}
+
+export class LongPressGestureHandler extends React.Component<
+  LongPressGestureHandlerProperties
+> {}
+
+export class PanGestureHandler extends React.Component<
+  PanGestureHandlerProperties
+> {}
+
+export class PinchGestureHandler extends React.Component<
+  PinchGestureHandlerProperties
+> {}
+
+export class RotationGestureHandler extends React.Component<
+  RotationGestureHandlerProperties
+> {}
+
+/* BUTTONS PROPERTIES */
+
+export interface RawButtonProperties
+  extends NativeViewGestureHandlerProperties {}
+
+export interface BaseButtonProperties extends RawButtonProperties {
+  onPress?: (pointerInside: boolean) => void;
+  onActiveStateChange?: (active: boolean) => void;
+}
+
+export interface RectButtonProperties extends RawButtonProperties {}
+
+export interface BorderlessButtonProperties extends RawButtonProperties {
+  borderless?: boolean;
+}
+
+/* BUTTONS CLASSES */
+
+export class RawButton extends React.Component<RawButtonProperties> {}
+
+export class BaseButton extends React.Component<BaseButtonProperties> {}
+
+export class RectButton extends React.Component<RectButtonProperties> {}
+
+export class BorderlessButton extends React.Component<
+  BorderlessButtonProperties
+> {}
+
+/* GESTURE HANDLER WRAPPED CLASSES */
+
+export class ScrollView extends React.Component<
+  NativeViewGestureHandlerProperties & ScrollViewProperties
+> {}
+
+export class Slider extends React.Component<
+  NativeViewGestureHandlerProperties & SliderProperties
+> {}
+
+export class Switch extends React.Component<
+  NativeViewGestureHandlerProperties & SwitchProperties
+> {}
+
+export class TextInput extends React.Component<
+  NativeViewGestureHandlerProperties & TextInputProperties
+> {}
+
+export class ToolbarAndroid extends React.Component<
+  NativeViewGestureHandlerProperties & ToolbarAndroidProperties
+> {}
+
+export class ViewPagerAndroid extends React.Component<
+  NativeViewGestureHandlerProperties & ViewPagerAndroidProperties
+> {}
+
+export class DrawerLayoutAndroid extends React.Component<
+  NativeViewGestureHandlerProperties & DrawerLayoutAndroidProperties
+> {}
+
+export class WebView extends React.Component<
+  NativeViewGestureHandlerProperties & WebViewProperties
+> {}
+
+/* OTHER */
+
+export class FlatList extends React.Component<
+  NativeViewGestureHandlerProperties & FlatListProperties<any>
+> {}
+
+export function gestureHandlerRootHOC(
+  Component: React.Component,
+  containerStyles?: any,
+): React.Component;
+
+export interface SwipeableProperties {
+  friction: number;
+  leftThreshold?: number;
+  rightThreshold?: number;
+  overshootLeft?: boolean;
+  overshootRight?: boolean;
+  onSwipeableLeftOpen?: () => void;
+  onSwipeableRightOpen?: () => void;
+  onSwipeableOpen?: () => void;
+  onSwipeableClose?: () => void;
+  renderLeftActions?: (
+    progressAnimatedValue: Animated.Value,
+    dragAnimatedValue: Animated.Value,
+  ) => JSX.Element | null | undefined | false;
+  renderRightActions?: (
+    progressAnimatedValue: Animated.Value,
+    dragAnimatedValue: Animated.Value,
+  ) => JSX.Element | null | undefined | false;
+  useNativeAnimations?: boolean;
+}
+
+export class Swipeable extends React.Component<SwipeableProperties> {}
+
+export interface DrawerLayoutProperties {
+  renderNavigationView: (
+    progressAnimatedValue: Animated.Value,
+  ) => JSX.Element | null | undefined | false;
+  drawerPosition?: 'left' | 'right';
+  drawerWidth?: number;
+  drawerBackgroundColor?: string;
+  keyboardDismissMode?: 'none' | 'on-drag';
+  onDrawerClose?: () => void;
+  onDrawerOpen?: () => void;
+  onDrawerStateChanged?: (
+    newState: 'Idle' | 'Dragging' | 'Settling',
+    drawerWillShow: boolean,
+  ) => void;
+  useNativeAnimations?: boolean;
+
+  drawerType?: 'front' | 'back' | 'slide';
+  edgeWidth?: number;
+  minSwipeDistance?: number;
+  hideStatusBar?: boolean;
+  statusBarAnimation?: 'slide' | 'none' | 'fade';
+  overlayColor?: string;
+}
+
+export class DrawerLayout extends React.Component<DrawerLayoutProperties> {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@types/react-native@^0.51.3":
+  version "0.51.3"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.51.3.tgz#73aae1b9b2618ead387ede3a80a17980b0e0d1f0"
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^16.0.31":
+  version "16.0.31"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.31.tgz#5285da62f3ac62b797f6d0729a1d6181f3180c3e"
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"


### PR DESCRIPTION
## Description
Adds TypeScript types definitions.
See also: #78 

## Test plan
The TS types are correctly picked up when importing Gesture Handlers inside `*.ts` file:
![zrzut ekranu 2017-12-19 o 17 17 25](https://user-images.githubusercontent.com/15357032/34166922-8a78693a-e4e0-11e7-979a-ef0dcb08a94a.png)
![zrzut ekranu 2017-12-19 o 17 17 34](https://user-images.githubusercontent.com/15357032/34166924-8bc82ea6-e4e0-11e7-83c8-87910ecfb3fe.png)

