### PR TITLE
Updated resources link on help page

### DIFF
--- a/website/pages/en/help.js
+++ b/website/pages/en/help.js
@@ -33,8 +33,7 @@ class Help extends React.Component {
       },
       {
         content: `Check our ["Resources" section](${docUrl(
-          'resources.html',
-          language
+          'resources.html'
         )}) for a list of open-source apps using Gesture Handler and a video recordings from conferences and workshops.`,
         title: 'Projects and talks',
       },


### PR DESCRIPTION
Resources link is located on https://kmagiera.github.io/react-native-gesture-handler/docs/resources.html while the link in help page is directing to https://kmagiera.github.io/react-native-gesture-handler/docs/en/resources.html