### PR TITLE
Filter animated events in config

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -109,7 +109,7 @@ const stateToPropMappings = {
   [State.END]: 'onEnded',
 };
 
-function isEventHandler(param, name) {
+function isConfigParam(param, name) {
   return (
     param !== undefined &&
     typeof param !== 'function' &&
@@ -139,7 +139,7 @@ function filterConfig(props, validProps, defaults = {}) {
   const res = { ...defaults };
   Object.keys(validProps).forEach(key => {
     const value = props[key];
-    if (isEventHandler(value, key)) {
+    if (isConfigParam(value, key)) {
       let value = props[key];
       if (key === 'simultaneousHandlers' || key === 'waitFor') {
         value = transformIntoHandlerTags(props[key]);

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -147,7 +147,7 @@ function filterConfig(props, validProps, defaults = {}) {
         }
       } else if ((key === 'onHandlerStateChange' || key === 'onGestureEvent') && value.__nodeID) {
         // reanimated
-        value = undefined
+        value = undefined;
       }
       res[key] = value;
     }

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -109,11 +109,13 @@ const stateToPropMappings = {
   [State.END]: 'onEnded',
 };
 
-function canUseNativeParam(param) {
+function isEventHandler(param, name) {
   return (
     param !== undefined &&
     typeof param !== 'function' &&
-    (typeof param !== 'object' || !('__isNative' in param))
+    (typeof param !== 'object' || !('__isNative' in param)) &&
+    name !== 'onHandlerStateChange' &&
+    name !== 'onGestureEvent'
   );
 }
 
@@ -137,7 +139,7 @@ function filterConfig(props, validProps, defaults = {}) {
   const res = { ...defaults };
   Object.keys(validProps).forEach(key => {
     const value = props[key];
-    if (canUseNativeParam(value)) {
+    if (isEventHandler(value, key)) {
       let value = props[key];
       if (key === 'simultaneousHandlers' || key === 'waitFor') {
         value = transformIntoHandlerTags(props[key]);
@@ -145,8 +147,6 @@ function filterConfig(props, validProps, defaults = {}) {
         if (typeof value !== 'object') {
           value = { top: value, left: value, bottom: value, right: value };
         }
-      } else if (key === 'onHandlerStateChange' || key === 'onGestureEvent') {
-        value = undefined;
       }
       res[key] = value;
     }

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -145,8 +145,7 @@ function filterConfig(props, validProps, defaults = {}) {
         if (typeof value !== 'object') {
           value = { top: value, left: value, bottom: value, right: value };
         }
-      } else if ((key === 'onHandlerStateChange' || key === 'onGestureEvent') && value.__nodeID) {
-        // reanimated
+      } else if (key === 'onHandlerStateChange' || key === 'onGestureEvent') {
         value = undefined;
       }
       res[key] = value;

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -145,6 +145,9 @@ function filterConfig(props, validProps, defaults = {}) {
         if (typeof value !== 'object') {
           value = { top: value, left: value, bottom: value, right: value };
         }
+      } else if ((key === 'onHandlerStateChange' || key === 'onGestureEvent') && value.__nodeID) {
+        // reanimated
+        value = undefined
       }
       res[key] = value;
     }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "husky": "^0.14.3",
     "jest": "16.0.2",
     "jest-react-native": "16.0.0",
-    "lint-staged": "^7.2.0",
+    "lint-staged": "^8.0.0-beta.1",
     "prettier": "^1.13.7",
     "react": "^16.0.0",
     "react-native": "^0.50.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,16 +117,16 @@ any-observable@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
 
+any-promise@^1.0.0, any-promise@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+
 anymatch@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
   dependencies:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
-
-app-root-path@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.1.0.tgz#98bf6599327ecea199309866e8140368fd2e646a"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -234,6 +234,10 @@ assert-plus@^0.2.0:
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+
+async-exit-hook@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz#8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3"
 
 async@1.x, async@^1.4.0:
   version "1.5.2"
@@ -2089,11 +2093,27 @@ fs-extra@^1.0.0:
     jsonfile "^2.1.0"
     klaw "^1.0.0"
 
+fs-extra@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
   dependencies:
     minipass "^2.2.1"
+
+fs-promise@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fs-promise/-/fs-promise-2.0.3.tgz#f64e4f854bcf689aa8bddcba268916db3db46854"
+  dependencies:
+    any-promise "^1.3.0"
+    fs-extra "^2.0.0"
+    mz "^2.6.0"
+    thenify-all "^1.6.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2957,14 +2977,14 @@ jest-util@^16.0.2:
     jest-mock "^16.0.2"
     mkdirp "^0.5.1"
 
-jest-validate@^23.0.0:
-  version "23.3.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.3.0.tgz#d49bea6aad98c30acd2cbb542434798a0cc13f76"
+jest-validate@^23.5.0:
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.6.0.tgz#36761f99d1ed33fcd425b4e4c5595d62b6597474"
   dependencies:
     chalk "^2.0.1"
     jest-get-type "^22.1.0"
     leven "^2.1.0"
-    pretty-format "^23.2.0"
+    pretty-format "^23.6.0"
 
 jest@16.0.2:
   version "16.0.2"
@@ -3122,11 +3142,11 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lint-staged@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.2.0.tgz#bdf4bb7f2f37fe689acfaec9999db288a5b26888"
+lint-staged@^8.0.0-beta.1:
+  version "8.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-8.0.0-beta.1.tgz#1bc554e3002e78b1b1bfa9730b4ab25496fe8cee"
   dependencies:
-    app-root-path "^2.0.1"
+    async-exit-hook "^2.0.1"
     chalk "^2.3.1"
     commander "^2.14.1"
     cosmiconfig "^5.0.2"
@@ -3134,9 +3154,10 @@ lint-staged@^7.2.0:
     dedent "^0.7.0"
     execa "^0.9.0"
     find-parent-dir "^0.3.0"
+    fs-promise "^2.0.3"
     is-glob "^4.0.0"
     is-windows "^1.0.2"
-    jest-validate "^23.0.0"
+    jest-validate "^23.5.0"
     listr "^0.14.1"
     lodash "^4.17.5"
     log-symbols "^2.2.0"
@@ -3699,6 +3720,14 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
+mz@^2.6.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
 nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
@@ -4179,9 +4208,9 @@ prettier@^1.13.7:
   version "1.13.7"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
 
-pretty-format@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.2.0.tgz#3b0aaa63c018a53583373c1cb3a5d96cc5e83017"
+pretty-format@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -5120,6 +5149,18 @@ test-exclude@^2.1.1:
 testcheck@^0.1.0:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/testcheck/-/testcheck-0.1.4.tgz#90056edd48d11997702616ce6716f197d8190164"
+
+thenify-all@^1.0.0, thenify-all@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
+  dependencies:
+    any-promise "^1.0.0"
 
 throat@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
There's no need to send reanimated and animated nodes in config.
Now the issue of freezing reanimated nodes is solved! 

Updated lint-staged. It's not so important