### PR TITLE
issue #241 - reseting values in Tap on Android

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -121,8 +121,6 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
       mOffsetY = 0;
       mStartX = event.getRawX();
       mStartY = event.getRawY();
-      mLastX = mStartX;
-      mLastY = mStartY;
     }
 
     if (action == MotionEvent.ACTION_POINTER_UP || action == MotionEvent.ACTION_POINTER_DOWN) {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -116,6 +116,15 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
     int state = getState();
     int action = event.getActionMasked();
 
+    if (state == STATE_UNDETERMINED) {
+      mOffsetX = 0;
+      mOffsetY = 0;
+      mStartX = event.getRawX();
+      mStartY = event.getRawY();
+      mLastX = mStartX;
+      mLastY = mStartY;
+    }
+
     if (action == MotionEvent.ACTION_POINTER_UP || action == MotionEvent.ACTION_POINTER_DOWN) {
       mOffsetX += mLastX - mStartX;
       mOffsetY += mLastY - mStartY;
@@ -140,10 +149,6 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
       fail();
     } else if (state == STATE_UNDETERMINED) {
       if (action == MotionEvent.ACTION_DOWN) {
-        mOffsetX = 0;
-        mOffsetY = 0;
-        mStartX = event.getRawX();
-        mStartY = event.getRawY();
         begin();
       }
       startTap();


### PR DESCRIPTION
## Motivation
This PR is related with issue #241. Tap handler wasn't woking properly with condition `maxDeltaX` and `maxDeltaY`
## Repro
If you wish to repro this this issue, please use code from issue in Example App
## Changes
`onHandle` method in TapGestureHandler was not reseting values `mLastX` and `mLastY` at the beginning of a gesture. It implies that the condition `shouldFail()` was not working properly which was clearly illustrated with `maxDeltaX: 0` and `maxDeltaY: 0` in given issue. Indeed `mLastX` and `mLastY` were representing values from previous gesture.
Now reseting was added and moved before `shouldFail()` condition.
However, it's difficult to meet condition given in the issue(`maxDeltaX: 0` and `maxDeltaY: 0`) it's possibile with emulated device