### PR TITLE
[TYPING] Fix RectButton props

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -15,6 +15,8 @@ import {
   DrawerLayoutAndroidProperties,
   TouchableWithoutFeedbackProperties,
   Insets,
+  ViewStyle,
+  StyleProp,
 } from 'react-native';
 
 /* GESTURE HANDLER STATE */
@@ -257,6 +259,7 @@ export interface RawButtonProperties
 export interface BaseButtonProperties extends RawButtonProperties {
   onPress?: (pointerInside: boolean) => void;
   onActiveStateChange?: (active: boolean) => void;
+  style?: StyleProp<ViewStyle>;
 }
 
 export interface RectButtonProperties extends RawButtonProperties {}
@@ -271,7 +274,7 @@ export class RawButton extends React.Component<RawButtonProperties> {}
 
 export class BaseButton extends React.Component<BaseButtonProperties> {}
 
-export class RectButton extends React.Component<RectButtonProperties> {}
+export class RectButton extends BaseButton {}
 
 export class BorderlessButton extends React.Component<
   BorderlessButtonProperties
@@ -319,7 +322,7 @@ export class FlatList extends React.Component<
 
 export function gestureHandlerRootHOC(
   Component: React.Component,
-  containerStyles?: any
+  containerStyles?: StyleProp<ViewStyle>
 ): React.Component;
 
 export interface SwipeableProperties {


### PR DESCRIPTION
Fix errors like these:

`[ts] Property 'onPress' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RectButton> & Readonly<{ children?: ReactNode; }> ...'.`

`[ts] Property 'style' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RectButton> & Readonly<{ children?: ReactNode; }> ...'.`

when using `<RectButton onPress={...} style={...} />`