### PR TITLE
Add extra fields to long press, fling and tap event payload on Android

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.java
@@ -55,6 +55,9 @@ public class GestureHandler<T extends GestureHandler> {
   private boolean mEnabled = true;
   private float mHitSlop[];
 
+  private float mLastX, mLastY;
+  private float mLastEventOffsetX, mLastEventOffsetY;
+
   private boolean mShouldCancelWhenOutside;
   private int mNumberOfPointers = 0;
 
@@ -304,6 +307,12 @@ public class GestureHandler<T extends GestureHandler> {
       }
       return;
     }
+
+    mLastX = GestureUtils.getLastPointerX(event, true);
+    mLastY = GestureUtils.getLastPointerY(event, true);
+    mLastEventOffsetX = event.getRawX() - event.getX();
+    mLastEventOffsetY = event.getRawY() - event.getY();
+
     onHandle(event);
     if (event != origEvent) {
       event.recycle();
@@ -481,5 +490,21 @@ public class GestureHandler<T extends GestureHandler> {
   public String toString() {
     String viewString = mView == null ? null : mView.getClass().getSimpleName();
     return this.getClass().getSimpleName() + "@[" + mTag + "]:"  + viewString;
+  }
+
+  public float getLastAbsolutePositionX() {
+    return mLastX;
+  }
+
+  public float getLastAbsolutePositionY() {
+    return mLastY;
+  }
+
+  public float getLastRelativePositionX() {
+    return mLastX - mLastEventOffsetX;
+  }
+
+  public float getLastRelativePositionY() {
+    return mLastY - mLastEventOffsetY;
   }
 }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.java
@@ -12,8 +12,6 @@ public class LongPressGestureHandler extends GestureHandler<LongPressGestureHand
   private long mMinDurationMs = DEFAULT_MIN_DURATION_MS;
   private float mMaxDistSq;
   private float mStartX, mStartY;
-  private float mLastX, mLastY;
-  private float mLastEventOffsetX, mLastEventOffsetY;
   private Handler mHandler;
 
   public LongPressGestureHandler(Context context) {
@@ -67,10 +65,6 @@ public class LongPressGestureHandler extends GestureHandler<LongPressGestureHand
         }
       }
     }
-    mLastX = GestureUtils.getLastPointerX(event, true);
-    mLastY = GestureUtils.getLastPointerY(event, true);
-    mLastEventOffsetX = event.getRawX() - event.getX();
-    mLastEventOffsetY = event.getRawY() - event.getY();
   }
 
   @Override
@@ -79,21 +73,5 @@ public class LongPressGestureHandler extends GestureHandler<LongPressGestureHand
       mHandler.removeCallbacksAndMessages(null);
       mHandler = null;
     }
-  }
-
-  public float getLastAbsolutePositionX() {
-    return mLastX;
-  }
-
-  public float getLastAbsolutePositionY() {
-    return mLastY;
-  }
-
-  public float getLastRelativePositionX() {
-    return mLastX - mLastEventOffsetX;
-  }
-
-  public float getLastRelativePositionY() {
-    return mLastY - mLastEventOffsetY;
   }
 }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.java
@@ -12,6 +12,8 @@ public class LongPressGestureHandler extends GestureHandler<LongPressGestureHand
   private long mMinDurationMs = DEFAULT_MIN_DURATION_MS;
   private float mMaxDistSq;
   private float mStartX, mStartY;
+  private float mLastX, mLastY;
+  private float mLastEventOffsetX, mLastEventOffsetY;
   private Handler mHandler;
 
   public LongPressGestureHandler(Context context) {
@@ -65,6 +67,10 @@ public class LongPressGestureHandler extends GestureHandler<LongPressGestureHand
         }
       }
     }
+    mLastX = GestureUtils.getLastPointerX(event, true);
+    mLastY = GestureUtils.getLastPointerY(event, true);
+    mLastEventOffsetX = event.getRawX() - event.getX();
+    mLastEventOffsetY = event.getRawY() - event.getY();
   }
 
   @Override
@@ -73,5 +79,21 @@ public class LongPressGestureHandler extends GestureHandler<LongPressGestureHand
       mHandler.removeCallbacksAndMessages(null);
       mHandler = null;
     }
+  }
+
+  public float getLastAbsolutePositionX() {
+    return mLastX;
+  }
+
+  public float getLastAbsolutePositionY() {
+    return mLastY;
+  }
+
+  public float getLastRelativePositionX() {
+    return mLastX - mLastEventOffsetX;
+  }
+
+  public float getLastRelativePositionY() {
+    return mLastY - mLastEventOffsetY;
   }
 }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
@@ -29,7 +29,6 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
   private float mStartX, mStartY;
   private float mOffsetX, mOffsetY;
   private float mLastX, mLastY;
-  private float mLastEventOffsetX, mLastEventOffsetY;
   private float mLastVelocityX, mLastVelocityY;
   private VelocityTracker mVelocityTracker;
 
