### PR TITLE
Fix BorderlessButtonProperties

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -299,7 +299,7 @@ export interface RectButtonProperties extends BaseButtonProperties {
   underlayColor?: string;
 }
 
-export interface BorderlessButtonProperties extends RawButtonProperties {
+export interface BorderlessButtonProperties extends BaseButtonProperties {
   borderless?: boolean;
 }
 


### PR DESCRIPTION
## Description
Fixes `BorderlessButtonProperties` to extend from `BaseButtonProperties` instead of `RawButtonProperties`.
This allows `BorderlessButton` to use `BaseButton` props such as `onPress` and `style`