### PR TITLE
Enable custom styles for DrawerLayout child container

### DIFF
--- a/DrawerLayout.js
+++ b/DrawerLayout.js
@@ -44,6 +44,7 @@ export type PropType = {
   hideStatusBar?: boolean,
   statusBarAnimation?: 'slide' | 'none' | 'fade',
   overlayColor: string,
+  contentContainerStyle?: any,
 
   // Properties not yet supported
   // onDrawerSlide?: Function
@@ -182,13 +183,14 @@ export default class DrawerLayout extends Component<PropType, StateType> {
       translationX = Animated.add(dragX, dragOffsetFromOnStartPosition);
     }
 
-    this._openValue = Animated.add(translationX, drawerTranslation).interpolate(
-      {
-        inputRange: [0, drawerWidth],
-        outputRange: [0, 1],
-        extrapolate: 'clamp',
-      }
-    );
+    this._openValue = Animated.add(
+      translationX,
+      drawerTranslation
+    ).interpolate({
+      inputRange: [0, drawerWidth],
+      outputRange: [0, 1],
+      extrapolate: 'clamp',
+    });
 
     this._onGestureEvent = Animated.event(
       [{ nativeEvent: { translationX: dragXValue, x: touchXValue } }],
@@ -334,6 +336,7 @@ export default class DrawerLayout extends Component<PropType, StateType> {
       drawerWidth,
       drawerPosition,
       drawerType,
+      contentContainerStyle,
     } = this.props;
 
     const fromLeft = drawerPosition === 'left';
@@ -381,6 +384,7 @@ export default class DrawerLayout extends Component<PropType, StateType> {
               ? styles.containerOnBack
               : styles.containerInFront,
             containerStyles,
+            contentContainerStyle,
           ]}>
           {this.props.children}
           {this._renderOverlay()}

--- a/Example/horizontalDrawer/index.js
+++ b/Example/horizontalDrawer/index.js
@@ -1,5 +1,12 @@
 import React, { Component } from 'react';
-import { StyleSheet, Text, Animated, View, TextInput } from 'react-native';
+import {
+  Platform,
+  StyleSheet,
+  Text,
+  Animated,
+  View,
+  TextInput,
+} from 'react-native';
 
 import { RectButton } from 'react-native-gesture-handler';
 
@@ -8,7 +15,14 @@ import DrawerLayout from 'react-native-gesture-handler/DrawerLayout';
 const TYPES = ['front', 'back', 'back', 'slide'];
 const PARALLAX = [false, false, true, false];
 
-const Page = ({ fromLeft, type, parallaxOn, flipSide, nextType }) => (
+const Page = ({
+  fromLeft,
+  type,
+  parallaxOn,
+  flipSide,
+  nextType,
+  openDrawer,
+}) => (
   <View style={styles.page}>
     <Text style={styles.pageText}>Hi 👋</Text>
     <RectButton style={styles.rectButton} onPress={flipSide}>
@@ -21,6 +35,9 @@ const Page = ({ fromLeft, type, parallaxOn, flipSide, nextType }) => (
         Type '{type}
         {parallaxOn && ' with parallax'}'! -> Next
       </Text>
+    </RectButton>
+    <RectButton style={styles.rectButton} onPress={openDrawer}>
+      <Text style={styles.rectButtonText}>Open drawer</Text>
     </RectButton>
     <TextInput
       style={styles.pageInput}
@@ -64,6 +81,9 @@ export default class Example extends Component {
     return (
       <View style={styles.container}>
         <DrawerLayout
+          ref={drawer => {
+            this.drawer = drawer;
+          }}
           drawerWidth={200}
           keyboardDismissMode="on-drag"
           drawerPosition={
@@ -71,10 +91,30 @@ export default class Example extends Component {
               ? DrawerLayout.positions.Left
               : DrawerLayout.positions.Right
           }
-          drawerType={TYPES[this.state.type]}
+          drawerType={drawerType}
           drawerBackgroundColor="#ddd"
+          overlayColor={drawerType === 'front' ? 'black' : '#00000000'}
           renderNavigationView={
             parallax ? this.renderParallaxDrawer : this.renderDrawer
+          }
+          contentContainerStyle={
+            // careful; don't elevate the child container
+            // over top of the drawer when the drawer is supposed
+            // to be in front - you won't be able to see/open it.
+            drawerType === 'front'
+              ? {}
+              : Platform.select({
+                  ios: {
+                    shadowColor: '#000',
+                    shadowOpacity: 0.5,
+                    shadowOffset: { width: 0, height: 2 },
+                    shadowRadius: 60,
+                  },
+                  android: {
+                    elevation: 100,
+                    backgroundColor: '#000',
+                  },
+                })
           }>
           <Page
             type={drawerType}
@@ -83,6 +123,7 @@ export default class Example extends Component {
             flipSide={() => this.setState({ fromLeft: !this.state.fromLeft })}
             nextType={() =>
               this.setState({ type: (this.state.type + 1) % TYPES.length })}
+            openDrawer={() => this.drawer.openDrawer()}
           />
         </DrawerLayout>
       </View>

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ On top of the standard list of parameters DrawerLayout has an additional set of 
  - `statusBarAnimation` – possible values are: `slide`, `none` or `fade` (defaults to `slide`). Can be used when `hideStatusBar` is set to `true` and will select the animation used for hiding/showing the status bar. See [StatusBar](http://facebook.github.io/react-native/docs/statusbar.html#statusbaranimation) documentation for more details.
  - `overlayColor` – color (default to `"black"`) of a semi-transparent overlay to be displayed on top of the content view when drawer gets open. A solid color should be used as the opacity is added by the Drawer itself and the opacity of the overlay is animated (from 0% to 70%).
  - `renderNavigationView` - function. This attibute is present in the standard implementation already and is one of the required params. Gesture handler version of DrawerLayout make it possible for the function passed as `renderNavigationView` to take an Animated value as a parameter that indicates the progress of drawer opening/closing animation (progress value is 0 when closed and 1 when opened). This can be used by the drawer component to animated its children while the drawer is opening or closing.
+ - `contentContainerStyle` - object. If specified, this allows you to apply styles to the wrapper `Animated.View` that `DrawerLayout` renders around its children. This is helpful e.g. if you want to add a drop shadow (since, if you apply it to the child view, the wrapper view may clip it).
 
 #### Example:
 


### PR DESCRIPTION
As discussed in [this Stack Overflow question](https://stackoverflow.com/questions/50136741/react-native-drawerlayout-shadow-on-child-appears-on-ios-but-not-on-android), I have a need to style the wrapper component that `DrawerLayout` renders around my child component, and I could not achieve the effect I wanted by simply styling my child component, since the parent `View` was clipping the shadow on Android.

This PR enables setting custom styles on that component. (I noticed that there might be a similar need for the custom styling on the wrapper of the drawer itself, but I don't have that need currently. I'm happy to look into it in this PR if you agree that it's valuable, or we can punt it.)