@@ -192,15 +191,11 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
       // reset starting point
       mLastX = GestureUtils.getLastPointerX(event, mAverageTouches);
       mLastY = GestureUtils.getLastPointerY(event, mAverageTouches);
-      mLastEventOffsetX = event.getRawX() - event.getX();
-      mLastEventOffsetY = event.getRawY() - event.getY();
       mStartX = mLastX;
       mStartY = mLastY;
     } else {
       mLastX = GestureUtils.getLastPointerX(event, mAverageTouches);
       mLastY = GestureUtils.getLastPointerY(event, mAverageTouches);
-      mLastEventOffsetX = event.getRawX() - event.getX();
-      mLastEventOffsetY = event.getRawY() - event.getY();
     }
 
     if (state == STATE_UNDETERMINED && event.getPointerCount() >= mMinPointers) {
@@ -273,21 +268,6 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
     return mLastVelocityY;
   }
 
-  public float getLastAbsolutePositionX() {
-    return mLastX;
-  }
-
-  public float getLastAbsolutePositionY() {
-    return mLastY;
-  }
-
-  public float getLastRelativePositionX() {
-    return mLastX - mLastEventOffsetX;
-  }
-
-  public float getLastRelativePositionY() {
-    return mLastY - mLastEventOffsetY;
-  }
 
   /**
    * This method adds movement to {@class VelocityTracker} first resetting offset of the event so

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java
@@ -23,7 +23,6 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
   private float mStartX, mStartY;
   private float mOffsetX, mOffsetY;
   private float mLastX, mLastY;
-  private float mLastEventOffsetX, mLastEventOffsetY;
 
   private Handler mHandler;
   private int mTapsSoFar;
@@ -128,15 +127,11 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
       mOffsetY += mLastY - mStartY;
       mLastX = GestureUtils.getLastPointerX(event, true);
       mLastY = GestureUtils.getLastPointerY(event, true);
-      mLastEventOffsetX = event.getRawX() - event.getX();
-      mLastEventOffsetY = event.getRawY() - event.getY();
       mStartX = mLastX;
       mStartY = mLastY;
     } else {
       mLastX = GestureUtils.getLastPointerX(event, true);
       mLastY = GestureUtils.getLastPointerY(event, true);
-      mLastEventOffsetX = event.getRawX() - event.getX();
-      mLastEventOffsetY = event.getRawY() - event.getY();
     }
 
     if (mNumberOfPointers < event.getPointerCount()) {
@@ -173,21 +168,5 @@ public class TapGestureHandler extends GestureHandler<TapGestureHandler> {
     if (mHandler != null) {
       mHandler.removeCallbacksAndMessages(null);
     }
-  }
-
-  public float getLastAbsolutePositionX() {
-    return mLastX;
-  }
-
-  public float getLastAbsolutePositionY() {
-    return mLastY;
-  }
-
-  public float getLastRelativePositionX() {
-    return mLastX - mLastEventOffsetX;
-  }
-
-  public float getLastRelativePositionY() {
-    return mLastY - mLastEventOffsetY;
   }
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -220,6 +220,15 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
         handler.setMaxDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_LONG_PRESS_MAX_DIST)));
       }
     }
+
+    @Override
+    public void extractEventData(LongPressGestureHandler handler, WritableMap eventData) {
+      super.extractEventData(handler, eventData);
+      eventData.putDouble("x", PixelUtil.toDIPFromPixel(handler.getLastRelativePositionX()));
+      eventData.putDouble("y", PixelUtil.toDIPFromPixel(handler.getLastRelativePositionY()));
+      eventData.putDouble("absoluteX", PixelUtil.toDIPFromPixel(handler.getLastAbsolutePositionX()));
+      eventData.putDouble("absoluteY", PixelUtil.toDIPFromPixel(handler.getLastAbsolutePositionY()));
+    }
   }
 
   private static class PanGestureHandlerFactory extends HandlerFactory<PanGestureHandler> {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -374,6 +374,14 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
         handler.setDirection(config.getInt(KEY_DIRECTION));
       }
     }
+    @Override
+    public void extractEventData(FlingGestureHandler handler, WritableMap eventData) {
+      super.extractEventData(handler, eventData);
+      eventData.putDouble("x", PixelUtil.toDIPFromPixel(handler.getLastRelativePositionX()));
+      eventData.putDouble("y", PixelUtil.toDIPFromPixel(handler.getLastRelativePositionY()));
+      eventData.putDouble("absoluteX", PixelUtil.toDIPFromPixel(handler.getLastAbsolutePositionX()));
+      eventData.putDouble("absoluteY", PixelUtil.toDIPFromPixel(handler.getLastAbsolutePositionY()));
+    }
   }
 
   private static class RotationGestureHandlerFactory extends HandlerFactory<RotationGestureHandler> {

--- a/docs/handler-fling.md
+++ b/docs/handler-fling.md
@@ -33,7 +33,27 @@ Determinate exact number of point required to handle the fling gesture.
 
 ## Event data
 
-Gesture events provided to `FlingGestureHandler` callbacks does not include any handler specific attributes beside the [common set of event attributes from base handler class](handler-common#event-data).
+See [set of event attributes from base handler class](handler-common.md#event-data). Below is a list of gesture event attributes specific to `FlingGestureHandler`:
+
+---
+### `x`
+
+X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the view attached to the handler. Expressed in point units.
+
+---
+### `y`
+
+Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the view attached to the handler. Expressed in point units.
+
+---
+### `absoluteX`
+
+X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
+
+---
+### `absoluteY`
+
+Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
 
 ## Example
 

--- a/docs/handler-longpress.md
+++ b/docs/handler-longpress.md
@@ -26,7 +26,27 @@ Allow finger movement while pressing. This property expresses the maximum distan
 
 ## Event data
 
-Gesture events provided to `LongPressGestureHandler` callbacks does not include any handler specific attributes beside the [common set of event attributes from base handler class](handler-common.md#event-data).
+See [set of event attributes from base handler class](handler-common.md#event-data). Below is a list of gesture event attributes specific to `LongPressGestureHandler`:
+
+---
+### `x`
+
+X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the view attached to the handler. Expressed in point units.
+
+---
+### `y`
+
+Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the view attached to the handler. Expressed in point units.
+
+---
+### `absoluteX`
+
+X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
+
+---
+### `absoluteY`
+
+Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
 
 ## Example
 

--- a/docs/handler-tap.md
+++ b/docs/handler-tap.md
@@ -52,7 +52,27 @@ When the finger travels the given distance expressed in points and handler hasn'
 
 
 ## Event data
-Gesture events provided to `TapGestureHandler` callbacks does not include any handler specific attributes beside the [common set of event attributes from base handler class](handler-common.md#event-data).
+See [set of event attributes from base handler class](handler-common.md#event-data). Below is a list of gesture event attributes specific to `TapGestureHandler`:
+
+---
+### `x`
+
+X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the view attached to the handler. Expressed in point units.
+
+---
+### `y`
+
+Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the view attached to the handler. Expressed in point units.
+
+---
+### `absoluteX`
+
+X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
+
+---
+### `absoluteY`
+
+Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
 
 ## Example
 

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -170,12 +170,20 @@ declare module 'react-native-gesture-handler' {
 
   export interface FlingGestureHandlerStateChangeEvent
     extends GestureHandlerStateChangeEvent {
-    nativeEvent: GestureHandlerStateChangeNativeEvent;
+    nativeEvent: GestureHandlerStateChangeNativeEvent &
+      FlingGestureHandlerEventExtra;
   }
 
   export interface FlingGestureHandlerGestureEvent
     extends GestureHandlerGestureEvent {
     nativeEvent: GestureHandlerGestureEventNativeEvent;
+  }
+
+  interface FlingGestureHandlerEventExtra {
+    x: number;
+    y: number;
+    absoluteX: number;
+    absoluteY: number;
   }
 
   /* GESTURE HANDLERS PROPERTIES */

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -94,6 +94,19 @@ declare module 'react-native-gesture-handler' {
       TapGestureHandlerEventExtra;
   }
 
