### PR TITLE
Rename uiManagerWillFlushUIBlocks to uiManagerWillPerformMounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Before instaling please check the following table to find which library version 
 
  | React Native version | React Native Gesture Handler version | Notes |
  | --- | --- | --- |
- | v0.52+ | **latest** | Breaking changes explained and fixed in [#101](https://github.com/kmagiera/react-native-gesture-handler/pull/44) |
- | v0.50 - v0.51 | 1.0.0-alpha.39 | |
+ | v0.50+ | **latest** | |
  | v0.47 - v0.49 | 1.0.0-alpha.29 | Breaking changes explained and fixed in [#44](https://github.com/kmagiera/react-native-gesture-handler/pull/44) |
  | pre v0.47 | **Not supported** |
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Before instaling please check the following table to find which library version 
 
  | React Native version | React Native Gesture Handler version | Notes |
  | --- | --- | --- |
- | v0.50+ | **latest** | |
+ | v0.52+ | **latest** | Breaking changes explained and fixed in [#101](https://github.com/kmagiera/react-native-gesture-handler/pull/44) |
+ | v0.50 - v0.51 | 1.0.0-alpha.39 | |
  | v0.47 - v0.49 | 1.0.0-alpha.29 | Breaking changes explained and fixed in [#44](https://github.com/kmagiera/react-native-gesture-handler/pull/44) |
  | pre v0.47 | **Not supported** |
 

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -130,6 +130,11 @@ RCT_EXPORT_METHOD(handleClearJSResponder)
 
 #pragma mark - RCTUIManagerObserver
 
+- (void)uiManagerWillFlushUIBlocks:(RCTUIManager *)uiManager
+{
+  [self uiManagerWillPerformMounting:uiManager];
+}
+
 - (void)uiManagerWillPerformMounting:(RCTUIManager *)uiManager
 {
     if (_operations.count == 0) {

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -130,7 +130,7 @@ RCT_EXPORT_METHOD(handleClearJSResponder)
 
 #pragma mark - RCTUIManagerObserver
 
-- (void)uiManagerWillFlushUIBlocks:(RCTUIManager *)uiManager
+- (void)uiManagerWillPerformMounting:(RCTUIManager *)uiManager
 {
     if (_operations.count == 0) {
         return;


### PR DESCRIPTION
This makes rngh compatible with react-native 0.52. It resolves #100.

This is necessary due to a breaking change in react-native 0.52: https://github.com/facebook/react-native/commit/0a8721c