### PR TITLE
Allow onHandlerStateChange to be an object

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -93,7 +93,7 @@ const GestureHandlerPropTypes = {
     }),
   ]),
   onGestureEvent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-  onHandlerStateChange: PropTypes.func,
+  onHandlerStateChange: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   onBegan: PropTypes.func,
   onFailed: PropTypes.func,
   onCancelled: PropTypes.func,


### PR DESCRIPTION
This enables onHandlerStateChange to be passed an Animated.Event which is technically not a function. Support for that case already exists, but was not represented in propTypes.