### PR TITLE
Create tag 

### DIFF
--- a/Example/draggable/index.js
+++ b/Example/draggable/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Animated, StyleSheet, View } from 'react-native';
 
 import {
+  createTag,
   PanGestureHandler,
   ScrollView,
   State,
@@ -11,6 +12,7 @@ import { USE_NATIVE_DRIVER } from '../config';
 import { LoremIpsum } from '../common';
 
 export class DraggableBox extends Component {
+  dragbox = createTag();
   constructor(props) {
     super(props);
     this._translateX = new Animated.Value(0);
@@ -44,7 +46,7 @@ export class DraggableBox extends Component {
         {...this.props}
         onGestureEvent={this._onGestureEvent}
         onHandlerStateChange={this._onHandlerStateChange}
-        id="dragbox">
+        id={this.dragbox}>
         <Animated.View
           style={[
             styles.box,

--- a/Example/multitap/index.js
+++ b/Example/multitap/index.js
@@ -6,6 +6,7 @@ import {
   ScrollView,
   State,
   TapGestureHandler,
+  createTag,
 } from 'react-native-gesture-handler';
 
 import { LoremIpsum } from '../common';
@@ -23,19 +24,22 @@ export class PressBox extends Component {
   };
   _onDoubleTap = event => {
     if (event.nativeEvent.state === State.ACTIVE) {
-      Alert.alert('D0able tap, good job!');
+      Alert.alert('Dable tap, good job!');
     }
   };
   render() {
+    const doubleTap = createTag();
     return (
       <LongPressGestureHandler
         onHandlerStateChange={this._onHandlerStateChange}
         minDurationMs={800}>
         <TapGestureHandler
           onHandlerStateChange={this._onSingleTap}
-          waitFor="double_tap">
+          waitFor={doubleTap}>
           <TapGestureHandler
-            id="double_tap"
+            maxDurationMs={1000}
+            minPointers={2}
+            id={doubleTap}
             onHandlerStateChange={this._onDoubleTap}
             numberOfTaps={2}>
             <View style={styles.box} />

--- a/Example/multitap/index.js
+++ b/Example/multitap/index.js
@@ -24,7 +24,7 @@ export class PressBox extends Component {
   };
   _onDoubleTap = event => {
     if (event.nativeEvent.state === State.ACTIVE) {
-      Alert.alert('Dable tap, good job!');
+      Alert.alert('D0able tap, good job!');
     }
   };
   render() {

--- a/Example/panAndScroll/index.js
+++ b/Example/panAndScroll/index.js
@@ -5,6 +5,7 @@ import {
   TapGestureHandler,
   ScrollView,
   State,
+  createTag,
 } from 'react-native-gesture-handler';
 
 import { USE_NATIVE_DRIVER } from '../config';
@@ -41,14 +42,15 @@ export class TapOrPan extends Component {
   };
 
   render() {
+    const { tapTag, panTag } = this.props;
     return (
       <TapGestureHandler
-        id="tap"
-        waitFor="pan"
+        id={tapTag}
+        waitFor={panTag}
         onHandlerStateChange={this._onTapHandlerStateChange}
         shouldCancelWhenOutside>
         <PanGestureHandler
-          id="pan"
+          id={panTag}
           minDeltaX={20}
           onGestureEvent={this._onPanGestureEvent}
           shouldCancelWhenOutside>
@@ -73,11 +75,13 @@ export class TapOrPan extends Component {
 }
 
 export default class Example extends Component {
+  tapTag = createTag();
+  panTag = createTag();
   render() {
     return (
-      <ScrollView waitFor={['tap', 'pan']}>
+      <ScrollView waitFor={[this.tapTag, this.panTag]}>
         <LoremIpsum words={150} />
-        <TapOrPan />
+        <TapOrPan tapTag={this.tapTag} panTag={this.panTag} />
         <LoremIpsum words={150} />
       </ScrollView>
     );

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -58,11 +58,13 @@ let handlerTag = 1;
 const handlerIDToTag = {};
 
 const GestureHandlerPropTypes = {
-  id: PropTypes.string,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   enabled: PropTypes.bool,
   waitFor: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string),
+    PropTypes.number,
+    PropTypes.arrayOf(PropTypes.number),
   ]),
   simultaneousHandlers: PropTypes.oneOfType([
     PropTypes.string,
@@ -113,7 +115,12 @@ function transformIntoHandlerTags(handlerIDs) {
   }
   // converts handler string IDs into their numeric tags
   return handlerIDs
-    .map(handlerID => handlerIDToTag[handlerID] || -1)
+    .map(
+      handlerID =>
+        typeof handlerID == 'number'
+          ? handlerID
+          : handlerIDToTag[handlerID] || -1
+    )
     .filter(handlerTag => handlerTag > 0);
 }
 
@@ -145,7 +152,11 @@ function createHandler(handlerName, propTypes = null, config = {}) {
 
     constructor(props) {
       super(props);
-      this._handlerTag = handlerTag++;
+      if (props.id && typeof props.id == 'number') {
+        this._handlerTag = props.id;
+      } else {
+        this._handlerTag = handlerTag++;
+      }
       this._config = {};
       if (props.id) {
         if (handlerIDToTag[props.id] !== undefined) {
@@ -598,6 +609,8 @@ const FlatListWithGHScroll = props => (
   />
 );
 
+const createTag = () => handlerTag++;
+
 export {
   WrappedScrollView as ScrollView,
   WrappedSlider as Slider,
@@ -626,4 +639,5 @@ export {
   Swipeable,
   DrawerLayout,
   Directions,
+  createTag,
 };

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -62,13 +62,17 @@ const GestureHandlerPropTypes = {
   enabled: PropTypes.bool,
   waitFor: PropTypes.oneOfType([
     PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
     PropTypes.number,
-    PropTypes.arrayOf(PropTypes.number),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    ),
   ]),
   simultaneousHandlers: PropTypes.oneOfType([
     PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.number,
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    ),
   ]),
   shouldCancelWhenOutside: PropTypes.bool,
   hitSlop: PropTypes.oneOfType([

--- a/README.md
+++ b/README.md
@@ -199,15 +199,17 @@ This type of button component should be used with simple icon-only or text-only 
 
 ## Controlling gesture handlers interactions
 
-Gesture handler library API allows for defining some basic interaction between handler components. Interactions can be defined by first setting a string identifer for a handler component with the `id` property and then referencing it with `waitFor` or `simultaneousHandlers` props in other handler component.
+Gesture handler library API allows for defining some basic interaction between handler components. Interactions can be defined by first setting a tag or string identifer for a handler component with the `id` property and then referencing it with `waitFor` or `simultaneousHandlers` props in other handler component.
+
+In order to generate unique tag of handler you have to use `ceateTag` method from our library
 
 #### `waitFor` property
 
-This property accepts one or more gesture handler IDs (either as a single string or an array of strings). If this property is set, the gesture handler will wait for the provided handlers to fail before it can activate.
+This property accepts one or more gesture handler IDs (either as a single string or tag or an array of strings or tags). If this property is set, the gesture handler will wait for the provided handlers to fail before it can activate.
 
 #### `simultaneousHandlers` property
 
-This property accepts one or more gesture handler IDs (either as a single string or an array of strings). Setting this property will make the gesture handler recognize a gesture simultaneously with handlers with provided IDs. Typical use case would be a map component, for which we want both pinch and rotate gestures to be recognized simultaneously.
+This property accepts one or more gesture handler IDs (either as a single string or tag or an array of strings or tags). Setting this property will make the gesture handler recognize a gesture simultaneously with handlers with provided IDs. Typical use case would be a map component, for which we want both pinch and rotate gestures to be recognized simultaneously.
 
 ## Custom components
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ This type of button component should be used with simple icon-only or text-only 
 
 Gesture handler library API allows for defining some basic interaction between handler components. Interactions can be defined by first setting a tag or string identifer for a handler component with the `id` property and then referencing it with `waitFor` or `simultaneousHandlers` props in other handler component.
 
-In order to generate unique tag of handler you have to use `ceateTag` method from our library
+In order to generate unique tag of handler you have to use `createTag` method from our library.
 
 #### `waitFor` property
 


### PR DESCRIPTION
## Motivation
Wish to make it unnecessary to use global unique string values to identify handler
## Changes
Added `createTag` method to provide unique ids and proper handlers or this ids as well as modify few examples to show how it works

Decided not not to use `React.createRef` as our library is quite deeply connected with react `ref` cycle and require using newest react version
