### PR TITLE
Bottom sheet example and TapGestureHandler improvements

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -16,6 +16,7 @@ import HorizontalDrawer from './horizontalDrawer';
 import Fling from './fling/index';
 import ChatHeads from './chatHeads';
 import { ComboWithGHScroll, ComboWithRNScroll } from './combo';
+import BottomSheet from './bottomSheet/index';
 
 YellowBox.ignoreWarnings([
   'Warning: isMounted(...) is deprecated',
@@ -53,6 +54,10 @@ const SCREENS = {
   //   title: 'Chat Heads (no native animated support yet)',
   // },
   Combo: { screen: ComboWithGHScroll },
+  BottomSheet: {
+    title: 'BottomSheet gestures interactions',
+    screen: BottomSheet,
+  },
   ComboWithRNScroll: {
     screen: ComboWithRNScroll,
     title: "Combo with RN's ScrollView",

--- a/Example/bottomSheet/index.js
+++ b/Example/bottomSheet/index.js
@@ -1,0 +1,153 @@
+import React, { Component } from 'react';
+import { Animated, StyleSheet, Text, View } from 'react-native';
+import {
+  PanGestureHandler,
+  NativeViewGestureHandler,
+  State,
+} from 'react-native-gesture-handler';
+
+import { LoremIpsum } from '../common';
+// import { USE_NATIVE_DRIVER } from '../config';
+USE_NATIVE_DRIVER = false;
+
+const HEADER_HEIGHT = 50;
+
+const SNAP_POINTS_FROM_TOP = [50, 300, 550];
+
+export default class BottomSheet extends Component {
+  constructor(props) {
+    super(props);
+    const START = SNAP_POINTS_FROM_TOP[0];
+    const END = SNAP_POINTS_FROM_TOP[SNAP_POINTS_FROM_TOP.length - 1];
+
+    this.state = {
+      lastSnap: END,
+    };
+
+    this._scrollY = new Animated.Value(0);
+    this._onScroll = Animated.event(
+      [{ nativeEvent: { contentOffset: { y: this._scrollY } } }],
+      { useNativeDriver: USE_NATIVE_DRIVER }
+    );
+
+    this._lastScrollYValue = 0;
+    this._lastScrollY = new Animated.Value(0);
+    this._onRegisterLastScroll = Animated.event(
+      [{ nativeEvent: { contentOffset: { y: this._lastScrollY } } }],
+      { useNativeDriver: USE_NATIVE_DRIVER }
+    );
+    this._lastScrollY.addListener(({ value }) => {
+      this._lastScrollYValue = value;
+    });
+
+    this._dragY = new Animated.Value(0);
+    this._onGestureEvent = Animated.event(
+      [{ nativeEvent: { translationY: this._dragY } }],
+      { useNativeDriver: USE_NATIVE_DRIVER }
+    );
+
+    this._reverseLastScrollY = Animated.multiply(
+      new Animated.Value(-1),
+      this._lastScrollY
+    );
+
+    this._translateYOffset = new Animated.Value(END);
+    this._translateY = Animated.add(
+      this._translateYOffset,
+      Animated.add(this._dragY, this._reverseLastScrollY)
+    ).interpolate({
+      inputRange: [START, END],
+      outputRange: [START, END],
+      extrapolate: 'clamp',
+    });
+
+    this._showScroll = this._translateY.interpolate({
+      inputRange: [START, START + 1],
+      outputRange: [1, 0],
+      extrapolate: 'clamp',
+    });
+  }
+  _onHandlerStateChange = ({ nativeEvent }) => {
+    if (nativeEvent.oldState === State.ACTIVE) {
+      let { velocityY, translationY } = nativeEvent;
+      translationY -= this._lastScrollYValue;
+      const dragToss = 0.05;
+      const endOffsetY =
+        this.state.lastSnap + translationY + dragToss * velocityY;
+
+      let destSnapPoint = SNAP_POINTS_FROM_TOP[0];
+      for (let i = 0; i < SNAP_POINTS_FROM_TOP.length; i++) {
+        const snapPoint = SNAP_POINTS_FROM_TOP[i];
+        const distFromSnap = Math.abs(snapPoint - endOffsetY);
+        if (distFromSnap < Math.abs(destSnapPoint - endOffsetY)) {
+          destSnapPoint = snapPoint;
+        }
+      }
+      this.setState({ lastSnap: destSnapPoint });
+      this._translateYOffset.extractOffset();
+      this._translateYOffset.setValue(translationY);
+      this._translateYOffset.flattenOffset();
+      this._dragY.setValue(0);
+      Animated.spring(this._translateYOffset, {
+        velocity: velocityY,
+        tension: 68,
+        friction: 12,
+        toValue: destSnapPoint,
+        useNativeDriver: USE_NATIVE_DRIVER,
+      }).start();
+    }
+  };
+  render() {
+    return (
+      <View style={styles.container}>
+        <PanGestureHandler
+          shouldActivateBeforeFinish
+          id="masterdrawer"
+          minDeltaY={2000}
+          maxDeltaY={this.state.lastSnap - SNAP_POINTS_FROM_TOP[0]}>
+          <View style={StyleSheet.absoluteFillObject}>
+            <PanGestureHandler
+              id="drawer"
+              simultaneousHandlers={['scroll', 'masterdrawer']}
+              shouldCancelWhenOutside={false}
+              onGestureEvent={this._onGestureEvent}
+              onHandlerStateChange={this._onHandlerStateChange}>
+              <Animated.View
+                style={[
+                  StyleSheet.absoluteFillObject,
+                  {
+                    transform: [{ translateY: this._translateY }],
+                  },
+                ]}>
+                <View style={styles.header} />
+                <NativeViewGestureHandler
+                  id="scroll"
+                  waitFor="masterdrawer"
+                  simultaneousHandlers="drawer">
+                  <Animated.ScrollView
+                    style={styles.scrollView}
+                    bounces={false}
+                    onScroll={this._onScroll}
+                    onScrollBeginDrag={this._onRegisterLastScroll}
+                    scrollEventThrottle={1}>
+                    <LoremIpsum />
+                  </Animated.ScrollView>
+                </NativeViewGestureHandler>
+              </Animated.View>
+            </PanGestureHandler>
+          </View>
+        </PanGestureHandler>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    height: HEADER_HEIGHT,
+    backgroundColor: 'red',
+  },
+});

--- a/Example/bottomSheet/index.js
+++ b/Example/bottomSheet/index.js
@@ -4,6 +4,7 @@ import {
   PanGestureHandler,
   NativeViewGestureHandler,
   State,
+  TapGestureHandler,
 } from 'react-native-gesture-handler';
 
 import { LoremIpsum } from '../common';
@@ -100,10 +101,9 @@ export default class BottomSheet extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <PanGestureHandler
-          shouldActivateBeforeFinish
+        <TapGestureHandler
+          maxDurationMs={100000}
           id="masterdrawer"
-          minDeltaY={2000}
           maxDeltaY={this.state.lastSnap - SNAP_POINTS_FROM_TOP[0]}>
           <View style={StyleSheet.absoluteFillObject}>
             <PanGestureHandler
@@ -131,12 +131,14 @@ export default class BottomSheet extends Component {
                     onScrollBeginDrag={this._onRegisterLastScroll}
                     scrollEventThrottle={1}>
                     <LoremIpsum />
+                    <LoremIpsum />
+                    <LoremIpsum />
                   </Animated.ScrollView>
                 </NativeViewGestureHandler>
               </Animated.View>
             </PanGestureHandler>
           </View>
-        </PanGestureHandler>
+        </TapGestureHandler>
       </View>
     );
   }

--- a/Example/bottomSheet/index.js
+++ b/Example/bottomSheet/index.js
@@ -8,8 +8,7 @@ import {
 } from 'react-native-gesture-handler';
 
 import { LoremIpsum } from '../common';
-// import { USE_NATIVE_DRIVER } from '../config';
-USE_NATIVE_DRIVER = false;
+import { USE_NATIVE_DRIVER } from '../config';
 
 const HEADER_HEIGHT = 50;
 

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -308,6 +308,7 @@ const TapGestureHandler = createHandler(
     maxDeltaY: PropTypes.number,
     minPointers: PropTypes.number,
     maxDist: PropTypes.number,
+    minPointers: PropTypes.number,
   },
   {}
 );

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -59,6 +59,7 @@ const handlerIDToTag = {};
 
 const GestureHandlerPropTypes = {
   id: PropTypes.string,
+  minPointers: PropTypes.number,
   enabled: PropTypes.bool,
   waitFor: PropTypes.oneOfType([
     PropTypes.string,

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -306,6 +306,7 @@ const TapGestureHandler = createHandler(
     numberOfTaps: PropTypes.number,
     maxDeltaX: PropTypes.number,
     maxDeltaY: PropTypes.number,
+    minPointers: PropTypes.number,
     maxDist: PropTypes.number,
   },
   {}

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -304,6 +304,9 @@ const TapGestureHandler = createHandler(
     maxDurationMs: PropTypes.number,
     maxDelayMs: PropTypes.number,
     numberOfTaps: PropTypes.number,
+    maxDeltaX: PropTypes.number,
+    maxDeltaY: PropTypes.number,
+    maxDist: PropTypes.number,
   },
   {}
 );

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -336,7 +336,6 @@ const PanGestureHandler = createHandler(
     maxDeltaX: PropTypes.number,
     maxDeltaY: PropTypes.number,
     minOffsetX: PropTypes.number,
-    shouldActivateBeforeFinish: PropTypes.bool,
     minOffsetY: PropTypes.number,
     minDist: PropTypes.number,
     minVelocity: PropTypes.number,

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -333,6 +333,7 @@ const PanGestureHandler = createHandler(
     maxDeltaX: PropTypes.number,
     maxDeltaY: PropTypes.number,
     minOffsetX: PropTypes.number,
+    shouldActivateBeforeFinish: PropTypes.bool,
     minOffsetY: PropTypes.number,
     minDist: PropTypes.number,
     minVelocity: PropTypes.number,

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ Library exports a `State` object that provides a number of constants used to exp
  - `minVelocityY`
  - `minPointers`
  - `maxPointers`
-  - `shouldActivateBeforeFinish` (you could use this handler for some kind of dicretre gestures - if gesture does not fail before releasing pointer, it will get active for a while like Tap or Fling)
  - `avgTouches` (**Android only**)
 
 #### `PinchGestureHandler`

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Library exports a `State` object that provides a number of constants used to exp
  - `minVelocityY`
  - `minPointers`
  - `maxPointers`
+  - `shouldActivateBeforeFinish` (you could use this handler for some kind of dicretre gestures - if gesture does not fail before releasing pointer, it will get active for a while like Tap or Fling)
  - `avgTouches` (**Android only**)
 
 #### `PinchGestureHandler`

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureUtils.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureUtils.java
@@ -1,0 +1,54 @@
+package com.swmansion.gesturehandler;
+
+
+import android.view.MotionEvent;
+
+public class GestureUtils {
+    /*package*/ static float getLastPointerX(MotionEvent event, boolean averageTouches) {
+        float offset = event.getRawX() - event.getX();
+        int excludeIndex = event.getActionMasked() == MotionEvent.ACTION_POINTER_UP ?
+                event.getActionIndex() : -1;
+
+        if (averageTouches) {
+            float sum = 0f;
+            int count = 0;
+            for (int i = 0, size = event.getPointerCount(); i < size; i++) {
+                if (i != excludeIndex) {
+                    sum += event.getX(i) + offset;
+                    count++;
+                }
+            }
+            return sum / count;
+        } else {
+            int lastPointerIdx = event.getPointerCount() - 1;
+            if (lastPointerIdx == excludeIndex) {
+                lastPointerIdx--;
+            }
+            return event.getX(lastPointerIdx) + offset;
+        }
+    }
+
+    /*package*/ static float getLastPointerY(MotionEvent event, boolean averageTouches) {
+        float offset = event.getRawY() - event.getY();
+        int excludeIndex = event.getActionMasked() == MotionEvent.ACTION_POINTER_UP ?
+                event.getActionIndex() : -1;
+
+        if (averageTouches) {
+            float sum = 0f;
+            int count = 0;
+            for (int i = 0, size = event.getPointerCount(); i < size; i++) {
+                if (i != excludeIndex) {
+                    sum += event.getY(i) + offset;
+                    count++;
+                }
+            }
+            return sum / count;
+        } else {
+            int lastPointerIdx = event.getPointerCount() - 1;
+            if (lastPointerIdx == excludeIndex) {
+                lastPointerIdx -= 1;
+            }
+            return event.getY(lastPointerIdx) + offset;
+        }
+    }
+}

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureUtils.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureUtils.java
@@ -1,10 +1,9 @@
 package com.swmansion.gesturehandler;
 
-
 import android.view.MotionEvent;
 
 public class GestureUtils {
-    /*package*/ static float getLastPointerX(MotionEvent event, boolean averageTouches) {
+    public static float getLastPointerX(MotionEvent event, boolean averageTouches) {
         float offset = event.getRawX() - event.getX();
         int excludeIndex = event.getActionMasked() == MotionEvent.ACTION_POINTER_UP ?
                 event.getActionIndex() : -1;
@@ -28,7 +27,7 @@ public class GestureUtils {
         }
     }
 
-    /*package*/ static float getLastPointerY(MotionEvent event, boolean averageTouches) {
+    public static float getLastPointerY(MotionEvent event, boolean averageTouches) {
         float offset = event.getRawY() - event.getY();
         int excludeIndex = event.getActionMasked() == MotionEvent.ACTION_POINTER_UP ?
                 event.getActionIndex() : -1;

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
@@ -47,55 +47,6 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
    * because each finger when treated separately will travel some distance, whereas the average
    * position of all the fingers will remain still while doing a rotation gesture.
    */
-  private static float getLastPointerX(MotionEvent event, boolean averageTouches) {
-    float offset = event.getRawX() - event.getX();
-    int excludeIndex = event.getActionMasked() == MotionEvent.ACTION_POINTER_UP ?
-            event.getActionIndex() : -1;
-
-    if (averageTouches) {
-      float sum = 0f;
-      int count = 0;
-      for (int i = 0, size = event.getPointerCount(); i < size; i++) {
-        if (i != excludeIndex) {
-          sum += event.getX(i) + offset;
-          count++;
-        }
-      }
-      return sum / count;
-    } else {
-      int lastPointerIdx = event.getPointerCount() - 1;
-      if (lastPointerIdx == excludeIndex) {
-        lastPointerIdx--;
-      }
-      return event.getX(lastPointerIdx) + offset;
-    }
-  }
-
-  private static float getLastPointerY(MotionEvent event, boolean averageTouches) {
-    float offset = event.getRawY() - event.getY();
-    int excludeIndex = event.getActionMasked() == MotionEvent.ACTION_POINTER_UP ?
-            event.getActionIndex() : -1;
-
-    if (averageTouches) {
-      float sum = 0f;
-      int count = 0;
-      for (int i = 0, size = event.getPointerCount(); i < size; i++) {
-        if (i != excludeIndex) {
-          sum += event.getY(i) + offset;
-          count++;
-        }
-      }
-      return sum / count;
-    } else {
-      int lastPointerIdx = event.getPointerCount() - 1;
-      if (lastPointerIdx == excludeIndex) {
-        lastPointerIdx -= 1;
-      }
-      return event.getY(lastPointerIdx) + offset;
-    }
-  }
-
-
   public PanGestureHandler(Context context) {
     ViewConfiguration vc = ViewConfiguration.get(context);
     int touchSlop = vc.getScaledTouchSlop();
@@ -239,15 +190,15 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
       mOffsetY += mLastY - mStartY;
 
       // reset starting point
-      mLastX = getLastPointerX(event, mAverageTouches);
-      mLastY = getLastPointerY(event, mAverageTouches);
+      mLastX = GestureUtils.getLastPointerX(event, mAverageTouches);
+      mLastY = GestureUtils.getLastPointerY(event, mAverageTouches);
       mLastEventOffsetX = event.getRawX() - event.getX();
       mLastEventOffsetY = event.getRawY() - event.getY();
       mStartX = mLastX;
       mStartY = mLastY;
     } else {
-      mLastX = getLastPointerX(event, mAverageTouches);
-      mLastY = getLastPointerY(event, mAverageTouches);
+      mLastX = GestureUtils.getLastPointerX(event, mAverageTouches);
+      mLastY = GestureUtils.getLastPointerY(event, mAverageTouches);
       mLastEventOffsetX = event.getRawX() - event.getX();
       mLastEventOffsetY = event.getRawY() - event.getY();
     }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
@@ -12,6 +12,7 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
 
   private static int DEFAULT_MIN_POINTERS = 1;
   private static int DEFAULT_MAX_POINTERS = 10;
+  private static boolean DEFAULT_SHOULD_ACTIVATE_BEFORE_FINISH = false;
 
   private float mMinOffsetX = MIN_VALUE_IGNORE;
   private float mMinOffsetY = MIN_VALUE_IGNORE;
@@ -25,6 +26,7 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
   private float mMinVelocitySq = MIN_VALUE_IGNORE;
   private int mMinPointers = DEFAULT_MIN_POINTERS;
   private int mMaxPointers = DEFAULT_MAX_POINTERS;
+  private boolean mShouldActivateBeforeFinish = DEFAULT_SHOULD_ACTIVATE_BEFORE_FINISH;
 
   private float mStartX, mStartY;
   private float mOffsetX, mOffsetY;
@@ -152,6 +154,11 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
     return this;
   }
 
+  public PanGestureHandler setShouldActivateBeforeFinish(boolean shouldActivateBeforeFinish) {
+    mShouldActivateBeforeFinish = shouldActivateBeforeFinish;
+    return this;
+  }
+
   /**
    * @param minVelocity in pixels per second
    */
@@ -271,7 +278,12 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
       if (state == STATE_ACTIVE) {
         end();
       } else {
-        fail();
+        if (mShouldActivateBeforeFinish) {
+          activate();
+          end();
+        } else {
+          fail();
+        }
       }
     } else if (action == MotionEvent.ACTION_POINTER_DOWN && event.getPointerCount() > mMaxPointers) {
       // When new finger is placed down (POINTER_DOWN) we check if MAX_POINTERS is not exceeded

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
@@ -12,7 +12,6 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
 
   private static int DEFAULT_MIN_POINTERS = 1;
   private static int DEFAULT_MAX_POINTERS = 10;
-  private static boolean DEFAULT_SHOULD_ACTIVATE_BEFORE_FINISH = false;
 
   private float mMinOffsetX = MIN_VALUE_IGNORE;
   private float mMinOffsetY = MIN_VALUE_IGNORE;
@@ -26,7 +25,6 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
   private float mMinVelocitySq = MIN_VALUE_IGNORE;
   private int mMinPointers = DEFAULT_MIN_POINTERS;
   private int mMaxPointers = DEFAULT_MAX_POINTERS;
-  private boolean mShouldActivateBeforeFinish = DEFAULT_SHOULD_ACTIVATE_BEFORE_FINISH;
 
   private float mStartX, mStartY;
   private float mOffsetX, mOffsetY;
@@ -154,11 +152,6 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
     return this;
   }
 
-  public PanGestureHandler setShouldActivateBeforeFinish(boolean shouldActivateBeforeFinish) {
-    mShouldActivateBeforeFinish = shouldActivateBeforeFinish;
-    return this;
-  }
-
   /**
    * @param minVelocity in pixels per second
    */
@@ -278,12 +271,7 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
       if (state == STATE_ACTIVE) {
         end();
       } else {
-        if (mShouldActivateBeforeFinish) {
-          activate();
-          end();
-        } else {
-          fail();
-        }
+        fail();
       }
     } else if (action == MotionEvent.ACTION_POINTER_DOWN && event.getPointerCount() > mMaxPointers) {
       // When new finger is placed down (POINTER_DOWN) we check if MAX_POINTERS is not exceeded

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -7,8 +7,8 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
   private static float MAX_VALUE_IGNORE = Float.MIN_VALUE;
   private static final long DEFAULT_MAX_DURATION_MS = 500;
   private static final long DEFAULT_MAX_DELAY_MS = 500;
-  private static final int DEFAULT_NUMBER_OF_TAPS= 1;
-  private static final int DEFAULT_MIN_NUMBER_OF_POINTERS= 1;
+  private static final int DEFAULT_NUMBER_OF_TAPS = 1;
+  private static final int DEFAULT_MIN_NUMBER_OF_POINTERS = 1;
 
   private float mMaxDeltaX = MAX_VALUE_IGNORE;
   private float mMaxDeltaY = MAX_VALUE_IGNORE;
@@ -137,8 +137,10 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
     mLastX = event.getRawX();
     mLastY = event.getRawY();
 
-    if (mNumberOfPointers < event.getPointerCount()) {
-      mNumberOfPointers = event.getPointerCount();
+    if (action == MotionEvent.ACTION_MOVE) {
+      if (mNumberOfPointers < event.getPointerCount()) {
+        mNumberOfPointers = event.getPointerCount();
+      }
     }
 
     if (action == MotionEvent.ACTION_DOWN) {
@@ -146,9 +148,7 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
         begin();
       }
       startTap();
-    }
-
-    if (shouldFail()) {
+    } else if (shouldFail()) {
       fail();
     }
     if (action == MotionEvent.ACTION_UP) {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -4,15 +4,21 @@ import android.os.Handler;
 import android.view.MotionEvent;
 
 public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
-
+  private static float MAX_VALUE_IGNORE = Float.MIN_VALUE;
   private static final long DEFAULT_MAX_DURATION_MS = 500;
   private static final long DEFAULT_MAX_DELAY_MS = 500;
   private static final int DEFAULT_NUMBER_OF_TAPS= 1;
+
+  private float mMaxDeltaX = MAX_VALUE_IGNORE;
+  private float mMaxDeltaY = MAX_VALUE_IGNORE;
+  private float mMaxDist = MAX_VALUE_IGNORE;
 
   private long mMaxDurationMs = DEFAULT_MAX_DURATION_MS;
   private long mMaxDelayMs = DEFAULT_MAX_DELAY_MS;
   private int mNumberOfTaps = DEFAULT_NUMBER_OF_TAPS;
 
+  private float mStartX, mStartY;
+  private float mOffsetX, mOffsetY;
   private float mLastX, mLastY;
   private float mLastEventOffsetX, mLastEventOffsetY;
 
@@ -38,6 +44,20 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
 
   public TapGestureHandler setMaxDurationMs(long maxDurationMs) {
     mMaxDurationMs = maxDurationMs;
+    return this;
+  }
+
+  public TapGestureHandler setMaxDx(float deltaX) {
+    mMaxDeltaX = deltaX;
+    return this;
+  }
+
+  public TapGestureHandler setMaxDy(float deltaY) {
+    mMaxDeltaY = deltaY;
+    return this;
+  }
+  public TapGestureHandler setMaxDist(float maxDist) {
+    mMaxDeltaY = maxDist;
     return this;
   }
 
@@ -68,27 +88,74 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
     }
   }
 
+  private static float getLastPointer(MotionEvent event, boolean isX) {
+    float offset = isX ? event.getRawX() - event.getX() : event.getRawY() - event.getY();
+    int excludeIndex = event.getActionMasked() == MotionEvent.ACTION_POINTER_UP ?
+            event.getActionIndex() : -1;
+      float sum = 0f;
+      int count = 0;
+      for (int i = 0, size = event.getPointerCount(); i < size; i++) {
+        if (i != excludeIndex) {
+          sum += (isX ? event.getX(i) : event.getY()) + offset;
+          count++;
+        }
+      }
+      return sum / count;
+  }
+
+  private boolean shouldFail() {
+    float dx = mLastX - mStartX + mOffsetX;
+    if (mMaxDeltaX != MAX_VALUE_IGNORE && Math.abs(dx) > mMaxDeltaX) {
+      return true;
+    }
+
+    float dy = mLastY - mStartY + mOffsetY;
+    if (mMaxDeltaY != MAX_VALUE_IGNORE && Math.abs(dy) > mMaxDeltaY) {
+      return true;
+    }
+
+    float dist = dy * dy + dx * dx;
+    return mMaxDist != MAX_VALUE_IGNORE && Math.abs(dist) > mMaxDist;
+  }
+
   @Override
   protected void onHandle(MotionEvent event) {
     int state = getState();
+    int action = event.getActionMasked();
+
+    if (action == MotionEvent.ACTION_POINTER_UP || action == MotionEvent.ACTION_POINTER_DOWN) {
+      mOffsetX += mLastX - mStartX;
+      mOffsetY += mLastY - mStartY;
+      mLastX = getLastPointer(event, true);
+      mLastY = getLastPointer(event, false);
+      mLastEventOffsetX = event.getRawX() - event.getX();
+      mLastEventOffsetY = event.getRawY() - event.getY();
+      mStartX = mLastX;
+      mStartY = mLastY;
+    } else {
+      mLastX = getLastPointer(event, true);
+      mLastY = getLastPointer(event, false);
+      mLastEventOffsetX = event.getRawX() - event.getX();
+      mLastEventOffsetY = event.getRawY() - event.getY();
+    }
 
     mLastEventOffsetX = event.getRawX() - event.getX();
     mLastEventOffsetY = event.getRawY() - event.getY();
     mLastX = event.getRawX();
     mLastY = event.getRawY();
 
-    if (state == STATE_UNDETERMINED) {
-      begin();
-      mTapsSoFar = 0;
+    if (action == MotionEvent.ACTION_DOWN) {
+      if (state == STATE_UNDETERMINED) {
+        begin();
+      }
       startTap();
     }
-    if (state == STATE_BEGAN) {
-      int action = event.getActionMasked();
-      if (action == MotionEvent.ACTION_UP) {
-        endTap();
-      } else if (action == MotionEvent.ACTION_DOWN) {
-        startTap();
-      }
+
+    if (shouldFail()) {
+      fail();
+    }
+    if (action == MotionEvent.ACTION_UP) {
+      endTap();
     }
   }
 

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -147,9 +147,12 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
         begin();
       }
       startTap();
-    } else if (shouldFail()) {
+    }
+
+    if (shouldFail()) {
       fail();
     }
+
     if (action == MotionEvent.ACTION_UP) {
       endTap();
     }
@@ -165,6 +168,7 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
   @Override
   protected void onReset() {
     mTapsSoFar = 0;
+    mNumberOfPointers = 0;
     if (mHandler != null) {
       mHandler.removeCallbacksAndMessages(null);
     }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -150,7 +150,7 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
         begin();
       }
       startTap();
-  } else if (state == STATE_BEGAN || state == STATE_ACTIVE) {
+  } else if (state == STATE_BEGAN) {
       if (action == MotionEvent.ACTION_UP) {
         endTap();
       }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -136,11 +136,8 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
     mLastEventOffsetY = event.getRawY() - event.getY();
     mLastX = event.getRawX();
     mLastY = event.getRawY();
-
-    if (action == MotionEvent.ACTION_MOVE) {
-      if (mNumberOfPointers < event.getPointerCount()) {
-        mNumberOfPointers = event.getPointerCount();
-      }
+    if (mNumberOfPointers < event.getPointerCount()) {
+      mNumberOfPointers = event.getPointerCount();
     }
 
     if (action == MotionEvent.ACTION_DOWN) {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -121,15 +121,11 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
       mOffsetY += mLastY - mStartY;
       mLastX = GestureUtils.getLastPointerX(event, true);
       mLastY = GestureUtils.getLastPointerY(event, true);
-      mLastEventOffsetX = event.getRawX() - event.getX();
-      mLastEventOffsetY = event.getRawY() - event.getY();
       mStartX = mLastX;
       mStartY = mLastY;
     } else {
       mLastX = GestureUtils.getLastPointerX(event, true);
       mLastY = GestureUtils.getLastPointerY(event, true);
-      mLastEventOffsetX = event.getRawX() - event.getX();
-      mLastEventOffsetY = event.getRawY() - event.getY();
     }
 
     mLastEventOffsetX = event.getRawX() - event.getX();
@@ -154,6 +150,10 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
       if (action == MotionEvent.ACTION_UP) {
         endTap();
       }
+      if (action == MotionEvent.ACTION_DOWN) {
+        startTap();
+      }
+
     }
   }
 

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -96,21 +96,6 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
     }
   }
 
-  private static float getLastPointer(MotionEvent event, boolean isX) {
-    float offset = isX ? event.getRawX() - event.getX() : event.getRawY() - event.getY();
-    int excludeIndex = event.getActionMasked() == MotionEvent.ACTION_POINTER_UP ?
-            event.getActionIndex() : -1;
-      float sum = 0f;
-      int count = 0;
-      for (int i = 0, size = event.getPointerCount(); i < size; i++) {
-        if (i != excludeIndex) {
-          sum += (isX ? event.getX(i) : event.getY()) + offset;
-          count++;
-        }
-      }
-      return sum / count;
-  }
-
   private boolean shouldFail() {
     float dx = mLastX - mStartX + mOffsetX;
     if (mMaxDeltaX != MAX_VALUE_IGNORE && Math.abs(dx) > mMaxDeltaX) {
@@ -134,15 +119,15 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
     if (action == MotionEvent.ACTION_POINTER_UP || action == MotionEvent.ACTION_POINTER_DOWN) {
       mOffsetX += mLastX - mStartX;
       mOffsetY += mLastY - mStartY;
-      mLastX = getLastPointer(event, true);
-      mLastY = getLastPointer(event, false);
+      mLastX = GestureUtils.getLastPointerX(event, true);
+      mLastY = GestureUtils.getLastPointerY(event, true);
       mLastEventOffsetX = event.getRawX() - event.getX();
       mLastEventOffsetY = event.getRawY() - event.getY();
       mStartX = mLastX;
       mStartY = mLastY;
     } else {
-      mLastX = getLastPointer(event, true);
-      mLastY = getLastPointer(event, false);
+      mLastX = GestureUtils.getLastPointerX(event, true);
+      mLastY = GestureUtils.getLastPointerY(event, true);
       mLastEventOffsetX = event.getRawX() - event.getX();
       mLastEventOffsetY = event.getRawY() - event.getY();
     }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -145,6 +145,8 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
 
     if (action == MotionEvent.ACTION_DOWN) {
       if (state == STATE_UNDETERMINED) {
+        mOffsetX = 0;
+        mOffsetY = 0;
         begin();
       }
       startTap();

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -136,25 +136,24 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
     mLastEventOffsetY = event.getRawY() - event.getY();
     mLastX = event.getRawX();
     mLastY = event.getRawY();
+
     if (mNumberOfPointers < event.getPointerCount()) {
       mNumberOfPointers = event.getPointerCount();
     }
 
-    if (action == MotionEvent.ACTION_DOWN) {
-      if (state == STATE_UNDETERMINED) {
+    if (shouldFail()) {
+      fail();
+    } else if (state == STATE_UNDETERMINED) {
+      if (action == MotionEvent.ACTION_DOWN) {
         mOffsetX = 0;
         mOffsetY = 0;
         begin();
       }
       startTap();
-    }
-
-    if (shouldFail()) {
-      fail();
-    }
-
-    if (action == MotionEvent.ACTION_UP) {
-      endTap();
+  } else if (state == STATE_BEGAN || state == STATE_ACTIVE) {
+      if (action == MotionEvent.ACTION_UP) {
+        endTap();
+      }
     }
   }
 

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -121,17 +121,16 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
       mOffsetY += mLastY - mStartY;
       mLastX = GestureUtils.getLastPointerX(event, true);
       mLastY = GestureUtils.getLastPointerY(event, true);
+      mLastEventOffsetX = event.getRawX() - event.getX();
+      mLastEventOffsetY = event.getRawY() - event.getY();
       mStartX = mLastX;
       mStartY = mLastY;
     } else {
       mLastX = GestureUtils.getLastPointerX(event, true);
       mLastY = GestureUtils.getLastPointerY(event, true);
+      mLastEventOffsetX = event.getRawX() - event.getX();
+      mLastEventOffsetY = event.getRawY() - event.getY();
     }
-
-    mLastEventOffsetX = event.getRawX() - event.getX();
-    mLastEventOffsetY = event.getRawY() - event.getY();
-    mLastX = event.getRawX();
-    mLastY = event.getRawY();
 
     if (mNumberOfPointers < event.getPointerCount()) {
       mNumberOfPointers = event.getPointerCount();
@@ -143,17 +142,17 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
       if (action == MotionEvent.ACTION_DOWN) {
         mOffsetX = 0;
         mOffsetY = 0;
+        mStartX = event.getRawX();
+        mStartY = event.getRawY();
         begin();
       }
       startTap();
   } else if (state == STATE_BEGAN) {
       if (action == MotionEvent.ACTION_UP) {
         endTap();
-      }
-      if (action == MotionEvent.ACTION_DOWN) {
+      } else if (action == MotionEvent.ACTION_DOWN) {
         startTap();
       }
-
     }
   }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -76,7 +76,6 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
   private static final String KEY_PAN_AVG_TOUCHES = "avgTouches";
   private static final String KEY_NUMBER_OF_POINTERS = "numberOfPointers";
   private static final String KEY_DIRECTION= "direction";
-  private static final String KEY_PAN_SHOULD_ACTIVATE_BEFORE_FINISH = "shouldActivateBeforeFinish";
 
   private abstract static class HandlerFactory<T extends GestureHandler>
           implements RNGestureHandlerEventDataExtractor<T> {
@@ -292,11 +291,6 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
       if (config.hasKey(KEY_PAN_AVG_TOUCHES)) {
         handler.setAverageTouches(config.getBoolean(KEY_PAN_AVG_TOUCHES));
       }
-      if (config.hasKey(KEY_PAN_SHOULD_ACTIVATE_BEFORE_FINISH)) {
-        handler.setShouldActivateBeforeFinish(
-                config.getBoolean(KEY_PAN_SHOULD_ACTIVATE_BEFORE_FINISH));
-      }
-
     }
 
     @Override

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -56,6 +56,9 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
   private static final String KEY_TAP_NUMBER_OF_TAPS = "numberOfTaps";
   private static final String KEY_TAP_MAX_DURATION_MS = "maxDurationMs";
   private static final String KEY_TAP_MAX_DELAY_MS = "maxDelayMs";
+  private static final String KEY_TAP_MAX_DELTA_X = "maxDeltaX";
+  private static final String KEY_TAP_MAX_DELTA_Y = "maxDeltaY";
+  private static final String KEY_TAP_MAX_DIST = "maxDist";
   private static final String KEY_LONG_PRESS_MIN_DURATION_MS = "minDurationMs";
   private static final String KEY_LONG_PRESS_MAX_DIST = "maxDist";
   private static final String KEY_PAN_MIN_DELTA_X = "minDeltaX";
@@ -72,7 +75,7 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
   private static final String KEY_PAN_MAX_POINTERS = "maxPointers";
   private static final String KEY_PAN_AVG_TOUCHES = "avgTouches";
   private static final String KEY_NUMBER_OF_POINTERS = "numberOfPointers";
-  private static final String KEY_DIRECTION = "direction";
+  private static final String KEY_DIRECTION= "direction";
   private static final String KEY_PAN_SHOULD_ACTIVATE_BEFORE_FINISH = "shouldActivateBeforeFinish";
 
   private abstract static class HandlerFactory<T extends GestureHandler>
@@ -164,6 +167,15 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
       }
       if (config.hasKey(KEY_TAP_MAX_DELAY_MS)) {
         handler.setMaxDelayMs(config.getInt(KEY_TAP_MAX_DELAY_MS));
+      }
+      if (config.hasKey(KEY_TAP_MAX_DELTA_X)) {
+        handler.setMaxDx(config.getInt(KEY_TAP_MAX_DELTA_X));
+      }
+      if (config.hasKey(KEY_TAP_MAX_DELTA_Y)) {
+        handler.setMaxDy(config.getInt(KEY_TAP_MAX_DELTA_Y));
+      }
+      if (config.hasKey(KEY_TAP_MAX_DIST)) {
+        handler.setMaxDist(config.getInt(KEY_TAP_MAX_DIST));
       }
     }
 
@@ -371,7 +383,6 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
 
     @Override
     public void extractEventData(RotationGestureHandler handler, WritableMap eventData) {
-      eventData.putDouble("rotation", handler.getRotation());
       eventData.putDouble("rotation", handler.getRotation());
       eventData.putDouble("anchorX", PixelUtil.toDIPFromPixel(handler.getAnchorX()));
       eventData.putDouble("anchorY", PixelUtil.toDIPFromPixel(handler.getAnchorY()));

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -72,7 +72,8 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
   private static final String KEY_PAN_MAX_POINTERS = "maxPointers";
   private static final String KEY_PAN_AVG_TOUCHES = "avgTouches";
   private static final String KEY_NUMBER_OF_POINTERS = "numberOfPointers";
-  private static final String KEY_DIRECTION= "direction";
+  private static final String KEY_DIRECTION = "direction";
+  private static final String KEY_PAN_SHOULD_ACTIVATE_BEFORE_FINISH = "shouldActivateBeforeFinish";
 
   private abstract static class HandlerFactory<T extends GestureHandler>
           implements RNGestureHandlerEventDataExtractor<T> {
@@ -279,6 +280,11 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
       if (config.hasKey(KEY_PAN_AVG_TOUCHES)) {
         handler.setAverageTouches(config.getBoolean(KEY_PAN_AVG_TOUCHES));
       }
+      if (config.hasKey(KEY_PAN_SHOULD_ACTIVATE_BEFORE_FINISH)) {
+        handler.setShouldActivateBeforeFinish(
+                config.getBoolean(KEY_PAN_SHOULD_ACTIVATE_BEFORE_FINISH));
+      }
+
     }
 
     @Override

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -59,6 +59,7 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
   private static final String KEY_TAP_MAX_DELTA_X = "maxDeltaX";
   private static final String KEY_TAP_MAX_DELTA_Y = "maxDeltaY";
   private static final String KEY_TAP_MAX_DIST = "maxDist";
+  private static final String KEY_TAP_MIN_POINTERS = "minPointers";
   private static final String KEY_LONG_PRESS_MIN_DURATION_MS = "minDurationMs";
   private static final String KEY_LONG_PRESS_MAX_DIST = "maxDist";
   private static final String KEY_PAN_MIN_DELTA_X = "minDeltaX";
@@ -175,6 +176,9 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
       }
       if (config.hasKey(KEY_TAP_MAX_DIST)) {
         handler.setMaxDist(config.getInt(KEY_TAP_MAX_DIST));
+      }
+      if (config.hasKey(KEY_TAP_MIN_POINTERS)) {
+        handler.setMinNumberOfPointers(config.getInt(KEY_TAP_MIN_POINTERS));
       }
     }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -169,13 +169,13 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
         handler.setMaxDelayMs(config.getInt(KEY_TAP_MAX_DELAY_MS));
       }
       if (config.hasKey(KEY_TAP_MAX_DELTA_X)) {
-        handler.setMaxDx(config.getInt(KEY_TAP_MAX_DELTA_X));
+        handler.setMaxDx(PixelUtil.toPixelFromDIP(config.getDouble(KEY_TAP_MAX_DELTA_X)));
       }
       if (config.hasKey(KEY_TAP_MAX_DELTA_Y)) {
-        handler.setMaxDy(config.getInt(KEY_TAP_MAX_DELTA_Y));
+        handler.setMaxDy(PixelUtil.toPixelFromDIP(config.getDouble(KEY_TAP_MAX_DELTA_Y)));
       }
       if (config.hasKey(KEY_TAP_MAX_DIST)) {
-        handler.setMaxDist(config.getInt(KEY_TAP_MAX_DIST));
+        handler.setMaxDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_TAP_MAX_DIST)));
       }
       if (config.hasKey(KEY_TAP_MIN_POINTERS)) {
         handler.setMinNumberOfPointers(config.getInt(KEY_TAP_MIN_POINTERS));

--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -22,6 +22,7 @@
 @property (nonatomic) CGFloat minVelocitySq;
 @property (nonatomic) CGFloat maxDeltaX;
 @property (nonatomic) CGFloat maxDeltaY;
+@property (nonatomic) BOOL shouldActivateBeforeFinish;
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
 
@@ -49,6 +50,7 @@
         _minVelocityY = NAN;
         _minVelocitySq = NAN;
         _hasCustomActivationCriteria = NO;
+        _shouldActivateBeforeFinish = NO;
         _realMinimumNumberOfTouches = self.minimumNumberOfTouches;
     }
     return self;
