### PR TITLE
Add setImmediate to handler's componentDidUpdate

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -239,25 +239,30 @@ function createHandler(handlerName, propTypes = null, config = {}) {
       });
     }
 
-    componentDidUpdate(prevProps, prevState) {
-      const viewTag = findNodeHandle(this._viewNode);
-      if (this._viewTag !== viewTag) {
-        this._viewTag = viewTag;
-        RNGestureHandlerModule.attachGestureHandler(this._handlerTag, viewTag);
-      }
+    componentDidUpdate() {
+      setImmediate(() => {
+        const viewTag = findNodeHandle(this._viewNode);
+        if (this._viewTag !== viewTag) {
+          this._viewTag = viewTag;
+          RNGestureHandlerModule.attachGestureHandler(
+            this._handlerTag,
+            viewTag
+          );
+        }
 
-      const newConfig = filterConfig(
-        this.props,
-        this.constructor.propTypes,
-        config
-      );
-      if (!deepEqual(this._config, newConfig)) {
-        this._config = newConfig;
-        RNGestureHandlerModule.updateGestureHandler(
-          this._handlerTag,
-          this._config
+        const newConfig = filterConfig(
+          this.props,
+          this.constructor.propTypes,
+          config
         );
-      }
+        if (!deepEqual(this._config, newConfig)) {
+          this._config = newConfig;
+          RNGestureHandlerModule.updateGestureHandler(
+            this._handlerTag,
+            this._config
+          );
+        }
+      });
     }
 
     render() {


### PR DESCRIPTION
## Motivation
https://github.com/kmagiera/react-native-gesture-handler/issues/182#issuecomment-390638025
Issue was deeply inspected here and 
## Changes
In order to handle proper lifecycle of adding tag of handling decided to add `setImmediate` to CDU.

This PR it connected with https://github.com/kmagiera/react-native-gesture-handler/pull/157