### PR TITLE
Change states flow 

### DIFF
--- a/Example/combo/index.js
+++ b/Example/combo/index.js
@@ -35,7 +35,7 @@ class TouchableHighlight extends Component {
   };
   constructor(props) {
     super(props);
-    this.state = { gestureHandlerState: State.UNDETERMINED };
+    this.state = { gestureHandlerState: State.BEGAN };
     this._pressedStyle = {
       opacity: this.props.activeOpacity,
     };

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -55,6 +55,14 @@ UIManager.RCTView.directEventTypes = {
 
 const State = RNGestureHandlerModule.State;
 
+// Used code below as it was impossible to do it with restructuration
+Object.defineProperty(State, 'UNDETERMINED', {
+  get() {
+    console.warn('It is deprecated to use state UNDETERMINED');
+    return 0;
+  },
+});
+
 const Directions = RNGestureHandlerModule.Direction;
 
 let handlerTag = 1;

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -56,6 +56,7 @@ UIManager.RCTView.directEventTypes = {
 const State = RNGestureHandlerModule.State;
 
 // Used code below as it was impossible to do it with restructuration
+// FIXME to be removed
 Object.defineProperty(State, 'UNDETERMINED', {
   get() {
     console.warn(

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -58,7 +58,9 @@ const State = RNGestureHandlerModule.State;
 // Used code below as it was impossible to do it with restructuration
 Object.defineProperty(State, 'UNDETERMINED', {
   get() {
-    console.warn('It is deprecated to use state UNDETERMINED');
+    console.warn(
+      'It is deprecated to use state UNDETERMINED. Now it used only for internal native states handling and will be removed in next version'
+    );
     return 0;
   },
 });

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
@@ -197,7 +197,7 @@ public class GestureHandlerOrchestrator {
       if (handler.mIsActive) {
         handler.dispatchStateChange(newState, prevState);
       }
-    } else {
+    } else if (prevState != GestureHandler.STATE_UNDETERMINED ){
       handler.dispatchStateChange(newState, prevState);
     }
     mHandlingChangeSemaphore -= 1;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -497,7 +497,6 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
   @Override
   public @Nullable Map getConstants() {
     return MapBuilder.of("State", MapBuilder.of(
-            "UNDETERMINED", GestureHandler.STATE_UNDETERMINED,
             "BEGAN", GestureHandler.STATE_BEGAN,
             "ACTIVE", GestureHandler.STATE_ACTIVE,
             "CANCELLED", GestureHandler.STATE_CANCELLED,

--- a/docs/state.md
+++ b/docs/state.md
@@ -7,8 +7,7 @@ sidebar_label: Handler State
 As described in ["About Gesture Handlers"](about-handlers.md) section gesture handlers can be treated as ["state machines"](https://en.wikipedia.org/wiki/Finite-state_machine).
 Each handler instance at any given time has an assigned state that can change when new touch events arrive or can be forced by the touch system to change it state in certain circumstances.
 
-There are six possible states for the handler:
- - [UNDETERMINED](#undetermined)
+There are five possible states for the handler:
  - [FAILED](#failed)
  - [BEGAN](#began)
  - [CANCELLED](#cancelled)
@@ -45,37 +44,34 @@ class Demo extends Component {
 
 ## State flows
 
-The most typical flow of the state is when the gesture handler first picks up the initial touch events, then at some point it reognizes the touches and after the end of the gesture is recognized it resets back to the initial state. The flow looks as follows (longer arrows represent that there are possibly more touch events received before the state changes):
+The most typical flow of the state is when the gesture handler first picks up the initial touch events, then at some point it recognizes the touches and after the end of the gesture is recognized it resets back to the initial state. The flow looks as follows (longer arrows represent that there are possibly more touch events received before the state changes):
 
-[`UNDETERMINED`](#undetermined) -> [`BEGAN`](#began) ------> [`ACTIVE`](#active) ------> [`END`](#end) -> [`UNDETERMINED`](#undetermined)
+[`BEGAN`](#began) ------> [`ACTIVE`](#active) ------> [`END`](#end)
 
 Here is another possible flow when the handler receive touches that causes it to fail recognition:
 
-[`UNDETERMINED`](#undetermined) -> [`BEGAN`](#began) ------> [`FAILED`](#failed) -> [`UNDETERMINED`](#undetermined)
+[`BEGAN`](#began) ------> [`FAILED`](#failed)
 
 Lastly even when the handler properly recognizes the gesture it may be interrupted by the touch system, in that case the flow looks as follows:
 
-[`UNDETERMINED`](#undetermined) -> [`BEGAN`](#began) ------> [`ACTIVE`](#active) ------> [`CANCELLED`](#cancelled) -> [`UNDETERMINED`](#undetermined)
+[`BEGAN`](#began) ------> [`ACTIVE`](#active) ------> [`CANCELLED`](#cancelled)
 
 ## States
 
 Section below lists all the possible handler states along with detailed description of each state:
 
-### UNDETERMINED
-This is the initial state of each handler. It also changes to that state when it is done recognizing and hasn't started recogninzing another gesture.
-
 ### FAILED
-Handler has received some touches, but for some condition (e.g. finger traveled too long distance when `maxDist` property is set) it won't get [activated](#ACTIVE) and gesture was not recognized. After that handler is reset to [the initial state](#undetermined).
+Handler has received some touches, but for some condition (e.g. finger traveled too long distance when `maxDist` property is set) it won't get [activated](#ACTIVE) and gesture was not recognized.
 
 ### BEGAN
 Handler has started receiving touch stream but hasn't yet receive enough data to either [fail](#failed) or [activate](#active).
 
 ### CANCELLED
-The gesture recognizer has received signal (possibly new touches or a command from the touch system controller) resulting in the cancellation of a continuous gesture. Gesture recognizer is reset to [the initial state](#undetermined).
+The gesture recognizer has received signal (possibly new touches or a command from the touch system controller) resulting in the cancellation of a continuous gesture.
 
 ### ACTIVE
 Handler has recognized gesture and will stay in the active as until the gesture finishes (normally when user lifts the finger) or get cancelled by the touch system. Under normal circumstances it would turn into [ended](#end) state. In case it is cancelled by the touch system it would turn into [CANCELLED](#cancelled) state.
 Learn about [discrete and continuous handlers here](about-handlers.md#discrete-vs-continuous) to understand how long handler can be kept in the ACTIVE state.
 
 ### END
-The gesture recognizer has received touches recognized as the end of the gesture. After that it will reset to [the initial state](#undetermined).
+The gesture recognizer has received touches recognized as the end of the gesture.

--- a/ios/Handlers/RNLongPressHandler.m
+++ b/ios/Handlers/RNLongPressHandler.m
@@ -71,17 +71,5 @@
         recognizer.allowableMovement = [RCTConvert CGFloat:prop];
     }
 }
-
-- (RNGestureHandlerState)state
-{
-    // For long press recognizer we treat "Began" state as "active"
-    // as it changes its state to "Began" as soon as the the minimum
-    // hold duration timeout is reached, whereas state "Changed" is
-    // only set after "Began" phase if there is some movement.
-    if (_recognizer.state == UIGestureRecognizerStateBegan) {
-        return RNGestureHandlerStateActive;
-    }
-    return [super state];
-}
 @end
 

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -69,7 +69,7 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
 {
     if ((self = [super init])) {
         _tag = tag;
-        _lastState = RNGestureHandlerStateUndetermined;
+        _lastState = RNGestureHandlerStateBegan;
         _hitSlop = RNGHHitSlopEmpty;
     }
     return self;
@@ -172,7 +172,7 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
                                                                                           extraData:extraData]];
             _lastState = RNGestureHandlerStateActive;
         }
-        if (_lastState != RNGestureHandlerStateUndetermined) {
+        if (_lastState != RNGestureHandlerStateBegan || (state != RNGestureHandlerStateCancelled && state != RNGestureHandlerStateFailed)) {
             id stateEvent = [[RNGestureHandlerStateChange alloc] initWithRactTag:reactTag
                                                                       handlerTag:_tag
                                                                            state:state
@@ -204,7 +204,7 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
         case UIGestureRecognizerStateChanged:
             return RNGestureHandlerStateActive;
     }
-    return RNGestureHandlerStateUndetermined;
+    return RNGestureHandlerStateBegan;
 }
 
 #pragma mark UIGestureRecognizerDelegate
@@ -284,7 +284,7 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
 
 - (void)reset
 {
-    _lastState = RNGestureHandlerStateUndetermined;
+    _lastState = RNGestureHandlerStateBegan;
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -172,12 +172,15 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
                                                                                           extraData:extraData]];
             _lastState = RNGestureHandlerStateActive;
         }
-        id stateEvent = [[RNGestureHandlerStateChange alloc] initWithRactTag:reactTag
-                                                                  handlerTag:_tag
-                                                                       state:state
-                                                                   prevState:_lastState
-                                                                   extraData:extraData];
-        [self.emitter sendStateChangeEvent:stateEvent];
+        if (_lastState != RNGestureHandlerStateUndetermined) {
+            id stateEvent = [[RNGestureHandlerStateChange alloc] initWithRactTag:reactTag
+                                                                      handlerTag:_tag
+                                                                           state:state
+                                                                       prevState:_lastState
+                                                                       extraData:extraData];
+            
+            [self.emitter sendStateChangeEvent:stateEvent];
+        }
         _lastState = state;
     }
 

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -192,7 +192,6 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
 - (RNGestureHandlerState)state
 {
     switch (_recognizer.state) {
-        case UIGestureRecognizerStateBegan:
         case UIGestureRecognizerStatePossible:
             return RNGestureHandlerStateBegan;
         case UIGestureRecognizerStateEnded:
@@ -201,6 +200,7 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
             return RNGestureHandlerStateFailed;
         case UIGestureRecognizerStateCancelled:
             return RNGestureHandlerStateCancelled;
+        case UIGestureRecognizerStateBegan:
         case UIGestureRecognizerStateChanged:
             return RNGestureHandlerStateActive;
     }

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -164,7 +164,6 @@ RCT_EXPORT_METHOD(handleClearJSResponder)
 - (NSDictionary *)constantsToExport
 {
     return @{ @"State": @{
-                      @"UNDETERMINED": @(RNGestureHandlerStateUndetermined),
                       @"BEGAN": @(RNGestureHandlerStateBegan),
                       @"ACTIVE": @(RNGestureHandlerStateActive),
                       @"CANCELLED": @(RNGestureHandlerStateCancelled),

--- a/ios/RNGestureHandlerState.h
+++ b/ios/RNGestureHandlerState.h
@@ -1,8 +1,7 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, RNGestureHandlerState) {
-    RNGestureHandlerStateUndetermined = 0,
-    RNGestureHandlerStateFailed,
+    RNGestureHandlerStateFailed = 1,
     RNGestureHandlerStateBegan,
     RNGestureHandlerStateCancelled,
     RNGestureHandlerStateActive,

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -29,8 +29,7 @@ export enum Directions {
 }
 
 export enum State {
-  UNDETERMINED = 0,
-  FAILED,
+  FAILED = 1,
   BEGAN,
   CANCELLED,
   ACTIVE,


### PR DESCRIPTION
## Motivation
Gestures flow (especially "beginning" on Android and iOS) are inconsistent. E.g. Pan, Pinch and rotate are "beginning" on the first touch on Android, but "activating" while fulfilling conditions to be activated. On iOS gesture is "beginning" while conditions are fulfilled and immediately is started in the next frame (see apple docs)

## Changes
Having observed states flow on iOS I came to conclusion than there's a small redundancy in gestures state

Following https://developer.apple.com/documentation/uikit/uigesturerecognizer/state/began I came to conclusion than `began` and `changed` could be treated as the same RNState, because there's no need to  favourise the first "active" frame as it is currently on iOS.

On android side every handler is getting "began" immediately and I suppose that there's no need to inform about it via gesture state change. 

Taking it into consideration I decided to treat "began" as initial state for every gesture handler and only send information about "activation" of each as the first event (similarly to iOS native behaviour). 

So I filter every cancellation or failure of undetermined GH on Android (like on iOS). I also changed a bit translation of native -> RN states on iOS.

So now it became useless to use `UNDETERMINED` state on js side. I made a small research and found out that hardly nobody (on Github) were doing it, so it's not very breaking. Using `Undetermined` state on js side is useless now, but I decided to add warning and maybe remove it totally in the next version
