### PR TITLE
Match types with react-native-navigation library

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -352,9 +352,9 @@ export class FlatList extends React.Component<
 > {}
 
 export function gestureHandlerRootHOC(
-  Component: React.Component,
+  Component: React.ComponentType<any>,
   containerStyles?: StyleProp<ViewStyle>
-): React.Component;
+): React.ComponentType<any>;
 
 export interface SwipeableProperties {
   friction: number;


### PR DESCRIPTION
This fixes mismatch in types with [react-native-navigation](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native-navigation/index.d.ts#L10)

As you can see from the link right type is `React.ComponentType<any>` since `gestureHandlerRootHOC` is only meant to be used with `registerComponent` from `react-native-navigation` :)