### PR TITLE
Issue #251 - Swipeble openLeft / openRight

### DIFF
--- a/Swipeable.js
+++ b/Swipeable.js
@@ -261,6 +261,18 @@ export default class Swipeable extends Component<PropType, StateType> {
     this._animateRow(this._currentOffset(), 0);
   };
 
+  openLeft = () => {
+    const { leftWidth = 0 } = this.state;
+    this._animateRow(this._currentOffset(), leftWidth);
+  };
+
+  openRight = () => {
+    const { rowWidth = 0 } = this.state;
+    const { rightOffset = rowWidth } = this.state;
+    const rightWidth = rowWidth - rightOffset;
+    this._animateRow(this._currentOffset(), -rightWidth);
+  };
+
   render() {
     const { rowState } = this.state;
     const { children, renderLeftActions, renderRightActions } = this.props;

--- a/docs/component-swipeable.md
+++ b/docs/component-swipeable.md
@@ -77,6 +77,21 @@ method that is expected to return an action panel that is going to be revealed f
 ### `renderRightActions`
 method that is expected to return an action panel that is going to be revealed from the right side when user swipes left.
 
+## Methods
+Using reference to `Swipeable` it's possible toi trigger some actions on it
+
+---
+### `close`
+method that closes component.
+
+---
+### `openLeft`
+method that opens component on left side.
+
+---
+### `openRight`
+method that opens component on right side.
+
 
 ### Example:
 

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -383,6 +383,8 @@ export interface SwipeableProperties {
 
 export class Swipeable extends React.Component<SwipeableProperties> {
   close: () => void;
+  openLeft: () => void;
+  openRight: () => void;
 }
 
 export interface DrawerLayoutProperties {


### PR DESCRIPTION
## Motivation
Author of the #251 issue noticed that it would be extremely useful to use openLeft/openRight methods on Swipeable

## Chages
Documented close() method which wasn't mentioned in docs before.

Added methods `openLeft` and `openRight` as @henrikra  requested with docs.
 