### PR TITLE
Fix RNGestureHandler.podspec

### DIFF
--- a/ios/RNGestureHandler.podspec
+++ b/ios/RNGestureHandler.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.author       = { package["author"]["name"] => package["author"]["email"] }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNGestureHandler.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/kmagiera/react-native-gesture-handler", :tag => "#{s.version}" }
   s.source_files = "**/*.{h,m}"
 
   s.dependency "React"


### PR DESCRIPTION
Corrected the git URL that was pointing to a non-existing repo (and that stopped Cocoapods from installing the dependency)