### PR TITLE
Issue #155 - Add possibility for DrawerLayout's child to be a render function

### DIFF
--- a/DrawerLayout.js
+++ b/DrawerLayout.js
@@ -183,14 +183,13 @@ export default class DrawerLayout extends Component<PropType, StateType> {
       translationX = Animated.add(dragX, dragOffsetFromOnStartPosition);
     }
 
-    this._openValue = Animated.add(
-      translationX,
-      drawerTranslation
-    ).interpolate({
-      inputRange: [0, drawerWidth],
-      outputRange: [0, 1],
-      extrapolate: 'clamp',
-    });
+    this._openValue = Animated.add(translationX, drawerTranslation).interpolate(
+      {
+        inputRange: [0, drawerWidth],
+        outputRange: [0, 1],
+        extrapolate: 'clamp',
+      }
+    );
 
     this._onGestureEvent = Animated.event(
       [{ nativeEvent: { translationX: dragXValue, x: touchXValue } }],
@@ -386,7 +385,9 @@ export default class DrawerLayout extends Component<PropType, StateType> {
             containerStyles,
             contentContainerStyle,
           ]}>
-          {this.props.children}
+          {typeof this.props.children === 'function'
+            ? this.props.children(this._openValue)
+            : this.props.children}
           {this._renderOverlay()}
         </Animated.View>
         <Animated.View

--- a/docs/component-drawer-layout.md
+++ b/docs/component-drawer-layout.md
@@ -43,7 +43,7 @@ function. This attribute is present in the standard implementation already and i
 
 ---
 ### `children`
-component or function. Children is a component which is rendered by default and is wrapped by drawer. However, it could be also render function which takes an Animated value as a parameter that indicates the progress of drawer opening/closing animation (progress value is 0 when closed and 1 when opened) is the same way like `renderNavigationView` prop
+component or function. Children is a component which is rendered by default and is wrapped by drawer. However, it could be also a render function which takes an Animated value as a parameter that indicates the progress of drawer opening/closing animation (progress value is 0 when closed and 1 when opened) is the same way like `renderNavigationView` prop.
 
 ## Example:
 See the [drawer example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/horizontalDrawer/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).

--- a/docs/component-drawer-layout.md
+++ b/docs/component-drawer-layout.md
@@ -42,6 +42,9 @@ color (default to `"black"`) of a semi-transparent overlay to be displayed on to
 function. This attribute is present in the standard implementation already and is one of the required params. Gesture handler version of DrawerLayout make it possible for the function passed as `renderNavigationView` to take an Animated value as a parameter that indicates the progress of drawer opening/closing animation (progress value is 0 when closed and 1 when opened). This can be used by the drawer component to animated its children while the drawer is opening or closing.
 
 ---
+### `children`
+component or function. Children is a component which is rendered by default and is wrapped by drawer. However, it could be also render function which takes an Animated value as a parameter that indicates the progress of drawer opening/closing animation (progress value is 0 when closed and 1 when opened) is the same way like `renderNavigationView` prop
+
 ## Example:
 See the [drawer example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/horizontalDrawer/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
 ```js


### PR DESCRIPTION
## Motivation
As @brettdh in #155  noticed, it might be useful if child of `DrawerLayout` could be a render function with progress as parameter

## Changes
Check if child is a function an if yes, invoke it with progress value parameter