### PR TITLE
Fix border radius of buttons on Android

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
@@ -48,7 +48,7 @@ public class RNGestureHandlerButtonViewManager extends
     }
 
     public void setBorderRadius(float borderRadius) {
-      mBorderRadius = borderRadius;
+      mBorderRadius = borderRadius * (float)getResources().getDisplayMetrics().density;
       mNeedBackgroundUpdate = true;
     }
 


### PR DESCRIPTION
Apparently, `setCornerRadius` accepts pixels, but React provides `dp`s. Hence this conversion.

Fixes #226.