### PR TITLE
Fix oneOfType usages

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -64,12 +64,12 @@ const GestureHandlerPropTypes = {
   waitFor: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,
-    PropTypes.arrayOf(PropTypes.oneOfType(PropTypes.string, PropTypes.object)),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.object])),
   ]),
   simultaneousHandlers: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,
-    PropTypes.arrayOf(PropTypes.oneOfType(PropTypes.string, PropTypes.object)),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.object])),
   ]),
   shouldCancelWhenOutside: PropTypes.bool,
   hitSlop: PropTypes.oneOfType([


### PR DESCRIPTION
Seeing some warnings due to these, I believe the parameter needs to be an array.