### PR TITLE
Change activation login in Pan on Android :hand:

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
@@ -203,7 +203,9 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
       mLastEventOffsetY = event.getRawY() - event.getY();
     }
 
-    if (state == STATE_UNDETERMINED && event.getPointerCount() >= mMinPointers) {
+    if (state == STATE_UNDETERMINED
+            && event.getPointerCount() >= mMinPointers
+            && action == MotionEvent.ACTION_MOVE) {
       mStartX = mLastX;
       mStartY = mLastY;
       mOffsetX = 0;


### PR DESCRIPTION
## Motivation
The author of #223 observed that the flow of activation PanGH on Android and iOS is different as on Android it gets activated immediately, but on iOS it has to wait for "move"
## Changes
As iOS behaviour seems to be more intuitive because "panning" is referring to some king of "moving" I decided to add extra condition on Android to check whether the event in "Move". If it's only `ACTION_DOWN` or `ACTION_POINTER_DOWN` it won't get active
The problem is if the event  `ACTION_POINTER_DOWN` will happen immediately after `ACTION_DOWN` and will be connected with some movement of first pointer. But this situation seems to be impossible to reproduce in real use case (even on emulator)