### PR TITLE
Add support for hitSlop on buttons on iOS

### DIFF
--- a/ios/RNGestureHandlerButton.h
+++ b/ios/RNGestureHandlerButton.h
@@ -9,4 +9,10 @@
 #import "RNGestureHandler.h"
 
 @interface RNGestureHandlerButton : UIControl
+
+/**
+ *  Insets used when hit testing inside this view.
+ */
+@property (nonatomic, assign) UIEdgeInsets hitTestEdgeInsets;
+
 @end

--- a/ios/RNGestureHandlerButton.m
+++ b/ios/RNGestureHandlerButton.m
@@ -33,9 +33,27 @@
  */
 @implementation RNGestureHandlerButton
 
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _hitTestEdgeInsets = UIEdgeInsetsZero;
+  }
+  return self;
+}
+
 - (BOOL)shouldHandleTouch:(UIView *)view
 {
     return [view isKindOfClass:[UIControl class]] || [view.gestureRecognizers count] > 0;
+}
+
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
+{
+  if (UIEdgeInsetsEqualToEdgeInsets(self.hitTestEdgeInsets, UIEdgeInsetsZero)) {
+    return [super pointInside:point withEvent:event];
+  }
+  CGRect hitFrame = UIEdgeInsetsInsetRect(self.bounds, self.hitTestEdgeInsets);
+  return CGRectContainsPoint(hitFrame, point);
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -27,6 +27,16 @@ RCT_EXPORT_MODULE(RNGestureHandlerButton)
 
 RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 
+RCT_CUSTOM_VIEW_PROPERTY(hitSlop, UIEdgeInsets, RNGestureHandlerButton)
+{
+  if (json) {
+    UIEdgeInsets hitSlopInsets = [RCTConvert UIEdgeInsets:json];
+    view.hitTestEdgeInsets = UIEdgeInsetsMake(-hitSlopInsets.top, -hitSlopInsets.left, -hitSlopInsets.bottom, -hitSlopInsets.right);
+  } else {
+    view.hitTestEdgeInsets = defaultView.hitTestEdgeInsets;
+  }
+}
+
 - (UIView *)view
 {
     return [RNGestureHandlerButton new];


### PR DESCRIPTION
This adds support for `hitSlop` for buttons on iOS. Android already has support for it. This is pretty much a copy paste from the implementation in `RCTView`.

Ideally we'd be able to reuse some of that code for support for things like border but I can't really think of a good solution if we want to use `UIButton`. `hitSlop` is pretty important to add since we cannot work around it by adding an extra view (like we can for things like border).

**Test plan**
Tested these changes in an app and made sure hit slop affected properly the touch area of a Button.