### PR TITLE
Issue #233 - Add touchesMoved invoke to touchesBegan in Tap

### DIFF
--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -12,6 +12,10 @@
 
 #import <React/RCTConvert.h>
 
+// RNBetterTapGestureRecognizer does not extend UITapGestureRecognizer so that as parameters like
+// maxDelay, maxDuration, minPointers, maxDelta are not configurable in UITapGestureRecognizer
+// and therefore require custom implementation.
+
 @interface RNBetterTapGestureRecognizer : UIGestureRecognizer
 
 @property (nonatomic) NSUInteger numberOfTaps;

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -12,12 +12,7 @@
 
 #import <React/RCTConvert.h>
 
-// RNBetterTapGestureRecognizer extends UIPanGestureRecognizer instead of UITapGestureRecognizer so that
-// translationInView can be used to make the recognizer respect max deltas constraint. Also parameters like
-// maxDelay and maxDuration are not configurable in UITapGestureRecognizer and therefore require custom
-// implementation.
-
-@interface RNBetterTapGestureRecognizer : UIPanGestureRecognizer
+@interface RNBetterTapGestureRecognizer : UIGestureRecognizer
 
 @property (nonatomic) NSUInteger numberOfTaps;
 @property (nonatomic) NSTimeInterval maxDelay;
@@ -25,97 +20,92 @@
 @property (nonatomic) CGFloat maxDistSq;
 @property (nonatomic) CGFloat maxDeltaX;
 @property (nonatomic) CGFloat maxDeltaY;
-
-@property (nonatomic) CGFloat currentNumberOfTaps;
-@property (nonatomic) CGPoint currentLocation;
-@property (nonatomic) CGPoint deltaLocation;
 @property (nonatomic) NSInteger minPointers;
