### PR TITLE
Add `activeOpacity` definition to RectButtonProperties

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -321,6 +321,7 @@ declare module 'react-native-gesture-handler' {
 
   export interface RectButtonProperties extends BaseButtonProperties {
     underlayColor?: string;
+    activeOpacity?: number;
   }
 
   export interface BorderlessButtonProperties extends BaseButtonProperties {


### PR DESCRIPTION
As per https://kmagiera.github.io/react-native-gesture-handler/docs/component-buttons.html, `activeOpacity` exists as a prop for `RectButton`.