### PR TITLE
Adapt to react-native's changes to ReactNativeBridgeEventPlugin

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -16,7 +16,6 @@ import {
   FlatList,
   Platform,
 } from 'react-native';
-import ReactNativeBridgeEventPlugin from 'react-native/Libraries/Renderer/shims/ReactNativeBridgeEventPlugin';
 import Touchable from 'react-native/Libraries/Components/Touchable/Touchable';
 
 import deepEqual from 'fbjs/lib/areEqual';
@@ -43,14 +42,14 @@ UIManager.clearJSResponder = () => {
   oldClearJSResponder();
 };
 
-ReactNativeBridgeEventPlugin.processEventTypes({
-  directEventTypes: {
-    topGestureHandlerEvent: { registrationName: 'onGestureHandlerEvent' },
-    topGestureHandlerStateChange: {
-      registrationName: 'onGestureHandlerStateChange',
-    },
+/* Overwrite UIManager.genericDirectEventTypes to include gesture handler specific events */
+UIManager.genericDirectEventTypes = {
+  ...UIManager.genericDirectEventTypes,
+  topGestureHandlerEvent: { registrationName: 'onGestureHandlerEvent' },
+  topGestureHandlerStateChange: {
+    registrationName: 'onGestureHandlerStateChange',
   },
-});
+};
 
 const State = RNGestureHandlerModule.State;
 

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -42,11 +42,13 @@ UIManager.clearJSResponder = () => {
   oldClearJSResponder();
 };
 
-/* Overwrite UIManager.genericDirectEventTypes to include gesture handler specific events */
-UIManager.genericDirectEventTypes = {
-  ...UIManager.genericDirectEventTypes,
-  topGestureHandlerEvent: { registrationName: 'onGestureHandlerEvent' },
-  topGestureHandlerStateChange: {
+// Add gesture spacific events to RCTView's directEventTypes object exported via UIManager.
+// Once new event types are registered with react it is possible to dispatch these to other
+// view types as well.
+UIManager.RCTView.directEventTypes = {
+  ...UIManager.RCTView.directEventTypes,
+  onGestureHandlerEvent: { registrationName: 'onGestureHandlerEvent' },
+  onGestureHandlerStateChange: {
     registrationName: 'onGestureHandlerStateChange',
   },
 };

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.java
@@ -12,8 +12,7 @@ import javax.annotation.Nullable;
 
 public class RNGestureHandlerEvent extends Event<RNGestureHandlerEvent> {
 
-  public static final String EVENT_NAME = "topGestureHandlerEvent";
-  public static final String REGISTRATION_NAME = "onGestureHandlerEvent";
+  public static final String EVENT_NAME = "onGestureHandlerEvent";
 
   private static final int TOUCH_EVENTS_POOL_SIZE = 7; // magic
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerPackage.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerPackage.java
@@ -17,45 +17,6 @@ import javax.annotation.Nullable;
 
 public class RNGestureHandlerPackage implements ReactPackage {
 
-  private static class DummyViewManager extends ViewGroupManager<RNGestureHandlerRootView> {
-    @Override
-    public String getName() {
-      return "GestureHandlerRootView";
-    }
-
-    @Override
-    protected RNGestureHandlerRootView createViewInstance(ThemedReactContext reactContext) {
-      return new RNGestureHandlerRootView(reactContext);
-    }
-
-    @Override
-    public void onDropViewInstance(RNGestureHandlerRootView view) {
-      view.tearDown();
-    }
-
-    /**
-     * The following event configuration is necessary even if you are not using
-     * GestureHandlerRootView component directly.
-     *
-     * This direct event configuration serves the purpose of translating event names from
-     * the names used in native code to "registration names" used in JS. This is necessary for the
-     * native Animated implementation that has to match events by their names on the native side
-     * given their "registration names" passed down from JS. For relevant code parts please refer to
-     * the following react-native core code parts:
-     *  - {@link UIManagerModule.CustomEventNamesResolver}
-     *  - {@link UIManagerModuleConstantsHelper#createConstantsForViewManager}
-     *  - {@link NativeAnimatedNodesManager#handleEvent}
-     */
-    @Override
-    public @Nullable Map getExportedCustomDirectEventTypeConstants() {
-      return MapBuilder.of(
-              RNGestureHandlerEvent.EVENT_NAME,
-              MapBuilder.of("registrationName", RNGestureHandlerEvent.REGISTRATION_NAME),
-              RNGestureHandlerStateChangeEvent.EVENT_NAME,
-              MapBuilder.of("registrationName", RNGestureHandlerStateChangeEvent.REGISTRATION_NAME));
-    }
-  }
-
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     return Arrays.<NativeModule>asList(new RNGestureHandlerModule(reactContext));
@@ -63,8 +24,6 @@ public class RNGestureHandlerPackage implements ReactPackage {
 
   @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-    return Arrays.<ViewManager>asList(
-            new RNGestureHandlerButtonViewManager(),
-            new DummyViewManager());
+    return Arrays.<ViewManager>asList(new RNGestureHandlerButtonViewManager());
   }
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.java
@@ -12,8 +12,7 @@ import javax.annotation.Nullable;
 
 public class RNGestureHandlerStateChangeEvent extends Event<RNGestureHandlerStateChangeEvent>{
 
-  public static final String EVENT_NAME = "topGestureHandlerStateChange";
-  public static final String REGISTRATION_NAME = "onGestureHandlerStateChange";
+  public static final String EVENT_NAME = "onGestureHandlerStateChange";
 
   private static final int TOUCH_EVENTS_POOL_SIZE = 7; // magic
 

--- a/ios/RNGestureHandlerEvents.m
+++ b/ios/RNGestureHandlerEvents.m
@@ -135,7 +135,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     [body setObject:_viewTag forKey:@"target"];
     [body setObject:_handlerTag forKey:@"handlerTag"];
     [body setObject:@(_state) forKey:@"state"];
-    return @[self.viewTag, @"topGestureHandlerEvent", body];
+    return @[self.viewTag, @"onGestureHandlerEvent", body];
 }
 
 @end
@@ -200,7 +200,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     [body setObject:_handlerTag forKey:@"handlerTag"];
     [body setObject:@(_state) forKey:@"state"];
     [body setObject:@(_prevState) forKey:@"oldState"];
-    return @[self.viewTag, @"topGestureHandlerStateChange", body];
+    return @[self.viewTag, @"onGestureHandlerStateChange", body];
 }
 
 @end


### PR DESCRIPTION
Fixes #191 

ReactNativeBridgeEventPlugin got removed here: https://github.com/facebook/react-native/commit/906dde06b3f25b4e87adcbc8ed64f72bc930ac6a

We used to rely on ReactNativeBridgeEventPlugin to register gesture specific event types. Without it, react will throw an error whenever gesture event gets dispatched as the even type would not be recognized by the react event system.

To fix that I had to find a way to inject event type configuration. The most robust solution I have found was to override event config of RCTView. A view that is a baseclass for all the other components in the system. Adding gesture handler event types to RCTView configuration guarantees that these will be properly registered in event registry before any event gets dispatched.

This change renders whole idea of "DummyViewManager" obsolete. The role of "DummyViewManager" was at first to export event type configuration to JS and let react consume that view configuration to register new event types. 
This changed when view manager lazy loading got introduced and the configuration wouldn't be parsed unless at least one instance of the "DummyView" got mounted.
To overcome this issue we started relying on ReactNativeBridgeEventPlugin to force register new event types. But we still needed dummy view manager on Android as it has been used by [CustomEventNamesResolver](https://github.com/facebook/react-native/blob/a83cddf037d1226ebe47c122460460546d459c53/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java#L104) to translate event registration name ("topGestureHandler" to "onGestureHandler").
The latter has been resolved by changing the registration and event name to be the same by ditching weird "topXXX" prefix. We now only use "onGestureHandler..." as a prefix for events which does no longer require us to have event configuration on the native side.
