### PR TITLE
[TYPING] Use ReactNode instead of JSX.Element to match official react typings

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -334,11 +334,11 @@ export interface SwipeableProperties {
   renderLeftActions?: (
     progressAnimatedValue: Animated.Value,
     dragAnimatedValue: Animated.Value,
-  ) => JSX.Element | null | undefined | false;
+  ) => React.ReactNode
   renderRightActions?: (
     progressAnimatedValue: Animated.Value,
     dragAnimatedValue: Animated.Value,
-  ) => JSX.Element | null | undefined | false;
+  ) => React.ReactNode
   useNativeAnimations?: boolean;
 }
 
@@ -347,7 +347,7 @@ export class Swipeable extends React.Component<SwipeableProperties> {}
 export interface DrawerLayoutProperties {
   renderNavigationView: (
     progressAnimatedValue: Animated.Value,
-  ) => JSX.Element | null | undefined | false;
+  ) => React.ReactNode
   drawerPosition?: 'left' | 'right';
   drawerWidth?: number;
   drawerBackgroundColor?: string;


### PR DESCRIPTION
I was getting an incompatibility type error and noticed this.

Also, ReactNode already includes these null | undefined | false conditions