### PR TITLE
Button border-related improvements

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -522,7 +522,6 @@ class RectButton extends React.Component {
   static defaultProps = {
     activeOpacity: 0.105,
     underlayColor: 'black',
-    overflow: 'hidden',
   };
 
   constructor(props) {
@@ -565,7 +564,6 @@ class BorderlessButton extends React.Component {
   static defaultProps = {
     activeOpacity: 0.3,
     borderless: true,
-    overlay: 'hidden',
   };
 
   constructor(props) {

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -450,6 +450,10 @@ class BaseButton extends React.Component {
     onActiveStateChange: PropTypes.func,
   };
 
+  static defaultProps = {
+    overflow: 'hidden',
+  };
+
   constructor(props) {
     super(props);
     this._lastActive = false;
@@ -518,6 +522,7 @@ class RectButton extends React.Component {
   static defaultProps = {
     activeOpacity: 0.105,
     underlayColor: 'black',
+    overflow: 'hidden',
   };
 
   constructor(props) {
@@ -560,6 +565,7 @@ class BorderlessButton extends React.Component {
   static defaultProps = {
     activeOpacity: 0.3,
     borderless: true,
+    overlay: 'hidden',
   };
 
   constructor(props) {

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -450,10 +450,6 @@ class BaseButton extends React.Component {
     onActiveStateChange: PropTypes.func,
   };
 
-  static defaultProps = {
-    overflow: 'hidden',
-  };
-
   constructor(props) {
     super(props);
     this._lastActive = false;
@@ -494,9 +490,12 @@ class BaseButton extends React.Component {
   };
 
   render() {
+    const { style, ...rest } = this.props;
+
     return (
       <RawButton
-        {...this.props}
+        style={[{ overflow: 'hidden' }, style]}
+        {...rest}
         onGestureEvent={this._onGestureEvent}
         onHandlerStateChange={this._onHandlerStateChange}
       />

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
@@ -3,9 +3,10 @@ package com.swmansion.gesturehandler.react;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
+import android.graphics.drawable.PaintDrawable;
+import android.graphics.drawable.RippleDrawable;
 import android.os.Build;
 import android.util.TypedValue;
 import android.view.MotionEvent;
@@ -13,6 +14,7 @@ import android.view.ViewGroup;
 
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 
 public class RNGestureHandlerButtonViewManager extends
@@ -26,6 +28,7 @@ public class RNGestureHandlerButtonViewManager extends
     int mBackgroundColor = Color.TRANSPARENT;
     boolean mUseForeground = false;
     boolean mUseBorderless = false;
+    float mBorderRadius = 0;
     boolean mNeedBackgroundUpdate = false;
 
 
@@ -42,6 +45,10 @@ public class RNGestureHandlerButtonViewManager extends
     public void setBackgroundColor(int color) {
       mBackgroundColor = color;
       mNeedBackgroundUpdate = true;
+    }
+
+    public void setBorderRadius(float borderRadius) {
+      mBorderRadius = borderRadius;
     }
 
     @Override
@@ -79,9 +86,24 @@ public class RNGestureHandlerButtonViewManager extends
       } else if (mBackgroundColor == Color.TRANSPARENT) {
         setBackground(createSelectableDrawable());
       } else {
-        ColorDrawable colorDrawable = new ColorDrawable(mBackgroundColor);
+        PaintDrawable colorDrawable = new PaintDrawable(mBackgroundColor);
+        Drawable selectable = createSelectableDrawable();
+        // Radius-connected lines below ought to be considered
+        // as a temporary solution. It do not allow to set
+        // different radius on each corner. However, I suppose it's fairly
+        // fine for button-related use cases.
+        // Therefore it might be used as long as:
+        // 1. ReactViewManager is not a generic class with a possibility to handle another ViewGroup
+        // 2. There's no way to force native behavior of ReactViewGroup's superclass's onTouchEvent
+        colorDrawable.setCornerRadius(mBorderRadius);
+        if (selectable instanceof RippleDrawable
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+          PaintDrawable mask = new PaintDrawable(Color.WHITE);
+          mask.setCornerRadius(mBorderRadius);
+          ((RippleDrawable) selectable).setDrawableByLayerId(android.R.id.mask, mask);
+        }
         LayerDrawable layerDrawable = new LayerDrawable(
-                new Drawable[] { colorDrawable, createSelectableDrawable() });
+                new Drawable[] { colorDrawable, selectable});
         setBackground(layerDrawable);
       }
     }
@@ -166,6 +188,11 @@ public class RNGestureHandlerButtonViewManager extends
   @ReactProp(name = "enabled")
   public void setEnabled(ButtonViewGroup view, boolean enabled) {
     view.setEnabled(enabled);
+  }
+
+  @ReactProp(name = ViewProps.BORDER_RADIUS)
+  public void setBorderRadius(ButtonViewGroup view, float borderRadius) {
+    view.setBorderRadius(borderRadius);
   }
 
   @Override

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
@@ -49,6 +49,7 @@ public class RNGestureHandlerButtonViewManager extends
 
     public void setBorderRadius(float borderRadius) {
       mBorderRadius = borderRadius;
+      mNeedBackgroundUpdate = true;
     }
 
     @Override
@@ -88,19 +89,21 @@ public class RNGestureHandlerButtonViewManager extends
       } else {
         PaintDrawable colorDrawable = new PaintDrawable(mBackgroundColor);
         Drawable selectable = createSelectableDrawable();
-        // Radius-connected lines below ought to be considered
-        // as a temporary solution. It do not allow to set
-        // different radius on each corner. However, I suppose it's fairly
-        // fine for button-related use cases.
-        // Therefore it might be used as long as:
-        // 1. ReactViewManager is not a generic class with a possibility to handle another ViewGroup
-        // 2. There's no way to force native behavior of ReactViewGroup's superclass's onTouchEvent
-        colorDrawable.setCornerRadius(mBorderRadius);
-        if (selectable instanceof RippleDrawable
-                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-          PaintDrawable mask = new PaintDrawable(Color.WHITE);
-          mask.setCornerRadius(mBorderRadius);
-          ((RippleDrawable) selectable).setDrawableByLayerId(android.R.id.mask, mask);
+        if (mBorderRadius != 0) {
+          // Radius-connected lines below ought to be considered
+          // as a temporary solution. It do not allow to set
+          // different radius on each corner. However, I suppose it's fairly
+          // fine for button-related use cases.
+          // Therefore it might be used as long as:
+          // 1. ReactViewManager is not a generic class with a possibility to handle another ViewGroup
+          // 2. There's no way to force native behavior of ReactViewGroup's superclass's onTouchEvent
+          colorDrawable.setCornerRadius(mBorderRadius);
+          if (selectable instanceof RippleDrawable
+                  && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            PaintDrawable mask = new PaintDrawable(Color.WHITE);
+            mask.setCornerRadius(mBorderRadius);
+            ((RippleDrawable) selectable).setDrawableByLayerId(android.R.id.mask, mask);
+          }
         }
         LayerDrawable layerDrawable = new LayerDrawable(
                 new Drawable[] { colorDrawable, selectable});

--- a/ios/RNGestureHandlerButton.m
+++ b/ios/RNGestureHandlerButton.m
@@ -45,5 +45,11 @@
     return inner;
 }
 
+- (void)layoutSubviews
+{
+    self.clipsToBounds = YES;
+    [super layoutSubviews];
+}
+
 @end
 

--- a/ios/RNGestureHandlerButton.m
+++ b/ios/RNGestureHandlerButton.m
@@ -45,11 +45,11 @@
     return inner;
 }
 
-- (void)layoutSubviews
+- (instancetype)init
 {
+    self = [super init];
     self.clipsToBounds = YES;
-    [super layoutSubviews];
+    return self;
 }
-
 @end
 

--- a/ios/RNGestureHandlerButton.m
+++ b/ios/RNGestureHandlerButton.m
@@ -45,11 +45,5 @@
     return inner;
 }
 
-- (instancetype)init
-{
-    self = [super init];
-    self.clipsToBounds = YES;
-    return self;
-}
 @end
 


### PR DESCRIPTION
## Motivation
This PR is my answer to https://github.com/kmagiera/react-native-gesture-handler/issues/59
This solution is not a perfect one what was explained in the code. However, it seems to be fairly fine in most use cases
## Changes
Changes in button-related files on both iOS and Android side. 
iOS fix is only changing one flag in order to force bounding highlight layer
Android is more complex and involved adding extra layer. I didn't wish just to copy code from RN core and I suppose it calls for some changes in RN code. 
 