+  export interface LongPressGestureHandlerStateChangeEvent
+    extends GestureHandlerStateChangeEvent {
+    nativeEvent: GestureHandlerStateChangeNativeEvent &
+      LongPressGestureHandlerEventExtra;
+  }
+
+  interface LongPressGestureHandlerEventExtra {
+    x: number;
+    y: number;
+    absoluteX: number;
+    absoluteY: number;
+  }
+
   interface PanGestureHandlerEventExtra {
     x: number;
     y: number;
@@ -212,7 +225,7 @@ declare module 'react-native-gesture-handler' {
     minDurationMs?: number;
     maxDist?: number;
     onGestureEvent?: (event: GestureHandlerGestureEvent) => void;
-    onHandlerStateChange?: (event: GestureHandlerStateChangeEvent) => void;
+    onHandlerStateChange?: (event: LongPressGestureHandlerStateChangeEvent) => void;
   }
 
   export interface PanGestureHandlerProperties extends GestureHandlerProperties {


### PR DESCRIPTION
Related to https://github.com/kmagiera/react-native-gesture-handler/issues/270
## Motivation 
There was a need ot implement `absoluteX`, `absoluteY`, `x` and `y` on Android in js event payload. 
It is already done on iOS.

## Changes
I found it already done for Tap, but it was not documented.

I decided to move it to `GestureHandler.java` as the mechanism of calculating values is the same.
However, we do not provide support for `Rotation`, because it has no sense and is not done on iOS. So I decided no to export these fields to JS in case of rotation GH 

Add docs.