### PR TITLE
Set a valid default value for drawerWidth

### DIFF
--- a/DrawerLayout.js
+++ b/DrawerLayout.js
@@ -68,7 +68,7 @@ export type DrawerMovementOptionType = {
 
 export default class DrawerLayout extends Component<PropType, StateType> {
   static defaultProps = {
-    drawerWidth: 0,
+    drawerWidth: 200,
     drawerPosition: 'left',
     useNativeAnimations: true,
     drawerType: 'front',


### PR DESCRIPTION
If `drawerWidth` is not specified, the entire view is blacked out. This is rather
surprising behavior; I expected `drawerWidth` to be optional, and I spent a lot
of time in confusion trying to figure out why this was happening.

This simple snack demonstrates the problem: https://snack.expo.io/SyDAUwq9M

Ideally, the drawer would have a reasonable default width regardless of
device size and/or adapting to the width of the component rendered by
`renderNavigationView`, but having a default that's not completely broken
at least lets the developer get started.