@@ -100,6 +102,14 @@
             [self setTranslation:CGPointMake(0, 0) inView:self.view];
         }
     }
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    if(self.shouldActivateBeforeFinish) {
+        self.state = UIGestureRecognizerStateBegan;
+    }
+     [super touchesEnded:touches withEvent:event];
 }
 
 - (void)reset
@@ -189,8 +199,13 @@
 
     APPLY_NAMED_INT_PROP(minimumNumberOfTouches, @"minPointers");
     APPLY_NAMED_INT_PROP(maximumNumberOfTouches, @"maxPointers");
+    
+    id prop = config[@"shouldActivateBeforeFinish"];
+    if (prop != nil) {
+        recognizer.shouldActivateBeforeFinish = [RCTConvert BOOL:prop];
+    }
 
-    id prop = config[@"minDist"];
+    prop = config[@"minDist"];
     if (prop != nil) {
         CGFloat dist = [RCTConvert CGFloat:prop];
         recognizer.minDistSq = dist * dist;

--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -22,7 +22,6 @@
 @property (nonatomic) CGFloat minVelocitySq;
 @property (nonatomic) CGFloat maxDeltaX;
 @property (nonatomic) CGFloat maxDeltaY;
-@property (nonatomic) BOOL shouldActivateBeforeFinish;
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
 
@@ -50,7 +49,6 @@
         _minVelocityY = NAN;
         _minVelocitySq = NAN;
         _hasCustomActivationCriteria = NO;
-        _shouldActivateBeforeFinish = NO;
         _realMinimumNumberOfTouches = self.minimumNumberOfTouches;
     }
     return self;
