### PR TITLE
[TYPING] Fix typing for underlayColor inside RectButton

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -262,7 +262,9 @@ export interface BaseButtonProperties extends RawButtonProperties {
   style?: StyleProp<ViewStyle>;
 }
 
-export interface RectButtonProperties extends RawButtonProperties {}
+export interface RectButtonProperties extends BaseButtonProperties {
+  underlayColor?: string
+}
 
 export interface BorderlessButtonProperties extends RawButtonProperties {
   borderless?: boolean;
@@ -274,7 +276,7 @@ export class RawButton extends React.Component<RawButtonProperties> {}
 
 export class BaseButton extends React.Component<BaseButtonProperties> {}
 
-export class RectButton extends BaseButton {}
+export class RectButton extends React.Component<RectButtonProperties> {}
 
 export class BorderlessButton extends React.Component<
   BorderlessButtonProperties


### PR DESCRIPTION
I recently converted my project to TypeScript and this error was really bugging me so I believe this should fix it. If I've done something terribly wrong please let me know.

This PR is very similar to [this one](https://github.com/kmagiera/react-native-gesture-handler/pull/104)

EDIT: I am very embarassed that I spelt TYPING wrong in my commit