### PR TITLE
Enable PanHandler to began in "TouchedBegan" method if it's possible

### DIFF
--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -70,6 +70,9 @@
         super.minimumNumberOfTouches = _realMinimumNumberOfTouches;
     }
     [super touchesBegan:touches withEvent:event];
+    if ([self numberOfTouches] >= _realMinimumNumberOfTouches) {
+      self.state = UIGestureRecognizerStateBegan;
+    }
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
@@ -97,7 +100,6 @@
         super.minimumNumberOfTouches = _realMinimumNumberOfTouches;
         if ([self numberOfTouches] >= _realMinimumNumberOfTouches) {
             self.state = UIGestureRecognizerStateBegan;
-            [self setTranslation:CGPointMake(0, 0) inView:self.view];
         }
     }
 }


### PR DESCRIPTION
## Motivation
Issues has been described here: https://github.com/kmagiera/react-native-gesture-handler/issues/223

## Changes
Change some logic of states ion iOS in order to behave like on Android
Add possibility to set state to `BEGAN` in `touchesBegan` method under some conditions on iOS.
Remove `[self setTranslation:CGPointMake(0, 0) inView:self.view];` as it implements default behaviour which does not call for extra handling 