@@ -102,14 +100,6 @@
             [self setTranslation:CGPointMake(0, 0) inView:self.view];
         }
     }
-}
-
-- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
-{
-    if(self.shouldActivateBeforeFinish) {
-        self.state = UIGestureRecognizerStateBegan;
-    }
-     [super touchesEnded:touches withEvent:event];
 }
 
 - (void)reset
@@ -199,13 +189,8 @@
 
     APPLY_NAMED_INT_PROP(minimumNumberOfTouches, @"minPointers");
     APPLY_NAMED_INT_PROP(maximumNumberOfTouches, @"maxPointers");
-    
-    id prop = config[@"shouldActivateBeforeFinish"];
-    if (prop != nil) {
-        recognizer.shouldActivateBeforeFinish = [RCTConvert BOOL:prop];
-    }
 
-    prop = config[@"minDist"];
+    id prop = config[@"minDist"];
     if (prop != nil) {
         CGFloat dist = [RCTConvert CGFloat:prop];
         recognizer.minDistSq = dist * dist;

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -98,27 +98,28 @@
         _maxNumberOfTouches = numberOfTouches;
     }
 
-    if (_gestureHandler.shouldCancelWhenOutside) {
-        CGPoint pt = [self locationInView:self.view];
-        if (!CGRectContainsPoint(self.view.bounds, pt)) {
-            self.state = UIGestureRecognizerStateFailed;
-            [self triggerAction];
-            [self reset];
-            return;
-        }
-    }
-
+    
     if ([self shouldFailUnderCustomCriteria]) {
         self.state = UIGestureRecognizerStateFailed;
+        [self triggerAction];
+        [self reset];
         return;
     }
 
     self.state = UIGestureRecognizerStatePossible;
     [self triggerAction];
