### PR TITLE
Fix lifecycle of handler 

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -229,40 +229,44 @@ function createHandler(handlerName, propTypes = null, config = {}) {
           this.constructor.propTypes,
           config
         );
-        RNGestureHandlerModule.createGestureHandler(
-          handlerName,
-          this._handlerTag,
-          this._config
-        );
-        RNGestureHandlerModule.attachGestureHandler(
-          this._handlerTag,
-          this._viewTag
-        );
+        if (this._viewTag && this._handlerTag) {
+          RNGestureHandlerModule.createGestureHandler(
+            handlerName,
+            this._handlerTag,
+            this._config
+          );
+          RNGestureHandlerModule.attachGestureHandler(
+            this._handlerTag,
+            this._viewTag
+          );
+        }
       });
     }
 
     componentDidUpdate() {
       setImmediate(() => {
-        const viewTag = findNodeHandle(this._viewNode);
-        if (this._viewTag !== viewTag) {
-          this._viewTag = viewTag;
-          RNGestureHandlerModule.attachGestureHandler(
-            this._handlerTag,
-            viewTag
-          );
-        }
+        if (this._handlerTag) {
+          const viewTag = findNodeHandle(this._viewNode);
+          if (this._viewTag !== viewTag) {
+            this._viewTag = viewTag;
+            RNGestureHandlerModule.attachGestureHandler(
+              this._handlerTag,
+              viewTag
+            );
+          }
 
-        const newConfig = filterConfig(
-          this.props,
-          this.constructor.propTypes,
-          config
-        );
-        if (!deepEqual(this._config, newConfig)) {
-          this._config = newConfig;
-          RNGestureHandlerModule.updateGestureHandler(
-            this._handlerTag,
-            this._config
+          const newConfig = filterConfig(
+            this.props,
+            this.constructor.propTypes,
+            config
           );
+          if (!deepEqual(this._config, newConfig)) {
+            this._config = newConfig;
+            RNGestureHandlerModule.updateGestureHandler(
+              this._handlerTag,
+              this._config
+            );
+          }
         }
       });
     }


### PR DESCRIPTION
## Motivation
This issue refers to https://github.com/kmagiera/react-native-gesture-handler/issues/194

If given operation will be trigger immediately, cause crash of the app:

- constructor
- componentDidMount (set setImmediate)
- componentWillUnmount
- unmount
- setImmediate from CDU
The last operation wants to mount its handler and pass (`this._handlerTag` gives `null`) its handler's tag, which does not exists

## Changes
Add queuing of whole handler-related "dangerous methods"