-@property (nonatomic) NSInteger maxNumberOfTouches;
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
 
 @end
 
 @implementation RNBetterTapGestureRecognizer {
-  __weak RNGestureHandler *_gestureHandler;
-  NSUInteger _tapsSoFar;
+    __weak RNGestureHandler *_gestureHandler;
+    NSUInteger _tapsSoFar;
+    CGPoint _initPosition;
+    NSInteger _maxNumberOfTouches;
 }
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
 {
-  if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
-    _gestureHandler = gestureHandler;
-    _tapsSoFar = 0;
-    _numberOfTaps = 1;
-    _maxDelay = 0.2;
-    _minPointers = 1;
-    _maxDuration = NAN;
-    _maxDeltaX = NAN;
-    _maxDeltaY = NAN;
-    _maxDistSq = NAN;
-    _maxNumberOfTouches = 0;
-    super.minimumNumberOfTouches = 20;
-  }
-  return self;
+    if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
+        _gestureHandler = gestureHandler;
+        _tapsSoFar = 0;
+        _numberOfTaps = 1;
+        _minPointers = 1;
+        _maxDelay = 0.2;
+        _maxDuration = NAN;
+        _maxDeltaX = NAN;
+        _maxDeltaY = NAN;
+        _maxDistSq = NAN;
+    }
+    return self;
 }
 
 - (void)triggerAction
 {
-  [_gestureHandler handleGesture:self];
+    [_gestureHandler handleGesture:self];
 }
 
 - (void)cancel
 {
-  self.enabled = NO;
+    self.enabled = NO;
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-  _tapsSoFar++;
-  NSInteger numberOfTouches = [touches count];
-  if (numberOfTouches > _maxNumberOfTouches) {
-    _maxNumberOfTouches = numberOfTouches;
-  }
-  if (_tapsSoFar) {
-    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
-  }
-  if (!isnan(_maxDuration)) {
-    [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDuration];
-  }
-  
-  [super touchesBegan:touches withEvent:event];
-  
-  // workaround below refers to error with recognizing gesture if there was no move event
-  // between touching down and up. As in TapHandler it's not a special case (contrary to PanHandler)
-  // the first touch (down event) has to be handled in the same way as move
-  // in order to allow handle to change its state not only if there was some move event during recognizing
-  // Otherwise it implies in error with calculating position of tap as
-  // it was sum of each touches before in this case
-  [super touchesMoved:touches withEvent:event];
+    [super touchesBegan:touches withEvent:event];
+    if (_tapsSoFar == 0) {
+        _initPosition = [self locationInView:self.view];
+    }
+    _tapsSoFar++;
+    if (_tapsSoFar) {
+        [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
+    }
+    NSInteger numberOfTouches = [touches count];
+    if (numberOfTouches > _maxNumberOfTouches) {
+        _maxNumberOfTouches = numberOfTouches;
+    }
+    if (!isnan(_maxDuration)) {
+        [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDuration];
+    }
+    self.state = UIGestureRecognizerStatePossible;
+    [self triggerAction];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-  [super touchesMoved:touches withEvent:event];
-  NSInteger numberOfTouches = [touches count];
-  if (self.state != UIGestureRecognizerStatePossible) {
-    return;
-  }
-  
-  if (numberOfTouches > _maxNumberOfTouches) {
-    _maxNumberOfTouches = numberOfTouches;
-  }
-  
-  if ([self shouldFailUnderCustomCriteria]) {
-    self.state = UIGestureRecognizerStateFailed;
+    [super touchesMoved:touches withEvent:event];
+    NSInteger numberOfTouches = [touches count];
+    if (numberOfTouches > _maxNumberOfTouches) {
+        _maxNumberOfTouches = numberOfTouches;
+    }
+
+    if (self.state != UIGestureRecognizerStatePossible) {
+        return;
+    }
+    
+    if ([self shouldFailUnderCustomCriteria]) {
+        self.state = UIGestureRecognizerStateFailed;
+        [self triggerAction];
+        [self reset];
+        return;
+    }
+
+    self.state = UIGestureRecognizerStatePossible;
     [self triggerAction];
-    [self reset];
-    return;
-  }
-  
-  self.state = UIGestureRecognizerStatePossible;
-  [self triggerAction];
-  return;
+}
+
+- (CGPoint)translationInView:(UIView *)view {
+    CGPoint currentPosition = [self locationInView:self.view];
+    return CGPointMake(currentPosition.x - _initPosition.x, currentPosition.y - _initPosition.y);
 }
 
 - (BOOL)shouldFailUnderCustomCriteria
@@ -142,33 +132,32 @@
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-  if (_numberOfTaps == _tapsSoFar && _maxNumberOfTouches >= _minPointers) {
-    self.state = UIGestureRecognizerStateBegan;
     [super touchesEnded:touches withEvent:event];
-    self.state = UIGestureRecognizerStateEnded;
-    [self reset];
-  } else {
-    [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDelay];
-  }
+    if (_numberOfTaps == _tapsSoFar && _maxNumberOfTouches >= _minPointers) {
+        self.state = UIGestureRecognizerStateEnded;
+        [self reset];
+    } else {
+        [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDelay];
+    }
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-  [super touchesCancelled:touches withEvent:event];
-  self.state = UIGestureRecognizerStateCancelled;
-  [self reset];
+    [super touchesCancelled:touches withEvent:event];
+    self.state = UIGestureRecognizerStateCancelled;
+    [self reset];
 }
 
 - (void)reset
 {
-  if (self.state == UIGestureRecognizerStateFailed) {
-    [self triggerAction];
-  }
-  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
-  _tapsSoFar = 0;
-  _maxNumberOfTouches = 0;
-  self.enabled = YES;
-  [super reset];
+    if (self.state == UIGestureRecognizerStateFailed) {
+        [self triggerAction];
+    }
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
+    _tapsSoFar = 0;
+    _maxNumberOfTouches = 0;
+    self.enabled = YES;
+    [super reset];
 }
 
 @end
@@ -177,38 +166,37 @@
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
-  if ((self = [super initWithTag:tag])) {
-    _recognizer = [[RNBetterTapGestureRecognizer alloc] initWithGestureHandler:self];
-  }
-  return self;
+    if ((self = [super initWithTag:tag])) {
+        _recognizer = [[RNBetterTapGestureRecognizer alloc] initWithGestureHandler:self];
+    }
+    return self;
 }
 
 - (void)configure:(NSDictionary *)config
 {
-  [super configure:config];
-  RNBetterTapGestureRecognizer *recognizer = (RNBetterTapGestureRecognizer *)_recognizer;
+    [super configure:config];
+    RNBetterTapGestureRecognizer *recognizer = (RNBetterTapGestureRecognizer *)_recognizer;
+
+    APPLY_INT_PROP(numberOfTaps);
+    APPLY_INT_PROP(minPointers);
+    APPLY_FLOAT_PROP(maxDeltaX);
+    APPLY_FLOAT_PROP(maxDeltaY);
   
-  APPLY_INT_PROP(numberOfTaps);
-  APPLY_INT_PROP(minPointers);
-  APPLY_FLOAT_PROP(maxDeltaX);
-  APPLY_FLOAT_PROP(maxDeltaY);
+    id prop = config[@"maxDelayMs"];
+    if (prop != nil) {
+        recognizer.maxDelay = [RCTConvert CGFloat:prop] / 1000.0;
+    }
+
+    prop = config[@"maxDurationMs"];
+    if (prop != nil) {
+        recognizer.maxDuration = [RCTConvert CGFloat:prop] / 1000.0;
+    }
   
-  id prop = config[@"maxDelayMs"];
-  if (prop != nil) {
-    recognizer.maxDelay = [RCTConvert CGFloat:prop] / 1000.0;
-  }
-  
-  prop = config[@"maxDurationMs"];
-  if (prop != nil) {
-    recognizer.maxDuration = [RCTConvert CGFloat:prop] / 1000.0;
-  }
-  
-  prop = config[@"maxDist"];
-  if (prop != nil) {
-    CGFloat dist = [RCTConvert CGFloat:prop];
-    recognizer.maxDistSq = dist * dist;
-  }
-  
+    prop = config[@"maxDist"];
+    if (prop != nil) {
+        CGFloat dist = [RCTConvert CGFloat:prop];
+        recognizer.maxDistSq = dist * dist;
+    }
 }
 
 @end

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -84,12 +84,14 @@
   }
   
   [super touchesBegan:touches withEvent:event];