+    return;
 }
 
 - (BOOL)shouldFailUnderCustomCriteria
 {
+    if (_gestureHandler.shouldCancelWhenOutside) {
+        CGPoint pt = [self locationInView:self.view];
+        if (!CGRectContainsPoint(self.view.bounds, pt)) {
+            return YES;
+        }
+    }
+
     CGPoint trans = [self translationInView:self.view];
     if (TEST_MAX_IF_NOT_NAN(fabs(trans.x), _maxDeltaX)) {
         return YES;

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -77,7 +77,7 @@
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
     [super touchesMoved:touches withEvent:event];
-    
+
     if (self.state != UIGestureRecognizerStatePossible) {
         return;
     }

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -26,6 +26,7 @@
 @property (nonatomic) CGFloat currentNumberOfTaps;
 @property (nonatomic) CGPoint currentLocation;
 @property (nonatomic) CGPoint deltaLocation;
+@property (nonatomic) NSInteger minPointers;
 
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
@@ -44,6 +45,7 @@
         _tapsSoFar = 0;
         _numberOfTaps = 1;
         _maxDelay = 0.2;
+        _minPointers = 1;
         _maxDuration = NAN;
         _maxDeltaX = NAN;
         _maxDeltaY = NAN;
@@ -120,7 +122,7 @@
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    if (_numberOfTaps == _tapsSoFar) {
+    if (_numberOfTaps == _tapsSoFar && self.numberOfTouches >= _minPointers) {
         self.state = UIGestureRecognizerStateBegan;
         [super touchesEnded:touches withEvent:event];
         self.state = UIGestureRecognizerStateEnded;
@@ -166,6 +168,7 @@
     RNBetterTapGestureRecognizer *recognizer = (RNBetterTapGestureRecognizer *)_recognizer;
 
     APPLY_INT_PROP(numberOfTaps);
+    APPLY_INT_PROP(minPointers);
     APPLY_FLOAT_PROP(maxDeltaX);
     APPLY_FLOAT_PROP(maxDeltaY);
 
@@ -178,7 +181,7 @@
     if (prop != nil) {
         recognizer.maxDuration = [RCTConvert CGFloat:prop] / 1000.0;
     }
-    
+
     prop = config[@"maxDist"];
     if (prop != nil) {
         CGFloat dist = [RCTConvert CGFloat:prop];

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -13,6 +13,8 @@
 #import <React/RCTConvert.h>
 
 @interface RNBetterTapGestureRecognizer : UIPanGestureRecognizer
+// We decided to extend UIPanGestureRecognizer
+// in order to implement maxDeltas using translationInView
 
 @property (nonatomic) NSUInteger numberOfTaps;
 @property (nonatomic) NSTimeInterval maxDelay;

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -12,11 +12,12 @@
 
 #import <React/RCTConvert.h>
 
-@interface RNBetterTapGestureRecognizer : UIPanGestureRecognizer
 // RNBetterTapGestureRecognizer extends UIPanGestureRecognizer instead of UITapGestureRecognizer so that
 // translationInView can be used to make the recognizer respect max deltas constraint. Also parameters like
 // maxDelay and maxDuration are not configurable in UITapGestureRecognizer and therefore require custom
 // implementation.
+
+@interface RNBetterTapGestureRecognizer : UIPanGestureRecognizer
 
 @property (nonatomic) NSUInteger numberOfTaps;
 @property (nonatomic) NSTimeInterval maxDelay;

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -13,8 +13,10 @@
 #import <React/RCTConvert.h>
 
 @interface RNBetterTapGestureRecognizer : UIPanGestureRecognizer
-// We decided to extend UIPanGestureRecognizer
-// in order to implement maxDeltas using translationInView
+// RNBetterTapGestureRecognizer extends UIPanGestureRecognizer instead of UITapGestureRecognizer so that
+// translationInView can be used to make the recognizer respect max deltas constraint. Also parameters like
+// maxDelay and maxDuration are not configurable in UITapGestureRecognizer and therefore require custom
+// implementation.
 
 @property (nonatomic) NSUInteger numberOfTaps;
 @property (nonatomic) NSTimeInterval maxDelay;


### PR DESCRIPTION
## Motivation
https://github.com/brentvatne/bottom-sheet-gesture-handler-experiment
Got inspired by @brentvatne code and made it possibile to implement bottom sheet in a bit hacky way using very long TapHandler. The problem was to to trigger scrolling scrollview at the end of extending a main card and not to trigger it when card is not opened fully.
Also then it became extremely easy to resolve another issue: https://github.com/kmagiera/react-native-gesture-handler/issues/146

## Changes
Initially I was trying to made it possible to track route (and maxDeltas) using 'normal' TapGestureHandler. Then I decided to implement new `TapGestureHandler` as quite unobvious extension of `UIPanGestureRecognizer` which gives us many ways of parameterization.
However, I wasn't really into extending out `PanGestureHandler` which seems to be unnecessary.
It gives a possibility to fail gesture whet its position pass `maxDeltaY` and then it allows scroll gesture to be triggered then. If it won't fail, scroll won't be scrolled. 
