### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 16
@@ -24,5 +24,5 @@ android {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    provided 'com.facebook.react:react-native:+'
+    compileOnly 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
provided is deprecated, in the new gradle its compileOnly. I've also updated the sdk and buildtools version. If its not conflicting with what you want to do, you can merge it.