### PR TITLE
Docs: Add an example on how to detect swipe direction

### DIFF
--- a/docs/handler-pan.md
+++ b/docs/handler-pan.md
@@ -99,7 +99,7 @@ See [set of event attributes from base handler class](handler-common.md#event-da
 
 Translation of the pan gesture along X axis accumulated over the time of the gesture. The value is expressed in the point units.
 
-Here a simple example of how to detect the direction of a user's swipe.
+Here is a simple example of how to detect the direction of a user's swipe.
 
 ```js
 _onHandlerStateChange = event => {

--- a/docs/handler-pan.md
+++ b/docs/handler-pan.md
@@ -103,7 +103,7 @@ Here is a simple example of how to detect the direction of a user's swipe.
 
 ```js
 _onHandlerStateChange = event => {
-  if (e.nativeEvent.oldState === State.ACTIVE) {
+  if (event.nativeEvent.oldState === State.ACTIVE) {
     const direction = event.nativeEvent.translationX < 0 ? 'right' : 'left';
     console.log(direction);
   }

--- a/docs/handler-pan.md
+++ b/docs/handler-pan.md
@@ -99,6 +99,21 @@ See [set of event attributes from base handler class](handler-common.md#event-da
 
 Translation of the pan gesture along X axis accumulated over the time of the gesture. The value is expressed in the point units.
 
+Here a simple example of how to detect the direction of a user's swipe.
+
+```js
+_onHandlerStateChange = event => {
+  if (e.nativeEvent.oldState === State.ACTIVE) {
+    const direction = event.nativeEvent.translationX < 0 ? 'right' : 'left';
+    console.log(direction);
+  }
+};
+
+<PanGestureHandler onHandlerStateChange={this._onHandlerStateChange}>
+  <View style={{ flex: 1 }} />
+</PanGestureHandler>
+```
+
 ---
 ### `translationY`
 


### PR DESCRIPTION
Hi @kmagiera,

First of all I want to thank you for your efforts working on this amazing addition to the React Native ecosystem, I've been following your progress over the last year.

I've added a simple snippet on how to use the pan handler to detect a swipe direction, I believe that adding this type of small-stripped-down use cases can be very beneficial to understand how to use this tool.

Thanks again, and I hope this work eventually gets included in core.