### PR TITLE
Fix handler lifecycle

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -218,8 +218,8 @@ function createHandler(handlerName, propTypes = null, config = {}) {
     }
 
     componentDidMount() {
-      this._viewTag = findNodeHandle(this._viewNode);
-      const viewTag = this._viewTag;
+      const viewTag = findNodeHandle(this._viewNode);
+      this._viewTag = viewTag;
       // Calling createGestureHandler from setImmediate guarantees that
       // all the other components are mounted which is necessary for
       // the refs to be set. If we were to call it directly here then if

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -229,40 +229,44 @@ function createHandler(handlerName, propTypes = null, config = {}) {
           this.constructor.propTypes,
           config
         );
-        RNGestureHandlerModule.createGestureHandler(
-          handlerName,
-          this._handlerTag,
-          this._config
-        );
-        RNGestureHandlerModule.attachGestureHandler(
-          this._handlerTag,
-          this._viewTag
-        );
+        if (this._viewTag && this._handlerTag) {
+          RNGestureHandlerModule.createGestureHandler(
+            handlerName,
+            this._handlerTag,
+            this._config
+          );
+          RNGestureHandlerModule.attachGestureHandler(
+            this._handlerTag,
+            this._viewTag
+          );
+        }
       });
     }
 
     componentDidUpdate() {
       setImmediate(() => {
-        const viewTag = findNodeHandle(this._viewNode);
-        if (this._viewTag !== viewTag) {
-          this._viewTag = viewTag;
-          RNGestureHandlerModule.attachGestureHandler(
-            this._handlerTag,
-            viewTag
-          );
-        }
+        if (this._handlerTag) {
+          const viewTag = findNodeHandle(this._viewNode);
+          if (this._viewTag !== viewTag) {
+            this._viewTag = viewTag;
+            RNGestureHandlerModule.attachGestureHandler(
+              this._handlerTag,
+              viewTag
+            );
+          }
 
-        const newConfig = filterConfig(
-          this.props,
-          this.constructor.propTypes,
-          config
-        );
-        if (!deepEqual(this._config, newConfig)) {
-          this._config = newConfig;
-          RNGestureHandlerModule.updateGestureHandler(
-            this._handlerTag,
-            this._config
+          const newConfig = filterConfig(
+            this.props,
+            this.constructor.propTypes,
+            config
           );
+          if (!deepEqual(this._config, newConfig)) {
+            this._config = newConfig;
+            RNGestureHandlerModule.updateGestureHandler(
+              this._handlerTag,
+              this._config
+            );
+          }
         }
       });
     }

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -28,23 +28,6 @@ import DrawerLayout from './DrawerLayout';
 
 const RNGestureHandlerModule = NativeModules.RNGestureHandlerModule;
 
-// Calling these native methoods from setImmediate guarantees that
-// all the other components are mounted which is necessary for
-// the refs to be set. If we were to call it directly here then if
-// the parent component ref is passed in `waitFor` or `simultaniousHandlers`
-// property it's `.current` element would be `null` because it has not
-const NATIVE_METHODS_TO_BE_DELAYED_WHITE_LIST = [
-  'attachGestureHandler',
-  'createGestureHandler',
-  'dropGestureHandler',
-];
-for (let method in NATIVE_METHODS_TO_BE_DELAYED_WHITE_LIST) {
-  const oldMethod = RNGestureHandlerModule[method];
-  RNGestureHandlerModule[method] = function(...args) {
-    setImmediate(() => oldMethod(...args));
-  };
-}
-
 /* Wrap JS responder calls and notify gesture handler manager */
 const { UIManager } = NativeModules;
 const {
@@ -226,49 +209,61 @@ function createHandler(handlerName, propTypes = null, config = {}) {
     };
 
     componentWillUnmount() {
-      RNGestureHandlerModule.dropGestureHandler(this._handlerTag);
-      if (this.props.id) {
-        delete handlerIDToTag[this.props.id];
-      }
+      setImmediate(() => {
+        RNGestureHandlerModule.dropGestureHandler(this._handlerTag);
+        if (this.props.id) {
+          delete handlerIDToTag[this.props.id];
+        }
+      });
     }
 
     componentDidMount() {
       this._viewTag = findNodeHandle(this._viewNode);
-      this._config = filterConfig(
-        this.props,
-        this.constructor.propTypes,
-        config
-      );
-      RNGestureHandlerModule.createGestureHandler(
-        handlerName,
-        this._handlerTag,
-        this._config
-      );
-      RNGestureHandlerModule.attachGestureHandler(
-        this._handlerTag,
-        this._viewTag
-      );
+      const viewTag = this._viewTag;
+      // Calling createGestureHandler from setImmediate guarantees that
+      // all the other components are mounted which is necessary for
+      // the refs to be set. If we were to call it directly here then if
+      // the parent component ref is passed in `waitFor` or `simultaniousHandlers`
+      // property it's `.current` element would be `null` because it has not
+      // yet been mounted.
+      setImmediate(() => {
+        this._config = filterConfig(
+          this.props,
+          this.constructor.propTypes,
+          config
+        );
+        RNGestureHandlerModule.createGestureHandler(
+          handlerName,
+          this._handlerTag,
+          this._config
+        );
+        RNGestureHandlerModule.attachGestureHandler(this._handlerTag, viewTag);
+      });
     }
 
     componentDidUpdate() {
       const viewTag = findNodeHandle(this._viewNode);
-      if (this._viewTag !== viewTag) {
-        this._viewTag = viewTag;
-        RNGestureHandlerModule.attachGestureHandler(this._handlerTag, viewTag);
-      }
-
-      const newConfig = filterConfig(
-        this.props,
-        this.constructor.propTypes,
-        config
-      );
-      if (!deepEqual(this._config, newConfig)) {
-        this._config = newConfig;
-        RNGestureHandlerModule.updateGestureHandler(
-          this._handlerTag,
-          this._config
+      setImmediate(() => {
+        if (this._viewTag !== viewTag) {
+          this._viewTag = viewTag;
+          RNGestureHandlerModule.attachGestureHandler(
+            this._handlerTag,
+            viewTag
+          );
+        }
+        const newConfig = filterConfig(
+          this.props,
+          this.constructor.propTypes,
+          config
         );
-      }
+        if (!deepEqual(this._config, newConfig)) {
+          this._config = newConfig;
+          RNGestureHandlerModule.updateGestureHandler(
+            this._handlerTag,
+            this._config
+          );
+        }
+      });
     }
 
     render() {

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -28,6 +28,11 @@ import DrawerLayout from './DrawerLayout';
 
 const RNGestureHandlerModule = NativeModules.RNGestureHandlerModule;
 
+// Calling these native methoods from setImmediate guarantees that
+// all the other components are mounted which is necessary for
+// the refs to be set. If we were to call it directly here then if
+// the parent component ref is passed in `waitFor` or `simultaniousHandlers`
+// property it's `.current` element would be `null` because it has not
 const NATIVE_METHODS_TO_BE_DELAYED_WHITE_LIST = [
   'attachGestureHandler',
   'createGestureHandler',


### PR DESCRIPTION
## Motivation
This issue refers to https://github.com/kmagiera/react-native-gesture-handler/issues/194

If given operation will be trigger immediately, cause crash of the app:

- constructor
- componentDidMount (set setImmediate)
- componentWillUnmount
- unmount
- setImmediate from CDU
The last operation wants to mount its handler and pass (`this._handlerTag` gives `null`) its handler's tag, which does not exists

## Changes
Add queuing of whole handler-related "dangerous methods"