+  
   // workaround below refers to error with recognizing gesture if there was no move event
-  // beetween touching down and up. As in TapHandler it's not a special case (contrary to PanHandler)
+  // between touching down and up. As in TapHandler it's not a special case (contrary to PanHandler)
   // the first touch (down event) has to be handled in the same way as move
   // in order to allow handle to change its state not only if there was some move event during recognizing
+  // Otherwise it implies in error with calculating position of tap as
+  // it was sum of each touches before in this case
   [super touchesMoved:touches withEvent:event];
-    
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -107,7 +107,7 @@
     [self triggerAction];
 }
 
-- (CGPoint)translationInView:(UIView *)view {
+- (CGPoint)translationInView {
     CGPoint currentPosition = [self locationInView:self.view];
     return CGPointMake(currentPosition.x - _initPosition.x, currentPosition.y - _initPosition.y);
 }
@@ -121,7 +121,7 @@
     }
   }
   
-  CGPoint trans = [self translationInView:self.view];
+  CGPoint trans = [self translationInView];
   if (TEST_MAX_IF_NOT_NAN(fabs(trans.x), _maxDeltaX)) {
     return YES;
   }

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -37,131 +37,136 @@
 @end
 
 @implementation RNBetterTapGestureRecognizer {
-    __weak RNGestureHandler *_gestureHandler;
-    NSUInteger _tapsSoFar;
+  __weak RNGestureHandler *_gestureHandler;
+  NSUInteger _tapsSoFar;
 }
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
 {
-    if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
-        _gestureHandler = gestureHandler;
-        _tapsSoFar = 0;
-        _numberOfTaps = 1;
-        _maxDelay = 0.2;
-        _minPointers = 1;
-        _maxDuration = NAN;
-        _maxDeltaX = NAN;
-        _maxDeltaY = NAN;
-        _maxDistSq = NAN;
-        _maxNumberOfTouches = 0;
-        super.minimumNumberOfTouches = 20;
-    }
-    return self;
+  if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
+    _gestureHandler = gestureHandler;
+    _tapsSoFar = 0;
+    _numberOfTaps = 1;
+    _maxDelay = 0.2;
+    _minPointers = 1;
+    _maxDuration = NAN;
+    _maxDeltaX = NAN;
+    _maxDeltaY = NAN;
+    _maxDistSq = NAN;
+    _maxNumberOfTouches = 0;
+    super.minimumNumberOfTouches = 20;
+  }
+  return self;
 }
 
 - (void)triggerAction
 {
-    [_gestureHandler handleGesture:self];
+  [_gestureHandler handleGesture:self];
 }
 
 - (void)cancel
 {
-    self.enabled = NO;
+  self.enabled = NO;
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    _tapsSoFar++;
-    NSInteger numberOfTouches = [touches count];
-    if (numberOfTouches > _maxNumberOfTouches) {
-        _maxNumberOfTouches = numberOfTouches;
-    }
-    if (_tapsSoFar) {
-        [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
-    }
-    if (!isnan(_maxDuration)) {
-        [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDuration];
-    }
-
-    [super touchesBegan:touches withEvent:event];
+  _tapsSoFar++;
+  NSInteger numberOfTouches = [touches count];
+  if (numberOfTouches > _maxNumberOfTouches) {
+    _maxNumberOfTouches = numberOfTouches;
+  }
+  if (_tapsSoFar) {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
+  }
+  if (!isnan(_maxDuration)) {
+    [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDuration];
+  }
+  
+  [super touchesBegan:touches withEvent:event];
+  // workaround below refers to error with recognizing gesture if there was no move event
+  // beetween touching down and up. As in TapHandler it's not a special case (contrary to PanHandler)
+  // the first touch (down event) has to be handled in the same way as move
+  // in order to allow handle to change its state not only if there was some move event during recognizing
+  [super touchesMoved:touches withEvent:event];
+    
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [super touchesMoved:touches withEvent:event];
-    NSInteger numberOfTouches = [touches count];
-    if (self.state != UIGestureRecognizerStatePossible) {
-        return;
-    }
-    
-    if (numberOfTouches > _maxNumberOfTouches) {
-        _maxNumberOfTouches = numberOfTouches;
-    }
-
-    
-    if ([self shouldFailUnderCustomCriteria]) {
-        self.state = UIGestureRecognizerStateFailed;
-        [self triggerAction];
-        [self reset];
-        return;
-    }
-
-    self.state = UIGestureRecognizerStatePossible;
-    [self triggerAction];
+  [super touchesMoved:touches withEvent:event];
+  NSInteger numberOfTouches = [touches count];
+  if (self.state != UIGestureRecognizerStatePossible) {
     return;
+  }
+  
+  if (numberOfTouches > _maxNumberOfTouches) {
+    _maxNumberOfTouches = numberOfTouches;
+  }
+  
+  if ([self shouldFailUnderCustomCriteria]) {
+    self.state = UIGestureRecognizerStateFailed;
+    [self triggerAction];
+    [self reset];
+    return;
+  }
+  
+  self.state = UIGestureRecognizerStatePossible;
+  [self triggerAction];
+  return;
 }
 
 - (BOOL)shouldFailUnderCustomCriteria
 {
-    if (_gestureHandler.shouldCancelWhenOutside) {
-        CGPoint pt = [self locationInView:self.view];
-        if (!CGRectContainsPoint(self.view.bounds, pt)) {
-            return YES;
-        }
+  if (_gestureHandler.shouldCancelWhenOutside) {
+    CGPoint pt = [self locationInView:self.view];
+    if (!CGRectContainsPoint(self.view.bounds, pt)) {
+      return YES;
     }
-
-    CGPoint trans = [self translationInView:self.view];
-    if (TEST_MAX_IF_NOT_NAN(fabs(trans.x), _maxDeltaX)) {
-        return YES;
-    }
-    if (TEST_MAX_IF_NOT_NAN(fabs(trans.y), _maxDeltaY)) {
-        return YES;
-    }
-    if (TEST_MAX_IF_NOT_NAN(fabs(trans.y * trans.y + trans.x + trans.x), _maxDistSq)) {
-        return YES;
-    }
-    return NO;
+  }
+  
+  CGPoint trans = [self translationInView:self.view];
+  if (TEST_MAX_IF_NOT_NAN(fabs(trans.x), _maxDeltaX)) {
+    return YES;
+  }
+  if (TEST_MAX_IF_NOT_NAN(fabs(trans.y), _maxDeltaY)) {
+    return YES;
+  }
+  if (TEST_MAX_IF_NOT_NAN(fabs(trans.y * trans.y + trans.x + trans.x), _maxDistSq)) {
+    return YES;
+  }
+  return NO;
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    if (_numberOfTaps == _tapsSoFar && _maxNumberOfTouches >= _minPointers) {
-        self.state = UIGestureRecognizerStateBegan;
-        [super touchesEnded:touches withEvent:event];
-        self.state = UIGestureRecognizerStateEnded;
-        [self reset];
-    } else {
-        [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDelay];
-    }
+  if (_numberOfTaps == _tapsSoFar && _maxNumberOfTouches >= _minPointers) {
+    self.state = UIGestureRecognizerStateBegan;
+    [super touchesEnded:touches withEvent:event];
+    self.state = UIGestureRecognizerStateEnded;
+    [self reset];
+  } else {
+    [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDelay];
+  }
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [super touchesCancelled:touches withEvent:event];
-    self.state = UIGestureRecognizerStateCancelled;
-    [self reset];
+  [super touchesCancelled:touches withEvent:event];
+  self.state = UIGestureRecognizerStateCancelled;
+  [self reset];
 }
 
 - (void)reset
 {
-    if (self.state == UIGestureRecognizerStateFailed) {
-        [self triggerAction];
-    }
-    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
-    _tapsSoFar = 0;
-    _maxNumberOfTouches = 0;
-    self.enabled = YES;
-    [super reset];
+  if (self.state == UIGestureRecognizerStateFailed) {
+    [self triggerAction];
+  }
+  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
+  _tapsSoFar = 0;
+  _maxNumberOfTouches = 0;
+  self.enabled = YES;
+  [super reset];
 }
 
 @end
@@ -170,38 +175,38 @@
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
-    if ((self = [super initWithTag:tag])) {
-        _recognizer = [[RNBetterTapGestureRecognizer alloc] initWithGestureHandler:self];
-    }
-    return self;
+  if ((self = [super initWithTag:tag])) {
+    _recognizer = [[RNBetterTapGestureRecognizer alloc] initWithGestureHandler:self];
+  }
+  return self;
 }
 
 - (void)configure:(NSDictionary *)config
 {
-    [super configure:config];
-    RNBetterTapGestureRecognizer *recognizer = (RNBetterTapGestureRecognizer *)_recognizer;
-
-    APPLY_INT_PROP(numberOfTaps);
-    APPLY_INT_PROP(minPointers);
-    APPLY_FLOAT_PROP(maxDeltaX);
-    APPLY_FLOAT_PROP(maxDeltaY);
-
-    id prop = config[@"maxDelayMs"];
-    if (prop != nil) {
-        recognizer.maxDelay = [RCTConvert CGFloat:prop] / 1000.0;
-    }
-
-    prop = config[@"maxDurationMs"];
-    if (prop != nil) {
-        recognizer.maxDuration = [RCTConvert CGFloat:prop] / 1000.0;
-    }
-
-    prop = config[@"maxDist"];
-    if (prop != nil) {
-        CGFloat dist = [RCTConvert CGFloat:prop];
-        recognizer.maxDistSq = dist * dist;
-    }
-
+  [super configure:config];
+  RNBetterTapGestureRecognizer *recognizer = (RNBetterTapGestureRecognizer *)_recognizer;
+  
+  APPLY_INT_PROP(numberOfTaps);
+  APPLY_INT_PROP(minPointers);
+  APPLY_FLOAT_PROP(maxDeltaX);
+  APPLY_FLOAT_PROP(maxDeltaY);
+  
+  id prop = config[@"maxDelayMs"];
+  if (prop != nil) {
+    recognizer.maxDelay = [RCTConvert CGFloat:prop] / 1000.0;
+  }
+  
+  prop = config[@"maxDurationMs"];
+  if (prop != nil) {
+    recognizer.maxDuration = [RCTConvert CGFloat:prop] / 1000.0;
+  }
+  
+  prop = config[@"maxDist"];
+  if (prop != nil) {
+    CGFloat dist = [RCTConvert CGFloat:prop];
+    recognizer.maxDistSq = dist * dist;
+  }
+  
 }
 
 @end

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -12,9 +12,10 @@
 
 #import <React/RCTConvert.h>
 
-// RNBetterTapGestureRecognizer does not extend UITapGestureRecognizer so that as parameters like
-// maxDelay, maxDuration, minPointers, maxDelta are not configurable in UITapGestureRecognizer
-// and therefore require custom implementation.
+// RNBetterTapGestureRecognizer extends UIGestureRecognizer instead of UITapGestureRecognizer 
+// because the latter does not allow for parameters like maxDelay, maxDuration, minPointers, 
+// maxDelta to be configured. Using our custom implementation of tap recognizer we are able
+// to support these.
 
 @interface RNBetterTapGestureRecognizer : UIGestureRecognizer
 


### PR DESCRIPTION
## Motivation 
https://github.com/kmagiera/react-native-gesture-handler/issues/233
Wish to fix this issue and manage problem when Tap's invoke is not connected with any move event.
## Repro
The most simply way to reproduce this issue is to use computer mouse on emulator as it gives the possibility to invoke touch down and up event without move. It is also possible on device but seems to be quite difficult as event stream is very sensitive
## Changes
~~Struggled to do it on various way like changing state manually, reseting UIPanGestureRecognizerState manually or even by setting proper translation
However the problem is that we need to control gesture "machine state" and it does not fit into Pan normal event flow.
Therefore TouchesMoved should to be called on began as well. 
As in TapHandler it's not a special case (contrary to PanHandler) the first touch (down event) has to be handled in the same way as move in order to allow handle to change its state not only if there was some move event during recognising
I made also codestyle fix as it didn't fit style of another files.
**So please consider that the only "real" change is line:** https://github.com/kmagiera/react-native-gesture-handler/pull/240/files#diff-5a7a364517bdcc250e56e4b950c8a083R91~~
Revert Tap changes in https://github.com/kmagiera/react-native-gesture-handler/pull/143/files and rewrite `translationInView` to be calculated every time. 