### PR TITLE
Unify PanGestureHandler activation/fail criteria

### DIFF
--- a/Example/panAndScroll/index.js
+++ b/Example/panAndScroll/index.js
@@ -51,7 +51,7 @@ export class TapOrPan extends Component {
         <Animated.View style={styles.wrapper}>
           <PanGestureHandler
             ref={panRef}
-            minDeltaX={20}
+            activeOffsetX={[-20, 20]}
             onGestureEvent={this._onPanGestureEvent}
             shouldCancelWhenOutside>
             <Animated.View style={styles.horizontalPan}>

--- a/Example/rows/index.js
+++ b/Example/rows/index.js
@@ -93,7 +93,7 @@ export class Swipeable extends Component {
         </Animated.View>
         <PanGestureHandler
           {...this.props}
-          minDeltaX={10}
+          activeOffsetX={[-10, 10]}
           onGestureEvent={this._onGestureEvent}
           onHandlerStateChange={this._onHandlerStateChange}>
           <Animated.View
@@ -183,7 +183,8 @@ export default class Example extends Component {
           </Swipeable>
           <LongPressGestureHandler
             onHandlerStateChange={({ nativeEvent }) =>
-              nativeEvent.state === State.ACTIVE && Alert.alert('Long')}>
+              nativeEvent.state === State.ACTIVE && Alert.alert('Long')
+            }>
             <RectButton
               style={styles.rectButton}
               onPress={() => Alert.alert('Fifth row clicked')}>

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -154,13 +154,10 @@ function filterConfig(props, validProps, defaults = {}) {
   return res;
 }
 function backwardCompatibleTransformProps(handlerName, props) {
-  console.warn('XX');
   const res = {};
   if (handlerName === 'PanGestureHandler') {
-    console.warn('XX2');
     // TODO inv
     if (props.minDeltaX) {
-      console.warn('XXX');
       res.minOffsetRangeStartX = -props.minDeltaX;
       res.minOffsetRangeEndX = props.minDeltaX;
     }

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -412,22 +412,22 @@ function backwardCompatibleTransformPanProps(props) {
   if (__DEV__) {
     if (props.minDeltaX && props.activeOffsetX) {
       throw new Error(
-        `It's not supported use minDeltaX with activeOffsetStartX or activeOffsetEndX`
+        `It's not supported use minDeltaX with activeOffsetXStart or activeOffsetXEnd`
       );
     }
     if (props.maxDeltaX && props.failOffsetX) {
       throw new Error(
-        `It's not supported use minDeltaX with activeOffsetStartX or activeOffsetEndX`
+        `It's not supported use minDeltaX with activeOffsetXStart or activeOffsetXEnd`
       );
     }
     if (props.minDeltaY && props.activeOffsetY) {
       throw new Error(
-        `It's not supported use minDeltaX with activeOffsetStartY or activeOffsetEndY`
+        `It's not supported use minDeltaX with activeOffsetYStart or activeOffsetYEnd`
       );
     }
     if (props.maxDeltaY && props.failOffsetY) {
       throw new Error(
-        `It's not supported use minDeltaX with activeOffsetStartY or activeOffsetEndY`
+        `It's not supported use minDeltaX with activeOffsetYStart or activeOffsetYEnd`
       );
     }
     if (
@@ -467,79 +467,79 @@ function backwardCompatibleTransformPanProps(props) {
     }
   }
   if (props.minDeltaX) {
-    res.activeOffsetStartX = -props.minDeltaX;
-    res.activeOffsetEndX = props.minDeltaX;
+    res.activeOffsetXStart = -props.minDeltaX;
+    res.activeOffsetXEnd = props.minDeltaX;
   }
   if (props.maxDeltaX) {
-    res.failOffsetStartX = -props.maxDeltaX;
-    res.failOffsetEndX = props.maxDeltaX;
+    res.failOffsetXStart = -props.maxDeltaX;
+    res.failOffsetXEnd = props.maxDeltaX;
   }
   if (props.minOffsetX) {
     if (props.minOffsetX < 0) {
-      res.activeOffsetStartX = props.minOffsetX;
+      res.activeOffsetXStart = props.minOffsetX;
     } else {
-      res.activeOffsetEndX = props.minOffsetX;
+      res.activeOffsetXEnd = props.minOffsetX;
     }
   }
 
   if (props.minDeltaY) {
-    res.activeOffsetStartY = -props.minDeltaY;
-    res.activeOffsetEndY = props.minDeltaY;
+    res.activeOffsetYStart = -props.minDeltaY;
+    res.activeOffsetYEnd = props.minDeltaY;
   }
   if (props.maxDeltaY) {
-    res.failOffsetStartY = -props.maxDeltaY;
-    res.failOffsetEndY = props.maxDeltaY;
+    res.failOffsetYStart = -props.maxDeltaY;
+    res.failOffsetYEnd = props.maxDeltaY;
   }
 
   if (props.minOffsetY) {
     if (props.minOffsetY < 0) {
-      res.activeOffsetStartY = props.minOffsetY;
+      res.activeOffsetYStart = props.minOffsetY;
     } else {
-      res.activeOffsetEndY = props.minOffsetY;
+      res.activeOffsetYEnd = props.minOffsetY;
     }
   }
 
   if (props.activeOffsetX) {
     if (Array.isArray(props.activeOffsetX)) {
-      res.activeOffsetStartX = props.activeOffsetX[0];
-      res.activeOffsetEndX = props.activeOffsetX[1];
+      res.activeOffsetXStart = props.activeOffsetX[0];
+      res.activeOffsetXEnd = props.activeOffsetX[1];
     } else if (props.activeOffsetX < 0) {
-      res.activeOffsetStartX = props.activeOffsetX;
+      res.activeOffsetXStart = props.activeOffsetX;
     } else {
-      res.activeOffsetEndX = props.activeOffsetX;
+      res.activeOffsetXEnd = props.activeOffsetX;
     }
   }
 
   if (props.activeOffsetY) {
     if (Array.isArray(props.activeOffsetY)) {
-      res.activeOffsetStartY = props.activeOffsetY[0];
-      res.activeOffsetEndY = props.activeOffsetY[1];
+      res.activeOffsetYStart = props.activeOffsetY[0];
+      res.activeOffsetYEnd = props.activeOffsetY[1];
     } else if (props.activeOffsetY < 0) {
-      res.activeOffsetStartY = props.activeOffsetY;
+      res.activeOffsetYStart = props.activeOffsetY;
     } else {
-      res.activeOffsetEndY = props.activeOffsetY;
+      res.activeOffsetYEnd = props.activeOffsetY;
     }
   }
 
   if (props.failOffsetX) {
     if (Array.isArray(props.failOffsetX)) {
-      res.failOffsetStartX = props.failOffsetX[0];
-      res.failOffsetEndX = props.failOffsetX[1];
+      res.failOffsetXStart = props.failOffsetX[0];
+      res.failOffsetXEnd = props.failOffsetX[1];
     } else if (props.failOffsetX < 0) {
-      res.failOffsetStartX = props.failOffsetX;
+      res.failOffsetXStart = props.failOffsetX;
     } else {
-      res.failOffsetEndX = props.failOffsetX;
+      res.failOffsetXEnd = props.failOffsetX;
     }
   }
 
   if (props.failOffsetY) {
     if (Array.isArray(props.failOffsetY)) {
-      res.failOffsetStartY = props.failOffsetY[0];
-      res.failOffsetEndY = props.failOffsetY[1];
+      res.failOffsetYStart = props.failOffsetY[0];
+      res.failOffsetYEnd = props.failOffsetY[1];
     } else if (props.failOffsetY < 0) {
-      res.failOffsetStartY = props.failOffsetY;
+      res.failOffsetYStart = props.failOffsetY;
     } else {
-      res.failOffsetEndY = props.failOffsetY;
+      res.failOffsetYEnd = props.failOffsetY;
     }
   }
 
@@ -576,14 +576,14 @@ const PanGestureHandler = createHandler(
   {},
   backwardCompatibleTransformPanProps,
   {
-    activeOffsetStartY: true,
-    activeOffsetEndY: true,
-    activeOffsetStartX: true,
-    activeOffsetEndX: true,
-    failOffsetStartY: true,
-    failOffsetEndY: true,
-    failOffsetStartX: true,
-    failOffsetEndX: true,
+    activeOffsetYStart: true,
+    activeOffsetYEnd: true,
+    activeOffsetXStart: true,
+    activeOffsetXEnd: true,
+    failOffsetYStart: true,
+    failOffsetYEnd: true,
+    failOffsetXStart: true,
+    failOffsetXEnd: true,
   }
 );
 const PinchGestureHandler = createHandler('PinchGestureHandler', {}, {});

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -156,7 +156,6 @@ function filterConfig(props, validProps, defaults = {}) {
 function backwardCompatibleTransformProps(handlerName, props) {
   const res = {};
   if (handlerName === 'PanGestureHandler') {
-    // TODO inv
     if (props.minDeltaX) {
       if (props.minOffsetRangeStartX || props.minOffsetRangeEndX) {
         throw new Error(

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -42,7 +42,7 @@ UIManager.clearJSResponder = () => {
   oldClearJSResponder();
 };
 
-// Add gesture spacific events to RCTView's directEventTypes object exported via UIManager.
+// Add gesture specific events to RCTView's directEventTypes object exported via UIManager.
 // Once new event types are registered with react it is possible to dispatch these to other
 // view types as well.
 UIManager.RCTView.directEventTypes = {
@@ -158,10 +158,20 @@ function backwardCompatibleTransformProps(handlerName, props) {
   if (handlerName === 'PanGestureHandler') {
     // TODO inv
     if (props.minDeltaX) {
+      if (props.minOffsetRangeStartX || props.minOffsetRangeEndX) {
+        throw new Error(
+          `It's not supported use minDeltaX with minOffsetRangeStartX or minOffsetRangeEndX`
+        );
+      }
       res.minOffsetRangeStartX = -props.minDeltaX;
       res.minOffsetRangeEndX = props.minDeltaX;
     }
     if (props.maxDeltaX) {
+      if (props.maxOffsetRangeStartX || props.maxOffsetRangeEndX) {
+        throw new Error(
+          `It's not supported use maxDeltaX with maxOffsetRangeStartX or maxOffsetRangeEndX`
+        );
+      }
       res.maxOffsetRangeStartX = -props.maxDeltaX;
       res.maxOffsetRangeEndX = props.maxDeltaX;
     }
@@ -174,10 +184,20 @@ function backwardCompatibleTransformProps(handlerName, props) {
     }
 
     if (props.minDeltaY) {
+      if (props.minOffsetRangeStartY || props.minOffsetRangeEndY) {
+        throw new Error(
+          `It's not supported use minDeltaY with minOffsetRangeStartY or minOffsetRangeEndY`
+        );
+      }
       res.minOffsetRangeStartY = -props.minDeltaY;
       res.minOffsetRangeEndY = props.minDeltaY;
     }
     if (props.maxDeltaY) {
+      if (props.maxOffsetRangeStartY || props.maxOffsetRangeEndY) {
+        throw new Error(
+          `It's not supported use maxDeltaY with maxOffsetRangeStartY or maxOffsetRangeEndY`
+        );
+      }
       res.maxOffsetRangeStartY = -props.maxDeltaY;
       res.maxOffsetRangeEndY = props.maxDeltaY;
     }
@@ -326,7 +346,7 @@ function createHandler(handlerName, propTypes = null, config = {}) {
       let gestureEventHandler = this._onGestureHandlerEvent;
       const { onGestureEvent, onGestureHandlerEvent } = this.props;
       if (onGestureEvent && typeof onGestureEvent !== 'function') {
-        // If it's not a mathod it should be an native Animated.event
+        // If it's not a method it should be an native Animated.event
         // object. We set it directly as the handler for the view
         // In this case nested handlers are not going to be supported
         if (onGestureHandlerEvent) {

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -157,54 +157,54 @@ function backwardCompatibleTransformProps(handlerName, props) {
   const res = {};
   if (handlerName === 'PanGestureHandler') {
     if (props.minDeltaX) {
-      if (props.minOffsetRangeStartX || props.minOffsetRangeEndX) {
+      if (props.activeOffsetStartX || props.activeOffsetEndX) {
         throw new Error(
-          `It's not supported use minDeltaX with minOffsetRangeStartX or minOffsetRangeEndX`
+          `It's not supported use minDeltaX with activeOffsetStartX or activeOffsetEndX`
         );
       }
-      res.minOffsetRangeStartX = -props.minDeltaX;
-      res.minOffsetRangeEndX = props.minDeltaX;
+      res.activeOffsetStartX = -props.minDeltaX;
+      res.activeOffsetEndX = props.minDeltaX;
     }
     if (props.maxDeltaX) {
-      if (props.maxOffsetRangeStartX || props.maxOffsetRangeEndX) {
+      if (props.failOffsetStartX || props.failOffsetEndX) {
         throw new Error(
-          `It's not supported use maxDeltaX with maxOffsetRangeStartX or maxOffsetRangeEndX`
+          `It's not supported use maxDeltaX with failOffsetStartX or failOffsetEndX`
         );
       }
-      res.maxOffsetRangeStartX = -props.maxDeltaX;
-      res.maxOffsetRangeEndX = props.maxDeltaX;
+      res.failOffsetStartX = -props.maxDeltaX;
+      res.failOffsetEndX = props.maxDeltaX;
     }
     if (props.minOffsetX) {
       if (props.minOffsetX < 0) {
-        res.minOffsetRangeStartX = props.minOffsetX;
+        res.activeOffsetStartX = props.minOffsetX;
       } else {
-        res.minOffsetRangeEndX = props.minOffsetX;
+        res.activeOffsetEndX = props.minOffsetX;
       }
     }
 
     if (props.minDeltaY) {
-      if (props.minOffsetRangeStartY || props.minOffsetRangeEndY) {
+      if (props.activeOffsetStartY || props.activeOffsetEndY) {
         throw new Error(
-          `It's not supported use minDeltaY with minOffsetRangeStartY or minOffsetRangeEndY`
+          `It's not supported use minDeltaY with activeOffsetStartY or activeOffsetEndY`
         );
       }
-      res.minOffsetRangeStartY = -props.minDeltaY;
-      res.minOffsetRangeEndY = props.minDeltaY;
+      res.activeOffsetStartY = -props.minDeltaY;
+      res.activeOffsetEndY = props.minDeltaY;
     }
     if (props.maxDeltaY) {
-      if (props.maxOffsetRangeStartY || props.maxOffsetRangeEndY) {
+      if (props.failOffsetStartY || props.failOffsetEndY) {
         throw new Error(
-          `It's not supported use maxDeltaY with maxOffsetRangeStartY or maxOffsetRangeEndY`
+          `It's not supported use maxDeltaY with failOffsetStartY or failOffsetEndY`
         );
       }
-      res.maxOffsetRangeStartY = -props.maxDeltaY;
-      res.maxOffsetRangeEndY = props.maxDeltaY;
+      res.failOffsetStartY = -props.maxDeltaY;
+      res.failOffsetEndY = props.maxDeltaY;
     }
     if (props.minOffsetY) {
       if (props.minOffsetY < 0) {
-        res.minOffsetRangeStartY = props.minOffsetY;
+        res.activeOffsetStartY = props.minOffsetY;
       } else {
-        res.minOffsetRangeEndY = props.minOffsetY;
+        res.activeOffsetEndY = props.minOffsetY;
       }
     }
   }
@@ -459,14 +459,14 @@ const LongPressGestureHandler = createHandler(
 const PanGestureHandler = createHandler(
   'PanGestureHandler',
   {
-    minOffsetRangeStartX: PropTypes.number,
-    minOffsetRangeEndX: PropTypes.number,
-    maxOffsetRangeStartX: PropTypes.number,
-    maxOffsetRangeEndX: PropTypes.number,
-    minOffsetRangeStartY: PropTypes.number,
-    minOffsetRangeEndY: PropTypes.number,
-    maxOffsetRangeStartY: PropTypes.number,
-    maxOffsetRangeEndY: PropTypes.number,
+    activeOffsetStartX: PropTypes.number,
+    activeOffsetEndX: PropTypes.number,
+    failOffsetStartX: PropTypes.number,
+    failOffsetEndX: PropTypes.number,
+    activeOffsetStartY: PropTypes.number,
+    activeOffsetEndY: PropTypes.number,
+    failOffsetStartY: PropTypes.number,
+    failOffsetEndY: PropTypes.number,
     minDist: PropTypes.number,
     minVelocity: PropTypes.number,
     minVelocityX: PropTypes.number,

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -407,65 +407,66 @@ const LongPressGestureHandler = createHandler(
   {}
 );
 
-function backwardCompatibleTransformPanProps(props) {
-  const res = {};
-  if (__DEV__) {
-    if (props.minDeltaX && props.activeOffsetX) {
-      throw new Error(
-        `It's not supported use minDeltaX with activeOffsetXStart or activeOffsetXEnd`
-      );
-    }
-    if (props.maxDeltaX && props.failOffsetX) {
-      throw new Error(
-        `It's not supported use minDeltaX with activeOffsetXStart or activeOffsetXEnd`
-      );
-    }
-    if (props.minDeltaY && props.activeOffsetY) {
-      throw new Error(
-        `It's not supported use minDeltaX with activeOffsetYStart or activeOffsetYEnd`
-      );
-    }
-    if (props.maxDeltaY && props.failOffsetY) {
-      throw new Error(
-        `It's not supported use minDeltaX with activeOffsetYStart or activeOffsetYEnd`
-      );
-    }
-    if (
-      Array.isArray(props.activeOffsetX) &&
-      (props.activeOffsetX[0] > 0 || props.activeOffsetX[1] < 0)
-    ) {
-      throw new Error(
-        `First element of activeOffsetX should be negative, a the second one should be positive`
-      );
-    }
-
-    if (
-      Array.isArray(props.activeOffsetY) &&
-      (props.activeOffsetY[0] > 0 || props.activeOffsetX[1] < 0)
-    ) {
-      throw new Error(
-        `First element of activeOffsetY should be negative, a the second one should be positive`
-      );
-    }
-
-    if (
-      Array.isArray(props.failOffsetX) &&
-      (props.failOffsetX[0] > 0 || props.failOffsetX[1] < 0)
-    ) {
-      throw new Error(
-        `First element of failOffsetX should be negative, a the second one should be positive`
-      );
-    }
-
-    if (
-      Array.isArray(props.failOffsetY) &&
-      (props.failOffsetY[0] > 0 || props.failOffsetX[1] < 0)
-    ) {
-      throw new Error(
-        `First element of failOffsetY should be negative, a the second one should be positive`
-      );
-    }
+function validatePanGestureHandlerProps(props) {
+  if (props.minDeltaX && props.activeOffsetX) {
+    throw new Error(
+      `It's not supported use minDeltaX with activeOffsetXStart or activeOffsetXEnd`
+    );
   }
+  if (props.maxDeltaX && props.failOffsetX) {
+    throw new Error(
+      `It's not supported use minDeltaX with activeOffsetXStart or activeOffsetXEnd`
+    );
+  }
+  if (props.minDeltaY && props.activeOffsetY) {
+    throw new Error(
+      `It's not supported use minDeltaX with activeOffsetYStart or activeOffsetYEnd`
+    );
+  }
+  if (props.maxDeltaY && props.failOffsetY) {
+    throw new Error(
+      `It's not supported use minDeltaX with activeOffsetYStart or activeOffsetYEnd`
+    );
+  }
+  if (
+    Array.isArray(props.activeOffsetX) &&
+    (props.activeOffsetX[0] > 0 || props.activeOffsetX[1] < 0)
+  ) {
+    throw new Error(
+      `First element of activeOffsetX should be negative, a the second one should be positive`
+    );
+  }
+
+  if (
+    Array.isArray(props.activeOffsetY) &&
+    (props.activeOffsetY[0] > 0 || props.activeOffsetX[1] < 0)
+  ) {
+    throw new Error(
+      `First element of activeOffsetY should be negative, a the second one should be positive`
+    );
+  }
+
+  if (
+    Array.isArray(props.failOffsetX) &&
+    (props.failOffsetX[0] > 0 || props.failOffsetX[1] < 0)
+  ) {
+    throw new Error(
+      `First element of failOffsetX should be negative, a the second one should be positive`
+    );
+  }
+
+  if (
+    Array.isArray(props.failOffsetY) &&
+    (props.failOffsetY[0] > 0 || props.failOffsetX[1] < 0)
+  ) {
+    throw new Error(
+      `First element of failOffsetY should be negative, a the second one should be positive`
+    );
+  }
+}
+
+function transformPanGestureHandlerProps(props) {
+  const res = {};
   if (props.minDeltaX) {
     res.activeOffsetXStart = -props.minDeltaX;
     res.activeOffsetXEnd = props.minDeltaX;
@@ -546,6 +547,13 @@ function backwardCompatibleTransformPanProps(props) {
   return res;
 }
 
+function managePanProps(props) {
+  if (__DEV__) {
+    validatePanGestureHandlerProps(props);
+  }
+  return transformPanGestureHandlerProps(props);
+}
+
 const PanGestureHandler = createHandler(
   'PanGestureHandler',
   {
@@ -574,7 +582,7 @@ const PanGestureHandler = createHandler(
     avgTouches: PropTypes.bool,
   },
   {},
-  backwardCompatibleTransformPanProps,
+  managePanProps,
   {
     activeOffsetYStart: true,
     activeOffsetYEnd: true,

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -153,6 +153,47 @@ function filterConfig(props, validProps, defaults = {}) {
   });
   return res;
 }
+function backwardCompatibleTransformProps(handlerName, props) {
+  console.warn('XX');
+  const res = {};
+  if (handlerName === 'PanGestureHandler') {
+    console.warn('XX2');
+    // TODO inv
+    if (props.minDeltaX) {
+      console.warn('XXX');
+      res.minOffsetRangeStartX = -props.minDeltaX;
+      res.minOffsetRangeEndX = props.minDeltaX;
+    }
+    if (props.maxDeltaX) {
+      res.maxOffsetRangeStartX = -props.maxDeltaX;
+      res.maxOffsetRangeEndX = props.maxDeltaX;
+    }
+    if (props.minOffsetX) {
+      if (props.minOffsetX < 0) {
+        res.minOffsetRangeStartX = props.minOffsetX;
+      } else {
+        res.minOffsetRangeEndX = props.minOffsetX;
+      }
+    }
+
+    if (props.minDeltaY) {
+      res.minOffsetRangeStartY = -props.minDeltaY;
+      res.minOffsetRangeEndY = props.minDeltaY;
+    }
+    if (props.maxDeltaY) {
+      res.maxOffsetRangeStartY = -props.maxDeltaY;
+      res.maxOffsetRangeEndY = props.maxDeltaY;
+    }
+    if (props.minOffsetY) {
+      if (props.minOffsetY < 0) {
+        res.minOffsetRangeStartY = props.minOffsetY;
+      } else {
+        res.minOffsetRangeEndY = props.minOffsetY;
+      }
+    }
+  }
+  return res;
+}
 
 function hasUnresolvedRefs(props) {
   const extract = refs => {
@@ -233,11 +274,10 @@ function createHandler(handlerName, propTypes = null, config = {}) {
 
     componentDidMount() {
       this._viewTag = findNodeHandle(this._viewNode);
-      this._config = filterConfig(
-        this.props,
-        this.constructor.propTypes,
-        config
-      );
+      this._config = filterConfig(this.props, this.constructor.propTypes, {
+        ...config,
+        ...backwardCompatibleTransformProps(handlerName, this.props),
+      });
       if (hasUnresolvedRefs(this.props)) {
         // If there are unresolved refs (e.g. ".current" has not yet been set)
         // passed as `simultaneousHandlers` or `waitFor`, we enqueue a call to
@@ -403,12 +443,14 @@ const LongPressGestureHandler = createHandler(
 const PanGestureHandler = createHandler(
   'PanGestureHandler',
   {
-    minDeltaX: PropTypes.number,
-    minDeltaY: PropTypes.number,
-    maxDeltaX: PropTypes.number,
-    maxDeltaY: PropTypes.number,
-    minOffsetX: PropTypes.number,
-    minOffsetY: PropTypes.number,
+    minOffsetRangeStartX: PropTypes.number,
+    minOffsetRangeEndX: PropTypes.number,
+    maxOffsetRangeStartX: PropTypes.number,
+    maxOffsetRangeEndX: PropTypes.number,
+    minOffsetRangeStartY: PropTypes.number,
+    minOffsetRangeEndY: PropTypes.number,
+    maxOffsetRangeStartY: PropTypes.number,
+    maxOffsetRangeEndY: PropTypes.number,
     minDist: PropTypes.number,
     minVelocity: PropTypes.number,
     minVelocityX: PropTypes.number,

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
@@ -15,17 +15,17 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
 
   private float mMinDistSq = MAX_VALUE_IGNORE;
 
-  private float mMinOffsetRangeStartX = MIN_VALUE_IGNORE;
-  private float mMinOffsetRangeEndX = MAX_VALUE_IGNORE;
+  private float mActiveOffsetStartX = MIN_VALUE_IGNORE;
+  private float mActiveOffsetEndX = MAX_VALUE_IGNORE;
 
-  private float mMaxOffsetRangeStartX = MAX_VALUE_IGNORE;
-  private float mMaxOffsetRangeEndX = MIN_VALUE_IGNORE;
+  private float mFailOffsetStartX = MAX_VALUE_IGNORE;
+  private float mFailOffsetEndX = MIN_VALUE_IGNORE;
 
-  private float mMinOffsetRangeStartY = MIN_VALUE_IGNORE;
-  private float mMinOffsetRangeEndY = MAX_VALUE_IGNORE;
+  private float mActiveOffsetStartY = MIN_VALUE_IGNORE;
+  private float mActiveOffsetEndY = MAX_VALUE_IGNORE;
 
-  private float mMaxOffsetRangeStartY = MAX_VALUE_IGNORE;
-  private float mMaxOffsetRangeEndY = MIN_VALUE_IGNORE;
+  private float mFailOffsetStartY = MAX_VALUE_IGNORE;
+  private float mFailOffsetEndY = MIN_VALUE_IGNORE;
 
   private float mMinVelocityX = MIN_VALUE_IGNORE;
   private float mMinVelocityY = MIN_VALUE_IGNORE;
@@ -59,43 +59,43 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
     mMinDistSq = touchSlop * touchSlop;
   }
 
-  public PanGestureHandler setMinOffsetRangeStartX(float minOffsetRangeStartX) {
-    mMinOffsetRangeStartX = minOffsetRangeStartX;
+  public PanGestureHandler setactiveOffsetStartX(float activeOffsetStartX) {
+    mActiveOffsetStartX = activeOffsetStartX;
     return this;
   }
 
-  public PanGestureHandler setMinOffsetRangeEndX(float minOffsetRangeEndX) {
-    mMinOffsetRangeEndX = minOffsetRangeEndX;
+  public PanGestureHandler setactiveOffsetEndX(float activeOffsetEndX) {
+    mActiveOffsetEndX = activeOffsetEndX;
     return this;
   }
 
-  public PanGestureHandler setMaxOffsetRangeStartX(float maxOffsetRangeStartX) {
-    mMaxOffsetRangeStartX = maxOffsetRangeStartX;
+  public PanGestureHandler setfailOffsetStartX(float failOffsetStartX) {
+    mFailOffsetStartX = failOffsetStartX;
     return this;
   }
 
-  public PanGestureHandler setMaxOffsetRangeEndX(float maxOffsetRangeEndX) {
-    mMaxOffsetRangeEndX = maxOffsetRangeEndX;
+  public PanGestureHandler setfailOffsetEndX(float failOffsetEndX) {
+    mFailOffsetEndX = failOffsetEndX;
     return this;
   }
 
-  public PanGestureHandler setMinOffsetRangeStartY(float minOffsetRangeStartY) {
-    mMinOffsetRangeStartY = minOffsetRangeStartY;
+  public PanGestureHandler setactiveOffsetStartY(float activeOffsetStartY) {
+    mActiveOffsetStartY = activeOffsetStartY;
     return this;
   }
 
-  public PanGestureHandler setMinOffsetRangeEndY(float minOffsetRangeEndY) {
-    mMinOffsetRangeEndY = minOffsetRangeEndY;
+  public PanGestureHandler setactiveOffsetEndY(float activeOffsetEndY) {
+    mActiveOffsetEndY = activeOffsetEndY;
     return this;
   }
 
-  public PanGestureHandler setMaxOffsetRangeStartY(float maxOffsetRangeStartY) {
-    mMaxOffsetRangeStartY = maxOffsetRangeStartY;
+  public PanGestureHandler setfailOffsetStartY(float failOffsetStartY) {
+    mFailOffsetStartY = failOffsetStartY;
     return this;
   }
 
-  public PanGestureHandler setMaxOffsetRangeEndY(float maxOffsetRangeEndY) {
-    mMaxOffsetRangeEndY = maxOffsetRangeEndY;
+  public PanGestureHandler setfailOffsetEndY(float failOffsetEndY) {
+    mFailOffsetEndY = failOffsetEndY;
     return this;
   }
 
@@ -139,20 +139,20 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
 
   private boolean shouldActivate() {
     float dx = mLastX - mStartX + mOffsetX;
-    if (mMinOffsetRangeStartX != MIN_VALUE_IGNORE && dx <=  mMinOffsetRangeStartX) {
+    if (mActiveOffsetStartX != MIN_VALUE_IGNORE && dx <=  mActiveOffsetStartX) {
       return true;
     }
 
-    if (mMinOffsetRangeEndX != MAX_VALUE_IGNORE && dx >=  mMinOffsetRangeEndX) {
+    if (mActiveOffsetEndX != MAX_VALUE_IGNORE && dx >=  mActiveOffsetEndX) {
       return true;
     }
 
     float dy = mLastY - mStartY + mOffsetY;
-    if (mMinOffsetRangeStartY != MIN_VALUE_IGNORE && dy <=  mMinOffsetRangeStartY) {
+    if (mActiveOffsetStartY != MIN_VALUE_IGNORE && dy <=  mActiveOffsetStartY) {
       return true;
     }
 
-    if (mMinOffsetRangeEndY != MAX_VALUE_IGNORE && dy >=  mMinOffsetRangeEndY) {
+    if (mActiveOffsetEndY != MAX_VALUE_IGNORE && dy >=  mActiveOffsetEndY) {
       return true;
     }
 
@@ -184,21 +184,21 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
   private boolean shouldFail() {
     float dx = mLastX - mStartX + mOffsetX;
 
-    if (mMaxOffsetRangeStartX != MAX_VALUE_IGNORE && dx <=  mMaxOffsetRangeStartX) {
+    if (mFailOffsetStartX != MAX_VALUE_IGNORE && dx <= mFailOffsetStartX) {
       return true;
     }
 
-    if (mMaxOffsetRangeEndX != MIN_VALUE_IGNORE && dx >=  mMaxOffsetRangeEndX) {
+    if (mFailOffsetEndX != MIN_VALUE_IGNORE && dx >=  mFailOffsetEndX) {
       return true;
     }
 
 
     float dy = mLastY - mStartY + mOffsetY;
-    if (mMaxOffsetRangeStartY != MAX_VALUE_IGNORE && dy <=  mMaxOffsetRangeStartY) {
+    if (mFailOffsetStartY != MAX_VALUE_IGNORE && dy <=  mFailOffsetStartY) {
       return true;
     }
 
-    if (mMaxOffsetRangeEndY != MIN_VALUE_IGNORE && dy >=  mMaxOffsetRangeEndY) {
+    if (mFailOffsetEndY != MIN_VALUE_IGNORE && dy >=  mFailOffsetEndY) {
       return true;
     }
 

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
@@ -13,13 +13,20 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
   private static int DEFAULT_MIN_POINTERS = 1;
   private static int DEFAULT_MAX_POINTERS = 10;
 
-  private float mMinOffsetX = MIN_VALUE_IGNORE;
-  private float mMinOffsetY = MIN_VALUE_IGNORE;
-  private float mMinDeltaX = MIN_VALUE_IGNORE;
-  private float mMinDeltaY = MIN_VALUE_IGNORE;
-  private float mMaxDeltaX = MAX_VALUE_IGNORE;
-  private float mMaxDeltaY = MAX_VALUE_IGNORE;
   private float mMinDistSq = MAX_VALUE_IGNORE;
+
+  private float mMinOffsetRangeStartX = MIN_VALUE_IGNORE;
+  private float mMinOffsetRangeEndX = MAX_VALUE_IGNORE;
+
+  private float mMaxOffsetRangeStartX = MAX_VALUE_IGNORE;
+  private float mMaxOffsetRangeEndX = MIN_VALUE_IGNORE;
+
+  private float mMinOffsetRangeStartY = MIN_VALUE_IGNORE;
+  private float mMinOffsetRangeEndY = MAX_VALUE_IGNORE;
+
+  private float mMaxOffsetRangeStartY = MAX_VALUE_IGNORE;
+  private float mMaxOffsetRangeEndY = MIN_VALUE_IGNORE;
+
   private float mMinVelocityX = MIN_VALUE_IGNORE;
   private float mMinVelocityY = MIN_VALUE_IGNORE;
   private float mMinVelocitySq = MIN_VALUE_IGNORE;
@@ -52,33 +59,43 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
     mMinDistSq = touchSlop * touchSlop;
   }
 
-  public PanGestureHandler setMinDx(float deltaX) {
-    mMinDeltaX = deltaX;
+  public PanGestureHandler setMinOffsetRangeStartX(float minOffsetRangeStartX) {
+    mMinOffsetRangeStartX = minOffsetRangeStartX;
     return this;
   }
 
-  public PanGestureHandler setMinDy(float deltaY) {
-    mMinDeltaY = deltaY;
+  public PanGestureHandler setMinOffsetRangeEndX(float minOffsetRangeEndX) {
+    mMinOffsetRangeEndX = minOffsetRangeEndX;
     return this;
   }
 
-  public PanGestureHandler setMaxDx(float deltaX) {
-    mMaxDeltaX = deltaX;
+  public PanGestureHandler setMaxOffsetRangeStartX(float maxOffsetRangeStartX) {
+    mMaxOffsetRangeStartX = maxOffsetRangeStartX;
     return this;
   }
 
-  public PanGestureHandler setMaxDy(float deltaY) {
-    mMaxDeltaY = deltaY;
+  public PanGestureHandler setMaxOffsetRangeEndX(float maxOffsetRangeEndX) {
+    mMaxOffsetRangeEndX = maxOffsetRangeEndX;
     return this;
   }
 
-  public PanGestureHandler setMinOffsetX(float offsetX) {
-    mMinOffsetX = offsetX;
+  public PanGestureHandler setMinOffsetRangeStartY(float minOffsetRangeStartY) {
+    mMinOffsetRangeStartY = minOffsetRangeStartY;
     return this;
   }
 
-  public PanGestureHandler setMinOffsetY(float offsetY) {
-    mMinOffsetY = offsetY;
+  public PanGestureHandler setMinOffsetRangeEndY(float minOffsetRangeEndY) {
+    mMinOffsetRangeEndY = minOffsetRangeEndY;
+    return this;
+  }
+
+  public PanGestureHandler setMaxOffsetRangeStartY(float maxOffsetRangeStartY) {
+    mMaxOffsetRangeStartY = maxOffsetRangeStartY;
+    return this;
+  }
+
+  public PanGestureHandler setMaxOffsetRangeEndY(float maxOffsetRangeEndY) {
+    mMaxOffsetRangeEndY = maxOffsetRangeEndY;
     return this;
   }
 
@@ -122,20 +139,20 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
 
   private boolean shouldActivate() {
     float dx = mLastX - mStartX + mOffsetX;
-    if (mMinDeltaX != MIN_VALUE_IGNORE && Math.abs(dx) >= mMinDeltaX) {
+    if (mMinOffsetRangeStartX != MIN_VALUE_IGNORE && dx <=  mMinOffsetRangeStartX) {
       return true;
     }
-    if (mMinOffsetX != MIN_VALUE_IGNORE &&
-            ((mMinOffsetX < 0 && dx <= mMinOffsetX) || (mMinOffsetX >= 0 && dx >= mMinOffsetX))) {
+
+    if (mMinOffsetRangeEndX != MAX_VALUE_IGNORE && dx >=  mMinOffsetRangeEndX) {
       return true;
     }
 
     float dy = mLastY - mStartY + mOffsetY;
-    if (mMinDeltaY != MIN_VALUE_IGNORE && Math.abs(dy) >= mMinDeltaY) {
+    if (mMinOffsetRangeStartY != MIN_VALUE_IGNORE && dy <=  mMinOffsetRangeStartY) {
       return true;
     }
-    if (mMinOffsetY != MIN_VALUE_IGNORE &&
-            ((mMinOffsetY < 0 && dy <= mMinOffsetY) || (mMinOffsetY >= 0 && dy >= mMinOffsetY))) {
+
+    if (mMinOffsetRangeEndY != MAX_VALUE_IGNORE && dy >=  mMinOffsetRangeEndY) {
       return true;
     }
 
@@ -166,12 +183,22 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
 
   private boolean shouldFail() {
     float dx = mLastX - mStartX + mOffsetX;
-    if (mMaxDeltaX != MAX_VALUE_IGNORE && Math.abs(dx) > mMaxDeltaX) {
+
+    if (mMaxOffsetRangeStartX != MAX_VALUE_IGNORE && dx <=  mMaxOffsetRangeStartX) {
       return true;
     }
 
+    if (mMaxOffsetRangeEndX != MIN_VALUE_IGNORE && dx >=  mMaxOffsetRangeEndX) {
+      return true;
+    }
+
+
     float dy = mLastY - mStartY + mOffsetY;
-    if (mMaxDeltaY != MAX_VALUE_IGNORE && Math.abs(dy) > mMaxDeltaY) {
+    if (mMaxOffsetRangeStartY != MAX_VALUE_IGNORE && dy <=  mMaxOffsetRangeStartY) {
+      return true;
+    }
+
+    if (mMaxOffsetRangeEndY != MIN_VALUE_IGNORE && dy >=  mMaxOffsetRangeEndY) {
       return true;
     }
 

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
@@ -15,17 +15,17 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
 
   private float mMinDistSq = MAX_VALUE_IGNORE;
 
-  private float mActiveOffsetStartX = MIN_VALUE_IGNORE;
-  private float mActiveOffsetEndX = MAX_VALUE_IGNORE;
+  private float mActiveOffsetXStart = MIN_VALUE_IGNORE;
+  private float mActiveOffsetXEnd = MAX_VALUE_IGNORE;
 
-  private float mFailOffsetStartX = MAX_VALUE_IGNORE;
-  private float mFailOffsetEndX = MIN_VALUE_IGNORE;
+  private float mFailOffsetXStart = MAX_VALUE_IGNORE;
+  private float mFailOffsetXEnd = MIN_VALUE_IGNORE;
 
-  private float mActiveOffsetStartY = MIN_VALUE_IGNORE;
-  private float mActiveOffsetEndY = MAX_VALUE_IGNORE;
+  private float mActiveOffsetYStart = MIN_VALUE_IGNORE;
+  private float mActiveOffsetYEnd = MAX_VALUE_IGNORE;
 
-  private float mFailOffsetStartY = MAX_VALUE_IGNORE;
-  private float mFailOffsetEndY = MIN_VALUE_IGNORE;
+  private float mFailOffsetYStart = MAX_VALUE_IGNORE;
+  private float mFailOffsetYEnd = MIN_VALUE_IGNORE;
 
   private float mMinVelocityX = MIN_VALUE_IGNORE;
   private float mMinVelocityY = MIN_VALUE_IGNORE;
@@ -59,43 +59,43 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
     mMinDistSq = touchSlop * touchSlop;
   }
 
-  public PanGestureHandler setactiveOffsetStartX(float activeOffsetStartX) {
-    mActiveOffsetStartX = activeOffsetStartX;
+  public PanGestureHandler setActiveOffsetXStart(float activeOffsetXStart) {
+    mActiveOffsetXStart = activeOffsetXStart;
     return this;
   }
 
-  public PanGestureHandler setactiveOffsetEndX(float activeOffsetEndX) {
-    mActiveOffsetEndX = activeOffsetEndX;
+  public PanGestureHandler setActiveOffsetXEnd(float activeOffsetXEnd) {
+    mActiveOffsetXEnd = activeOffsetXEnd;
     return this;
   }
 
-  public PanGestureHandler setfailOffsetStartX(float failOffsetStartX) {
-    mFailOffsetStartX = failOffsetStartX;
+  public PanGestureHandler setFailOffsetXStart(float failOffsetXStart) {
+    mFailOffsetXStart = failOffsetXStart;
     return this;
   }
 
-  public PanGestureHandler setfailOffsetEndX(float failOffsetEndX) {
-    mFailOffsetEndX = failOffsetEndX;
+  public PanGestureHandler setFailOffsetXEnd(float failOffsetXEnd) {
+    mFailOffsetXEnd = failOffsetXEnd;
     return this;
   }
 
-  public PanGestureHandler setactiveOffsetStartY(float activeOffsetStartY) {
-    mActiveOffsetStartY = activeOffsetStartY;
+  public PanGestureHandler setActiveOffsetYStart(float activeOffsetYStart) {
+    mActiveOffsetYStart = activeOffsetYStart;
     return this;
   }
 
-  public PanGestureHandler setactiveOffsetEndY(float activeOffsetEndY) {
-    mActiveOffsetEndY = activeOffsetEndY;
+  public PanGestureHandler setActiveOffsetYEnd(float activeOffsetYEnd) {
+    mActiveOffsetYEnd = activeOffsetYEnd;
     return this;
   }
 
-  public PanGestureHandler setfailOffsetStartY(float failOffsetStartY) {
-    mFailOffsetStartY = failOffsetStartY;
+  public PanGestureHandler setFailOffsetYStart(float failOffsetYStart) {
+    mFailOffsetYStart = failOffsetYStart;
     return this;
   }
 
-  public PanGestureHandler setfailOffsetEndY(float failOffsetEndY) {
-    mFailOffsetEndY = failOffsetEndY;
+  public PanGestureHandler setFailOffsetYEnd(float failOffsetYEnd) {
+    mFailOffsetYEnd = failOffsetYEnd;
     return this;
   }
 
@@ -139,20 +139,20 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
 
   private boolean shouldActivate() {
     float dx = mLastX - mStartX + mOffsetX;
-    if (mActiveOffsetStartX != MIN_VALUE_IGNORE && dx <=  mActiveOffsetStartX) {
+    if (mActiveOffsetXStart != MIN_VALUE_IGNORE && dx <=  mActiveOffsetXStart) {
       return true;
     }
 
-    if (mActiveOffsetEndX != MAX_VALUE_IGNORE && dx >=  mActiveOffsetEndX) {
+    if (mActiveOffsetXEnd != MAX_VALUE_IGNORE && dx >=  mActiveOffsetXEnd) {
       return true;
     }
 
     float dy = mLastY - mStartY + mOffsetY;
-    if (mActiveOffsetStartY != MIN_VALUE_IGNORE && dy <=  mActiveOffsetStartY) {
+    if (mActiveOffsetYStart != MIN_VALUE_IGNORE && dy <=  mActiveOffsetYStart) {
       return true;
     }
 
-    if (mActiveOffsetEndY != MAX_VALUE_IGNORE && dy >=  mActiveOffsetEndY) {
+    if (mActiveOffsetYEnd != MAX_VALUE_IGNORE && dy >=  mActiveOffsetYEnd) {
       return true;
     }
 
@@ -184,21 +184,21 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
   private boolean shouldFail() {
     float dx = mLastX - mStartX + mOffsetX;
 
-    if (mFailOffsetStartX != MAX_VALUE_IGNORE && dx <= mFailOffsetStartX) {
+    if (mFailOffsetXStart != MAX_VALUE_IGNORE && dx <= mFailOffsetXStart) {
       return true;
     }
 
-    if (mFailOffsetEndX != MIN_VALUE_IGNORE && dx >=  mFailOffsetEndX) {
+    if (mFailOffsetXEnd != MIN_VALUE_IGNORE && dx >=  mFailOffsetXEnd) {
       return true;
     }
 
 
     float dy = mLastY - mStartY + mOffsetY;
-    if (mFailOffsetStartY != MAX_VALUE_IGNORE && dy <=  mFailOffsetStartY) {
+    if (mFailOffsetYStart != MAX_VALUE_IGNORE && dy <=  mFailOffsetYStart) {
       return true;
     }
 
-    if (mFailOffsetEndY != MIN_VALUE_IGNORE && dy >=  mFailOffsetEndY) {
+    if (mFailOffsetYEnd != MIN_VALUE_IGNORE && dy >=  mFailOffsetYEnd) {
       return true;
     }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -62,14 +62,14 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
   private static final String KEY_TAP_MIN_POINTERS = "minPointers";
   private static final String KEY_LONG_PRESS_MIN_DURATION_MS = "minDurationMs";
   private static final String KEY_LONG_PRESS_MAX_DIST = "maxDist";
-  private static final String KEY_PAN_ACTIVE_OFFSET_START_X = "activeOffsetStartX";
-  private static final String KEY_PAN_ACTIVE_OFFSET_END_X = "activeOffsetEndX";
-  private static final String KEY_PAN_FAIL_OFFSET_RANGE_START_X = "failOffsetStartX";
-  private static final String KEY_PAN_FAIL_OFFSET_RANGE_END_X = "failOffsetEndX";
-  private static final String KEY_PAN_ACTIVE_OFFSET_START_Y = "activeOffsetStartY";
-  private static final String KEY_PAN_ACTIVE_OFFSET_END_Y = "activeOffsetEndY";
-  private static final String KEY_PAN_FAIL_OFFSET_RANGE_START_Y = "failOffsetStartY";
-  private static final String KEY_PAN_FAIL_OFFSET_RANGE_END_Y = "failOffsetEndY";
+  private static final String KEY_PAN_ACTIVE_OFFSET_X_START = "activeOffsetXStart";
+  private static final String KEY_PAN_ACTIVE_OFFSET_X_END = "activeOffsetXEnd";
+  private static final String KEY_PAN_FAIL_OFFSET_RANGE_X_START = "failOffsetXStart";
+  private static final String KEY_PAN_FAIL_OFFSET_RANGE_X_END = "failOffsetXEnd";
+  private static final String KEY_PAN_ACTIVE_OFFSET_Y_START = "activeOffsetYStart";
+  private static final String KEY_PAN_ACTIVE_OFFSET_Y_END = "activeOffsetYEnd";
+  private static final String KEY_PAN_FAIL_OFFSET_RANGE_Y_START = "failOffsetYStart";
+  private static final String KEY_PAN_FAIL_OFFSET_RANGE_Y_END = "failOffsetYEnd";
   private static final String KEY_PAN_MIN_DIST = "minDist";
   private static final String KEY_PAN_MIN_VELOCITY = "minVelocity";
   private static final String KEY_PAN_MIN_VELOCITY_X = "minVelocityX";
@@ -253,36 +253,36 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
     public void configure(PanGestureHandler handler, ReadableMap config) {
       super.configure(handler, config);
       boolean hasCustomActivationCriteria = false;
-      if(config.hasKey(KEY_PAN_ACTIVE_OFFSET_START_X)) {
-        handler.setactiveOffsetStartX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_START_X)));
+      if(config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_START)) {
+        handler.setActiveOffsetXStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_X_START)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_ACTIVE_OFFSET_END_X)) {
-        handler.setactiveOffsetEndX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_END_X)));
+      if(config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_END)) {
+        handler.setActiveOffsetXEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_X_END)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_START_X)) {
-        handler.setfailOffsetStartX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_START_X)));
+      if(config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_START)) {
+        handler.setFailOffsetXStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_X_START)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_END_X)) {
-        handler.setfailOffsetEndX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_END_X)));
+      if(config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_END)) {
+        handler.setFailOffsetXEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_X_END)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_ACTIVE_OFFSET_START_Y)) {
-        handler.setactiveOffsetStartY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_START_Y)));
+      if(config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_START)) {
+        handler.setActiveOffsetYStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_Y_START)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_ACTIVE_OFFSET_END_Y)) {
-        handler.setactiveOffsetEndY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_END_Y)));
+      if(config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_END)) {
+        handler.setActiveOffsetYEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_Y_END)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_START_Y)) {
-        handler.setfailOffsetStartY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_START_Y)));
+      if(config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_START)) {
+        handler.setFailOffsetYStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_Y_START)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_END_Y)) {
-        handler.setfailOffsetEndY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_END_Y)));
+      if(config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_END)) {
+        handler.setFailOffsetYEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_Y_END)));
         hasCustomActivationCriteria = true;
       }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -62,12 +62,14 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
   private static final String KEY_TAP_MIN_POINTERS = "minPointers";
   private static final String KEY_LONG_PRESS_MIN_DURATION_MS = "minDurationMs";
   private static final String KEY_LONG_PRESS_MAX_DIST = "maxDist";
-  private static final String KEY_PAN_MIN_DELTA_X = "minDeltaX";
-  private static final String KEY_PAN_MIN_DELTA_Y = "minDeltaY";
-  private static final String KEY_PAN_MAX_DELTA_X = "maxDeltaX";
-  private static final String KEY_PAN_MAX_DELTA_Y = "maxDeltaY";
-  private static final String KEY_PAN_MIN_OFFSET_X = "minOffsetX";
-  private static final String KEY_PAN_MIN_OFFSET_Y = "minOffsetY";
+  private static final String KEY_PAN_MIN_OFFSET_RANGE_START_X = "minOffsetRangeStartX";
+  private static final String KEY_PAN_MIN_OFFSET_RANGE_END_X = "minOffsetRangeEndX";
+  private static final String KEY_PAN_MAX_OFFSET_RANGE_START_X = "maxOffsetRangeStartX";
+  private static final String KEY_PAN_MAX_OFFSET_RANGE_END_X = "maxOffsetRangeEndX";
+  private static final String KEY_PAN_MIN_OFFSET_RANGE_START_Y = "minOffsetRangeStartY";
+  private static final String KEY_PAN_MIN_OFFSET_RANGE_END_Y = "minOffsetRangeEndY";
+  private static final String KEY_PAN_MAX_OFFSET_RANGE_START_Y = "maxOffsetRangeStartY";
+  private static final String KEY_PAN_MAX_OFFSET_RANGE_END_Y = "maxOffsetRangeEndY";
   private static final String KEY_PAN_MIN_DIST = "minDist";
   private static final String KEY_PAN_MIN_VELOCITY = "minVelocity";
   private static final String KEY_PAN_MIN_VELOCITY_X = "minVelocityX";
@@ -251,26 +253,36 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
     public void configure(PanGestureHandler handler, ReadableMap config) {
       super.configure(handler, config);
       boolean hasCustomActivationCriteria = false;
-      if (config.hasKey(KEY_PAN_MIN_DELTA_X)) {
-        handler.setMinDx(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_DELTA_X)));
+      if(config.hasKey(KEY_PAN_MIN_OFFSET_RANGE_START_X)) {
+        handler.setMinOffsetRangeStartX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_OFFSET_RANGE_START_X)));
         hasCustomActivationCriteria = true;
       }
-      if (config.hasKey(KEY_PAN_MIN_DELTA_Y)) {
-        handler.setMinDy(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_DELTA_Y)));
+      if(config.hasKey(KEY_PAN_MIN_OFFSET_RANGE_END_X)) {
+        handler.setMinOffsetRangeEndX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_OFFSET_RANGE_END_X)));
         hasCustomActivationCriteria = true;
       }
-      if (config.hasKey(KEY_PAN_MAX_DELTA_X)) {
-        handler.setMaxDx(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MAX_DELTA_X)));
-      }
-      if (config.hasKey(KEY_PAN_MAX_DELTA_Y)) {
-        handler.setMaxDy(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MAX_DELTA_Y)));
-      }
-      if (config.hasKey(KEY_PAN_MIN_OFFSET_X)) {
-        handler.setMinOffsetX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_OFFSET_X)));
+      if(config.hasKey(KEY_PAN_MAX_OFFSET_RANGE_START_X)) {
+        handler.setMaxOffsetRangeStartX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MAX_OFFSET_RANGE_START_X)));
         hasCustomActivationCriteria = true;
       }
-      if (config.hasKey(KEY_PAN_MIN_OFFSET_Y)) {
-        handler.setMinOffsetY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_OFFSET_Y)));
+      if(config.hasKey(KEY_PAN_MAX_OFFSET_RANGE_END_X)) {
+        handler.setMaxOffsetRangeEndX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MAX_OFFSET_RANGE_END_X)));
+        hasCustomActivationCriteria = true;
+      }
+      if(config.hasKey(KEY_PAN_MIN_OFFSET_RANGE_START_Y)) {
+        handler.setMinOffsetRangeStartY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_OFFSET_RANGE_START_Y)));
+        hasCustomActivationCriteria = true;
+      }
+      if(config.hasKey(KEY_PAN_MIN_OFFSET_RANGE_END_Y)) {
+        handler.setMinOffsetRangeEndY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_OFFSET_RANGE_END_Y)));
+        hasCustomActivationCriteria = true;
+      }
+      if(config.hasKey(KEY_PAN_MAX_OFFSET_RANGE_START_Y)) {
+        handler.setMaxOffsetRangeStartY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MAX_OFFSET_RANGE_START_Y)));
+        hasCustomActivationCriteria = true;
+      }
+      if(config.hasKey(KEY_PAN_MAX_OFFSET_RANGE_END_Y)) {
+        handler.setMaxOffsetRangeEndY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MAX_OFFSET_RANGE_END_Y)));
         hasCustomActivationCriteria = true;
       }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -62,14 +62,14 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
   private static final String KEY_TAP_MIN_POINTERS = "minPointers";
   private static final String KEY_LONG_PRESS_MIN_DURATION_MS = "minDurationMs";
   private static final String KEY_LONG_PRESS_MAX_DIST = "maxDist";
-  private static final String KEY_PAN_MIN_OFFSET_RANGE_START_X = "minOffsetRangeStartX";
-  private static final String KEY_PAN_MIN_OFFSET_RANGE_END_X = "minOffsetRangeEndX";
-  private static final String KEY_PAN_MAX_OFFSET_RANGE_START_X = "maxOffsetRangeStartX";
-  private static final String KEY_PAN_MAX_OFFSET_RANGE_END_X = "maxOffsetRangeEndX";
-  private static final String KEY_PAN_MIN_OFFSET_RANGE_START_Y = "minOffsetRangeStartY";
-  private static final String KEY_PAN_MIN_OFFSET_RANGE_END_Y = "minOffsetRangeEndY";
-  private static final String KEY_PAN_MAX_OFFSET_RANGE_START_Y = "maxOffsetRangeStartY";
-  private static final String KEY_PAN_MAX_OFFSET_RANGE_END_Y = "maxOffsetRangeEndY";
+  private static final String KEY_PAN_ACTIVE_OFFSET_START_X = "activeOffsetStartX";
+  private static final String KEY_PAN_ACTIVE_OFFSET_END_X = "activeOffsetEndX";
+  private static final String KEY_PAN_FAIL_OFFSET_RANGE_START_X = "failOffsetStartX";
+  private static final String KEY_PAN_FAIL_OFFSET_RANGE_END_X = "failOffsetEndX";
+  private static final String KEY_PAN_ACTIVE_OFFSET_START_Y = "activeOffsetStartY";
+  private static final String KEY_PAN_ACTIVE_OFFSET_END_Y = "activeOffsetEndY";
+  private static final String KEY_PAN_FAIL_OFFSET_RANGE_START_Y = "failOffsetStartY";
+  private static final String KEY_PAN_FAIL_OFFSET_RANGE_END_Y = "failOffsetEndY";
   private static final String KEY_PAN_MIN_DIST = "minDist";
   private static final String KEY_PAN_MIN_VELOCITY = "minVelocity";
   private static final String KEY_PAN_MIN_VELOCITY_X = "minVelocityX";
@@ -253,36 +253,36 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
     public void configure(PanGestureHandler handler, ReadableMap config) {
       super.configure(handler, config);
       boolean hasCustomActivationCriteria = false;
-      if(config.hasKey(KEY_PAN_MIN_OFFSET_RANGE_START_X)) {
-        handler.setMinOffsetRangeStartX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_OFFSET_RANGE_START_X)));
+      if(config.hasKey(KEY_PAN_ACTIVE_OFFSET_START_X)) {
+        handler.setactiveOffsetStartX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_START_X)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_MIN_OFFSET_RANGE_END_X)) {
-        handler.setMinOffsetRangeEndX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_OFFSET_RANGE_END_X)));
+      if(config.hasKey(KEY_PAN_ACTIVE_OFFSET_END_X)) {
+        handler.setactiveOffsetEndX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_END_X)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_MAX_OFFSET_RANGE_START_X)) {
-        handler.setMaxOffsetRangeStartX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MAX_OFFSET_RANGE_START_X)));
+      if(config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_START_X)) {
+        handler.setfailOffsetStartX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_START_X)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_MAX_OFFSET_RANGE_END_X)) {
-        handler.setMaxOffsetRangeEndX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MAX_OFFSET_RANGE_END_X)));
+      if(config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_END_X)) {
+        handler.setfailOffsetEndX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_END_X)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_MIN_OFFSET_RANGE_START_Y)) {
-        handler.setMinOffsetRangeStartY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_OFFSET_RANGE_START_Y)));
+      if(config.hasKey(KEY_PAN_ACTIVE_OFFSET_START_Y)) {
+        handler.setactiveOffsetStartY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_START_Y)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_MIN_OFFSET_RANGE_END_Y)) {
-        handler.setMinOffsetRangeEndY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_OFFSET_RANGE_END_Y)));
+      if(config.hasKey(KEY_PAN_ACTIVE_OFFSET_END_Y)) {
+        handler.setactiveOffsetEndY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_END_Y)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_MAX_OFFSET_RANGE_START_Y)) {
-        handler.setMaxOffsetRangeStartY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MAX_OFFSET_RANGE_START_Y)));
+      if(config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_START_Y)) {
+        handler.setfailOffsetStartY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_START_Y)));
         hasCustomActivationCriteria = true;
       }
-      if(config.hasKey(KEY_PAN_MAX_OFFSET_RANGE_END_Y)) {
-        handler.setMaxOffsetRangeEndY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MAX_OFFSET_RANGE_END_Y)));
+      if(config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_END_Y)) {
+        handler.setfailOffsetEndY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_END_Y)));
         hasCustomActivationCriteria = true;
       }
 

--- a/docs/handler-pan.md
+++ b/docs/handler-pan.md
@@ -49,82 +49,81 @@ Minimum distance the finger (or multiple finger) need to travel before the handl
 ---
 ### `minPointers`
 
-A number of fingers that is required to be placed before handler can [activate](state.md#active). Should be a positive integer.
+A number of fingers that is required to be placed before handler can [activate](state.md#active). Should be a higher or equal to 0 integer.
 
 ---
 ### `maxPointers`
 
-When the given number of fingers is placed on the screen and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture. Should be a positive integer.
+When the given number of fingers is placed on the screen and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture. Should be a higher or equal to 0 integer.
 
 ---
 ### `activeOffsetX`
 
-Range along X axis where fingers travels without activation of handler. Moving outside this range implies activation of handler. Range could be given as an array or a single number.
- If range is set as array, first value must be negative, a the second one positive.
- If there's given only positive number `p`, it means that range is: `(-inf, p)`. If the number if negative, the range is: `(p, inf)`. 
-
+Range along X axis where fingers travels without activation of handler. Moving outside of this range implies activation of handler. Range can be given as an array or a single number.
+ If range is set as an array, first value must be lower or equal to 0, a the second one higher or equal to 0.
+ If only one number `p` is given a range of `(-inf, p)` will be used if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
 ---
 ### `activeOffsetY`
 
-Range along Y axis where fingers travels without activation of handler. Moving outside this range implies activation of handler. Range could be given as an array or a single number.
- If range is set as array, first value must be negative, a the second one positive.
- If there's given only positive number `p`, it means that range is: `(-inf, p)`. If the number if negative, the range is: `(p, inf)`. 
+Range along Y axis where fingers travels without activation of handler. Moving outside of this range implies activation of handler. Range can be given as an array or a single number.
+ If range is set as an array, first value must be lower or equal to 0, a the second one higher or equal to 0.
+ If only one number `p` is given a range of `(-inf, p)` will be used if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
 
 ---
 ### `failOffsetY`
 
-When the finger moves outside this range along Y axis and handler hasn't yet activated it will fail recognizing the gesture. Range could be given as an array or a single number.
- If range is set as array, first value must be negative, a the second one positive.
- If there's given only positive number `p`, it means that range is: `(-inf, p)`. If the number if negative, the range is: `(p, inf)`. 
+When the finger moves outside this range (in points) along Y axis and handler hasn't yet activated it will fail recognizing the gesture. Range can be given as an array or a single number.
+ If range is set as an array, first value must be lower or equal to 0, a the second one higher or equal to 0.
+ If only one number `p` is given a range of `(-inf, p)` will be used if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
 
 ---
 ### `failOffsetX`
 
-When the finger moves outside this range along X axis and handler hasn't yet activated it will fail recognizing the gesture. Range could be given as an array or a single number.
- If range is set as array, first value must be negative, a the second one positive.
- If there's given only positive number `p`, it means that range is: `(-inf, p)`. If the number if negative, the range is: `(p, inf)`. 
+When the finger moves outside this range (in points) along X axis and handler hasn't yet activated it will fail recognizing the gesture. Range can be given as an array or a single number.
+ If range is set as an array, first value must be lower or equal to 0, a the second one higher or equal to 0.
+ If only one number `p` is given a range of `(-inf, p)` will be used if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
 
 ---
 ### `maxDeltaX`
 
-> This method is deprecated but supported for backward compatibility. Please use `failOffsetX`.
+> This method is deprecated but supported for backward compatibility. Instead of using `maxDeltaX={N}` you can do `failOffsetX={[-N, N]}`.
     
 When the finger travels the given distance expressed in points along X axis and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture.
 
 ---
 ### `maxDeltaY`
 
-> This method is deprecated but supported for backward compatibility. Please use `failOffsetY`.
+> This method is deprecated but supported for backward compatibility. Instead of using `maxDeltaY={N}` you can do `failOffsetY={[-N, N]}`.
 
 When the finger travels the given distance expressed in points along Y axis and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture.
 
 ---
 ### `minOffsetX`
 
-> This method is deprecated but supported for backward compatibility. Please use `activeOffsetX`.
+> This method is deprecated but supported for backward compatibility. Instead of using `minOffsetX={N}` you can do `activeOffsetX={N}`.
 
-Minimum distance expressed in points along X axis the finger (or multiple finger) need to travel before the handler [activates](state.md#active). If set to a negative value we expect the finger to travel "left" by the given distance. When set to a positive number the handler will activate on a movement to the "right". If you wish for the movement direction to be ignored use [`minDeltaX`](#mindeltax) instead.
+Minimum distance along X (in points) axis the finger (or multiple finger) need to travel before the handler [activates](state.md#active). If set to a lower or equal to 0 value we expect the finger to travel "left" by the given distance. When set to a higher or equal to 0 number the handler will activate on a movement to the "right". If you wish for the movement direction to be ignored use [`minDeltaX`](#mindeltax) instead.
 
 ---
 ### `minOffsetY`
 
-> This method is deprecated but supported for backward compatibility. Please use `activeOffsetY`.
+> This method is deprecated but supported for backward compatibility. Instead of using `minOffsetY={N}` you can do `activeOffsetY={N}`.
 
-Minimum distance expressed in points along Y axis the finger (or multiple finger) need to travel before the handler [activates](state.md#active). If set to a negative value we expect the finger to travel "up" by the given distance. When set to a positive number the handler will activate on a movement to the "bottom". If you wish for the movement direction to be ignored use [`minDeltaY`](#mindeltay) instead.
+Minimum distance along Y (in points) axis the finger (or multiple finger) need to travel before the handler [activates](state.md#active). If set to a lower or equal to 0 value we expect the finger to travel "up" by the given distance. When set to a higher or equal to 0 number the handler will activate on a movement to the "bottom". If you wish for the movement direction to be ignored use [`minDeltaY`](#mindeltay) instead.
 
 ---
 ### `minDeltaX`
 
-> This method is deprecated but supported for backward compatibility. Please use `activeOffsetX`.
+> This method is deprecated but supported for backward compatibility. Instead of using `minDeltaX={N}` you can do `activeOffsetX={[-N, N]}`.
 
-Minimum distance expressed in points along X axis the finger (or multiple finger) need to travel (left or right) before the handler [activates](state.md#active). Unlike [`minoffsetx`](#minoffsetx) this parameter accepts only non-negative numbers that represents the distance in point units. If you want for the handler to [activate](state.md#active) for the movement in one particular direction use [`minOffsetX`](#minoffsetx) instead.
+Minimum distance along X (in points) axis the finger (or multiple finger) need to travel (left or right) before the handler [activates](state.md#active). Unlike [`minoffsetx`](#minoffsetx) this parameter accepts only non-lower or equal to 0 numbers that represents the distance in point units. If you want for the handler to [activate](state.md#active) for the movement in one particular direction use [`minOffsetX`](#minoffsetx) instead.
 
 ---
 ### `minDeltaY`
 
-> This method is deprecated but supported for backward compatibility. Please use `activeOffsetY`.
+> This method is deprecated but supported for backward compatibility. Instead of using `minDeltaY={N}` you can do `activeOffsetY={[-N, N]}`.
 
-Minimum distance expressed in points along Y axis the finger (or multiple finger) need to travel (top or bottom) before the handler [activates](state.md#active). Unlike [`minOffsetY`](#minoffsety) this parameter accepts only non-negative numbers that represents the distance in point units. If you want for the handler to [activate](state.md#active) for the movement in one particular direction use [`minOffsetY`](#minoffsety) instead.
+Minimum distance along Y (in points) axis the finger (or multiple finger) need to travel (top or bottom) before the handler [activates](state.md#active). Unlike [`minOffsetY`](#minoffsety) this parameter accepts only non-lower or equal to 0 numbers that represents the distance in point units. If you want for the handler to [activate](state.md#active) for the movement in one particular direction use [`minOffsetY`](#minoffsety) instead.
 
 ---
 ### `avgTouches` (Android only)

--- a/docs/handler-pan.md
+++ b/docs/handler-pan.md
@@ -57,64 +57,58 @@ A number of fingers that is required to be placed before handler can [activate](
 When the given number of fingers is placed on the screen and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture. Should be a positive integer.
 
 ---
-### `minOffsetRangeStartX`, `minOffsetRangeEndX`
+### `activeOffsetX`, `activeOffsetY`
 
-Range along X axis where fingers travels without activation of handler. Moving outside this range implies activation of handler
-
----
-### `minOffsetRangeStartY`, `minOffsetRangeEndY`
-
-Range along Y axis where fingers travels without activation of handler. Moving outside this range implies activation of handler
+Range along X or Y axis where fingers travels without activation of handler. Moving outside this range implies activation of handler. Range could be given as array or a single number.
+ If range is set as array, first value must be negative, a the second one positive.
+ If there's given only positive number `p`, it means that range is: `(-inf, p)`. If the number if negative, the range is: `(p, inf)`. 
 
 ---
-### `maxOffsetRangeStartX`, `maxOffsetRangeEndX`
+### `failOffsetX`, `failOffsetY`
 
-When the finger moves outside this range along X axis and handler hasn't yet activated it will fail recognizing the gesture.
-
----
-### `maxOffsetRangeStartY`, `maxOffsetRangeEndY`
-
-When the finger moves outside this range along Y axis and handler hasn't yet activated it will fail recognizing the gesture.
+When the finger moves outside this range along X or Y axis and handler hasn't yet activated it will fail recognizing the gesture. Range could be given as array or a single number.
+ If range is set as array, first value must be negative, a the second one positive.
+ If there's given only positive number `p`, it means that range is: `(-inf, p)`. If the number if negative, the range is: `(p, inf)`. 
 
 ---
 ### `maxDeltaX`
 
-> This method is depracated but supported for backward compability. Please use `maxOffsetRangeStartX` and `maxOffsetRangeEndX`.
+> This method is deprecated but supported for backward compatibility. Please use `maxOffsetRangeStartX` and `maxOffsetRangeEndX`.
     
 When the finger travels the given distance expressed in points along X axis and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture.
 
 ---
 ### `maxDeltaY`
 
-> This method is depracated but supported for backward compability. Please use `maxOffsetRangeStartY` and `maxOffsetRangeEndY`.
+> This method is deprecated but supported for backward compatibility. Please use `maxOffsetRangeStartY` and `maxOffsetRangeEndY`.
 
 When the finger travels the given distance expressed in points along Y axis and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture.
 
 ---
 ### `minOffsetX`
 
-> This method is depracated but supported for backward compability. Please use `minOffsetRangeStartX` or `minOffsetRangeEndX`.
+> This method is deprecated but supported for backward compatibility. Please use `minOffsetRangeStartX` or `minOffsetRangeEndX`.
 
 Minimum distance expressed in points along X axis the finger (or multiple finger) need to travel before the handler [activates](state.md#active). If set to a negative value we expect the finger to travel "left" by the given distance. When set to a positive number the handler will activate on a movement to the "right". If you wish for the movement direction to be ignored use [`minDeltaX`](#mindeltax) instead.
 
 ---
 ### `minOffsetY`
 
-> This method is depracated but supported for backward compability. Please use `minOffsetRangeStartY` or `minOffsetRangeEndY`.
+> This method is deprecated but supported for backward compatibility. Please use `minOffsetRangeStartY` or `minOffsetRangeEndY`.
 
 Minimum distance expressed in points along Y axis the finger (or multiple finger) need to travel before the handler [activates](state.md#active). If set to a negative value we expect the finger to travel "up" by the given distance. When set to a positive number the handler will activate on a movement to the "bottom". If you wish for the movement direction to be ignored use [`minDeltaY`](#mindeltay) instead.
 
 ---
 ### `minDeltaX`
 
-> This method is depracated but supported for backward compability. Please use `minOffsetRangeStartX` and `minOffsetRangeEndX`.
+> This method is deprecated but supported for backward compatibility. Please use `minOffsetRangeStartX` and `minOffsetRangeEndX`.
 
 Minimum distance expressed in points along X axis the finger (or multiple finger) need to travel (left or right) before the handler [activates](state.md#active). Unlike [`minoffsetx`](#minoffsetx) this parameter accepts only non-negative numbers that represents the distance in point units. If you want for the handler to [activate](state.md#active) for the movement in one particular direction use [`minOffsetX`](#minoffsetx) instead.
 
 ---
 ### `minDeltaY`
 
-> This method is depracated but supported for backward compability. Please use `minOffsetRangeStartY` and `minOffsetRangeEndY`.
+> This method is deprecated but supported for backward compatibility. Please use `minOffsetRangeStartY` and `minOffsetRangeEndY`.
 
 Minimum distance expressed in points along Y axis the finger (or multiple finger) need to travel (top or bottom) before the handler [activates](state.md#active). Unlike [`minOffsetY`](#minoffsety) this parameter accepts only non-negative numbers that represents the distance in point units. If you want for the handler to [activate](state.md#active) for the movement in one particular direction use [`minOffsetY`](#minoffsety) instead.
 

--- a/docs/handler-pan.md
+++ b/docs/handler-pan.md
@@ -73,42 +73,42 @@ When the finger moves outside this range along X or Y axis and handler hasn't ye
 ---
 ### `maxDeltaX`
 
-> This method is deprecated but supported for backward compatibility. Please use `maxOffsetRangeStartX` and `maxOffsetRangeEndX`.
+> This method is deprecated but supported for backward compatibility. Please use `failOffsetX`.
     
 When the finger travels the given distance expressed in points along X axis and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture.
 
 ---
 ### `maxDeltaY`
 
-> This method is deprecated but supported for backward compatibility. Please use `maxOffsetRangeStartY` and `maxOffsetRangeEndY`.
+> This method is deprecated but supported for backward compatibility. Please use `failOffsetY`.
 
 When the finger travels the given distance expressed in points along Y axis and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture.
 
 ---
 ### `minOffsetX`
 
-> This method is deprecated but supported for backward compatibility. Please use `minOffsetRangeStartX` or `minOffsetRangeEndX`.
+> This method is deprecated but supported for backward compatibility. Please use `activeOffsetX`.
 
 Minimum distance expressed in points along X axis the finger (or multiple finger) need to travel before the handler [activates](state.md#active). If set to a negative value we expect the finger to travel "left" by the given distance. When set to a positive number the handler will activate on a movement to the "right". If you wish for the movement direction to be ignored use [`minDeltaX`](#mindeltax) instead.
 
 ---
 ### `minOffsetY`
 
-> This method is deprecated but supported for backward compatibility. Please use `minOffsetRangeStartY` or `minOffsetRangeEndY`.
+> This method is deprecated but supported for backward compatibility. Please use `activeOffsetY`.
 
 Minimum distance expressed in points along Y axis the finger (or multiple finger) need to travel before the handler [activates](state.md#active). If set to a negative value we expect the finger to travel "up" by the given distance. When set to a positive number the handler will activate on a movement to the "bottom". If you wish for the movement direction to be ignored use [`minDeltaY`](#mindeltay) instead.
 
 ---
 ### `minDeltaX`
 
-> This method is deprecated but supported for backward compatibility. Please use `minOffsetRangeStartX` and `minOffsetRangeEndX`.
+> This method is deprecated but supported for backward compatibility. Please use `activeOffsetX`.
 
 Minimum distance expressed in points along X axis the finger (or multiple finger) need to travel (left or right) before the handler [activates](state.md#active). Unlike [`minoffsetx`](#minoffsetx) this parameter accepts only non-negative numbers that represents the distance in point units. If you want for the handler to [activate](state.md#active) for the movement in one particular direction use [`minOffsetX`](#minoffsetx) instead.
 
 ---
 ### `minDeltaY`
 
-> This method is deprecated but supported for backward compatibility. Please use `minOffsetRangeStartY` and `minOffsetRangeEndY`.
+> This method is deprecated but supported for backward compatibility. Please use `activeOffsetY`.
 
 Minimum distance expressed in points along Y axis the finger (or multiple finger) need to travel (top or bottom) before the handler [activates](state.md#active). Unlike [`minOffsetY`](#minoffsety) this parameter accepts only non-negative numbers that represents the distance in point units. If you want for the handler to [activate](state.md#active) for the movement in one particular direction use [`minOffsetY`](#minoffsety) instead.
 

--- a/docs/handler-pan.md
+++ b/docs/handler-pan.md
@@ -57,16 +57,30 @@ A number of fingers that is required to be placed before handler can [activate](
 When the given number of fingers is placed on the screen and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture. Should be a positive integer.
 
 ---
-### `activeOffsetX`, `activeOffsetY`
+### `activeOffsetX`
 
-Range along X or Y axis where fingers travels without activation of handler. Moving outside this range implies activation of handler. Range could be given as array or a single number.
+Range along X axis where fingers travels without activation of handler. Moving outside this range implies activation of handler. Range could be given as an array or a single number.
  If range is set as array, first value must be negative, a the second one positive.
  If there's given only positive number `p`, it means that range is: `(-inf, p)`. If the number if negative, the range is: `(p, inf)`. 
 
 ---
-### `failOffsetX`, `failOffsetY`
+### `activeOffsetY`
 
-When the finger moves outside this range along X or Y axis and handler hasn't yet activated it will fail recognizing the gesture. Range could be given as array or a single number.
+Range along Y axis where fingers travels without activation of handler. Moving outside this range implies activation of handler. Range could be given as an array or a single number.
+ If range is set as array, first value must be negative, a the second one positive.
+ If there's given only positive number `p`, it means that range is: `(-inf, p)`. If the number if negative, the range is: `(p, inf)`. 
+
+---
+### `failOffsetY`
+
+When the finger moves outside this range along Y axis and handler hasn't yet activated it will fail recognizing the gesture. Range could be given as an array or a single number.
+ If range is set as array, first value must be negative, a the second one positive.
+ If there's given only positive number `p`, it means that range is: `(-inf, p)`. If the number if negative, the range is: `(p, inf)`. 
+
+---
+### `failOffsetX`
+
+When the finger moves outside this range along X axis and handler hasn't yet activated it will fail recognizing the gesture. Range could be given as an array or a single number.
  If range is set as array, first value must be negative, a the second one positive.
  If there's given only positive number `p`, it means that range is: `(-inf, p)`. If the number if negative, the range is: `(p, inf)`. 
 

--- a/docs/handler-pan.md
+++ b/docs/handler-pan.md
@@ -47,26 +47,6 @@ See [set of properties inherited from base handler class](handler-common.md#prop
 Minimum distance the finger (or multiple finger) need to travel before the handler [activates](state.md#active). Expressed in points.
 
 ---
-### `minOffsetX`
-
-Minimum distance expressed in points along X axis the finger (or multiple finger) need to travel before the handler [activates](state.md#active). If set to a negative value we expect the finger to travel "left" by the given distance. When set to a positive number the handler will activate on a movement to the "right". If you wish for the movement direction to be ignored use [`minDeltaX`](#mindeltax) instead.
-
----
-### `minOffsetY`
-
-Minimum distance expressed in points along Y axis the finger (or multiple finger) need to travel before the handler [activates](state.md#active). If set to a negative value we expect the finger to travel "up" by the given distance. When set to a positive number the handler will activate on a movement to the "bottom". If you wish for the movement direction to be ignored use [`minDeltaY`](#mindeltay) instead.
-
----
-### `minDeltaX`
-
-Minimum distance expressed in points along X axis the finger (or multiple finger) need to travel (left or right) before the handler [activates](state.md#active). Unlike [`minoffsetx`](#minoffsetx) this parameter accepts only non-negative numbers that represents the distance in point units. If you want for the handler to [activate](state.md#active) for the movement in one particular direction use [`minOffsetX`](#minoffsetx) instead.
-
----
-### `minDeltaY`
-
-Minimum distance expressed in points along Y axis the finger (or multiple finger) need to travel (top or bottom) before the handler [activates](state.md#active). Unlike [`minOffsetY`](#minoffsety) this parameter accepts only non-negative numbers that represents the distance in point units. If you want for the handler to [activate](state.md#active) for the movement in one particular direction use [`minOffsetY`](#minoffsety) instead.
-
----
 ### `minPointers`
 
 A number of fingers that is required to be placed before handler can [activate](state.md#active). Should be a positive integer.
@@ -77,15 +57,66 @@ A number of fingers that is required to be placed before handler can [activate](
 When the given number of fingers is placed on the screen and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture. Should be a positive integer.
 
 ---
+### `minOffsetRangeStartX`, `minOffsetRangeEndX`
+
+Range along X axis where fingers travels without activation of handler. Moving outside this range implies activation of handler
+
+---
+### `minOffsetRangeStartY`, `minOffsetRangeEndY`
+
+Range along Y axis where fingers travels without activation of handler. Moving outside this range implies activation of handler
+
+---
+### `maxOffsetRangeStartX`, `maxOffsetRangeEndX`
+
+When the finger moves outside this range along X axis and handler hasn't yet activated it will fail recognizing the gesture.
+
+---
+### `maxOffsetRangeStartY`, `maxOffsetRangeEndY`
+
+When the finger moves outside this range along Y axis and handler hasn't yet activated it will fail recognizing the gesture.
+
+---
 ### `maxDeltaX`
 
+> This method is depracated but supported for backward compability. Please use `maxOffsetRangeStartX` and `maxOffsetRangeEndX`.
+    
 When the finger travels the given distance expressed in points along X axis and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture.
 
 ---
 ### `maxDeltaY`
 
+> This method is depracated but supported for backward compability. Please use `maxOffsetRangeStartY` and `maxOffsetRangeEndY`.
+
 When the finger travels the given distance expressed in points along Y axis and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture.
 
+---
+### `minOffsetX`
+
+> This method is depracated but supported for backward compability. Please use `minOffsetRangeStartX` or `minOffsetRangeEndX`.
+
+Minimum distance expressed in points along X axis the finger (or multiple finger) need to travel before the handler [activates](state.md#active). If set to a negative value we expect the finger to travel "left" by the given distance. When set to a positive number the handler will activate on a movement to the "right". If you wish for the movement direction to be ignored use [`minDeltaX`](#mindeltax) instead.
+
+---
+### `minOffsetY`
+
+> This method is depracated but supported for backward compability. Please use `minOffsetRangeStartY` or `minOffsetRangeEndY`.
+
+Minimum distance expressed in points along Y axis the finger (or multiple finger) need to travel before the handler [activates](state.md#active). If set to a negative value we expect the finger to travel "up" by the given distance. When set to a positive number the handler will activate on a movement to the "bottom". If you wish for the movement direction to be ignored use [`minDeltaY`](#mindeltay) instead.
+
+---
+### `minDeltaX`
+
+> This method is depracated but supported for backward compability. Please use `minOffsetRangeStartX` and `minOffsetRangeEndX`.
+
+Minimum distance expressed in points along X axis the finger (or multiple finger) need to travel (left or right) before the handler [activates](state.md#active). Unlike [`minoffsetx`](#minoffsetx) this parameter accepts only non-negative numbers that represents the distance in point units. If you want for the handler to [activate](state.md#active) for the movement in one particular direction use [`minOffsetX`](#minoffsetx) instead.
+
+---
+### `minDeltaY`
+
+> This method is depracated but supported for backward compability. Please use `minOffsetRangeStartY` and `minOffsetRangeEndY`.
+
+Minimum distance expressed in points along Y axis the finger (or multiple finger) need to travel (top or bottom) before the handler [activates](state.md#active). Unlike [`minOffsetY`](#minoffsety) this parameter accepts only non-negative numbers that represents the distance in point units. If you want for the handler to [activate](state.md#active) for the movement in one particular direction use [`minOffsetY`](#minoffsety) instead.
 
 ---
 ### `avgTouches` (Android only)

--- a/docs/handler-pan.md
+++ b/docs/handler-pan.md
@@ -59,13 +59,13 @@ When the given number of fingers is placed on the screen and handler hasn't yet 
 ---
 ### `activeOffsetX`
 
-Range along X axis where fingers travels without activation of handler. Moving outside of this range implies activation of handler. Range can be given as an array or a single number.
+Range along X axis (in points) where fingers travels without activation of handler. Moving outside of this range implies activation of handler. Range can be given as an array or a single number.
  If range is set as an array, first value must be lower or equal to 0, a the second one higher or equal to 0.
  If only one number `p` is given a range of `(-inf, p)` will be used if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
 ---
 ### `activeOffsetY`
 
-Range along Y axis where fingers travels without activation of handler. Moving outside of this range implies activation of handler. Range can be given as an array or a single number.
+Range along Y axis (in points) where fingers travels without activation of handler. Moving outside of this range implies activation of handler. Range can be given as an array or a single number.
  If range is set as an array, first value must be lower or equal to 0, a the second one higher or equal to 0.
  If only one number `p` is given a range of `(-inf, p)` will be used if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
 

--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -16,14 +16,14 @@
 @property (nonatomic) CGFloat minVelocityX;
 @property (nonatomic) CGFloat minVelocityY;
 @property (nonatomic) CGFloat minVelocitySq;
-@property (nonatomic) CGFloat activeOffsetStartX;
-@property (nonatomic) CGFloat activeOffsetEndX;
-@property (nonatomic) CGFloat failOffsetStartX;
-@property (nonatomic) CGFloat failOffsetEndX;
-@property (nonatomic) CGFloat activeOffsetStartY;
-@property (nonatomic) CGFloat activeOffsetEndY;
-@property (nonatomic) CGFloat failOffsetStartY;
-@property (nonatomic) CGFloat failOffsetEndY;
+@property (nonatomic) CGFloat activeOffsetXStart;
+@property (nonatomic) CGFloat activeOffsetXEnd;
+@property (nonatomic) CGFloat failOffsetXStart;
+@property (nonatomic) CGFloat failOffsetXEnd;
+@property (nonatomic) CGFloat activeOffsetYStart;
+@property (nonatomic) CGFloat activeOffsetYEnd;
+@property (nonatomic) CGFloat failOffsetYStart;
+@property (nonatomic) CGFloat failOffsetYEnd;
 
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
@@ -45,14 +45,14 @@
     _minVelocityX = NAN;
     _minVelocityY = NAN;
     _minVelocitySq = NAN;
-    _activeOffsetStartX = NAN;
-    _activeOffsetEndX = NAN;
-    _failOffsetStartX = NAN;
-    _failOffsetEndX = NAN;
-    _activeOffsetStartY = NAN;
-    _activeOffsetEndY = NAN;
-    _failOffsetStartY = NAN;
-    _failOffsetEndY = NAN;
+    _activeOffsetXStart = NAN;
+    _activeOffsetXEnd = NAN;
+    _failOffsetXStart = NAN;
+    _failOffsetXEnd = NAN;
+    _activeOffsetYStart = NAN;
+    _activeOffsetYEnd = NAN;
+    _failOffsetYStart = NAN;
+    _failOffsetYEnd = NAN;
     _hasCustomActivationCriteria = NO;
     _realMinimumNumberOfTouches = self.minimumNumberOfTouches;
   }
@@ -117,25 +117,25 @@
 {
   _hasCustomActivationCriteria = !isnan(_minDistSq)
   || !isnan(_minVelocityX) || !isnan(_minVelocityY) || !isnan(_minVelocitySq)
-  || !isnan(_activeOffsetStartX) || !isnan(_activeOffsetEndX) || !isnan(_failOffsetStartX)
-  || !isnan(_failOffsetEndX) || !isnan(_activeOffsetStartY) || !isnan(_activeOffsetEndY)
-  || !isnan(_failOffsetStartY) || !isnan(_failOffsetEndY);
+  || !isnan(_activeOffsetXStart) || !isnan(_activeOffsetXEnd) || !isnan(_failOffsetXStart)
+  || !isnan(_failOffsetXEnd) || !isnan(_activeOffsetYStart) || !isnan(_activeOffsetYEnd)
+  || !isnan(_failOffsetYStart) || !isnan(_failOffsetYEnd);
 }
 
 - (BOOL)shouldFailUnderCustomCriteria
 {
   CGPoint trans = [self translationInView:self.view];
   
-  if (TEST_MIN_IF_NOT_NAN(trans.x, _failOffsetStartX)) {
+  if (TEST_MIN_IF_NOT_NAN(trans.x, _failOffsetXStart)) {
     return YES;
   }
-  if (TEST_MAX_IF_NOT_NAN(trans.x, _failOffsetEndX)) {
+  if (TEST_MAX_IF_NOT_NAN(trans.x, _failOffsetXEnd)) {
     return YES;
   }
-  if (TEST_MIN_IF_NOT_NAN(trans.y, _failOffsetStartY)) {
+  if (TEST_MIN_IF_NOT_NAN(trans.y, _failOffsetYStart)) {
     return YES;
   }
-  if (TEST_MAX_IF_NOT_NAN(trans.y, _failOffsetEndY)) {
+  if (TEST_MAX_IF_NOT_NAN(trans.y, _failOffsetYEnd)) {
     return YES;
   }
   
@@ -146,16 +146,16 @@
 - (BOOL)shouldActivateUnderCustomCriteria
 {
   CGPoint trans = [self translationInView:self.view];
-  if (TEST_MIN_IF_NOT_NAN(trans.x, _activeOffsetStartX)) {
+  if (TEST_MIN_IF_NOT_NAN(trans.x, _activeOffsetXStart)) {
     return YES;
   }
-  if (TEST_MAX_IF_NOT_NAN(trans.x, _activeOffsetEndX)) {
+  if (TEST_MAX_IF_NOT_NAN(trans.x, _activeOffsetXEnd)) {
     return YES;
   }
-  if (TEST_MIN_IF_NOT_NAN(trans.y, _activeOffsetStartY)) {
+  if (TEST_MIN_IF_NOT_NAN(trans.y, _activeOffsetYStart)) {
     return YES;
   }
-  if (TEST_MAX_IF_NOT_NAN(trans.y, _activeOffsetEndY)) {
+  if (TEST_MAX_IF_NOT_NAN(trans.y, _activeOffsetYEnd)) {
     return YES;
   }
   
@@ -196,14 +196,14 @@
   
   APPLY_FLOAT_PROP(minVelocityX);
   APPLY_FLOAT_PROP(minVelocityY);
-  APPLY_FLOAT_PROP(activeOffsetStartX);
-  APPLY_FLOAT_PROP(activeOffsetEndX);
-  APPLY_FLOAT_PROP(failOffsetStartX);
-  APPLY_FLOAT_PROP(failOffsetEndX);
-  APPLY_FLOAT_PROP(activeOffsetStartY);
-  APPLY_FLOAT_PROP(activeOffsetEndY);
-  APPLY_FLOAT_PROP(failOffsetStartY);
-  APPLY_FLOAT_PROP(failOffsetEndY);
+  APPLY_FLOAT_PROP(activeOffsetXStart);
+  APPLY_FLOAT_PROP(activeOffsetXEnd);
+  APPLY_FLOAT_PROP(failOffsetXStart);
+  APPLY_FLOAT_PROP(failOffsetXEnd);
+  APPLY_FLOAT_PROP(activeOffsetYStart);
+  APPLY_FLOAT_PROP(activeOffsetYEnd);
+  APPLY_FLOAT_PROP(failOffsetYStart);
+  APPLY_FLOAT_PROP(failOffsetYEnd);
   
   
   APPLY_NAMED_INT_PROP(minimumNumberOfTouches, @"minPointers");

--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -16,14 +16,14 @@
 @property (nonatomic) CGFloat minVelocityX;
 @property (nonatomic) CGFloat minVelocityY;
 @property (nonatomic) CGFloat minVelocitySq;
-@property (nonatomic) CGFloat minOffsetRangeStartX;
-@property (nonatomic) CGFloat minOffsetRangeEndX;
-@property (nonatomic) CGFloat maxOffsetRangeStartX;
-@property (nonatomic) CGFloat maxOffsetRangeEndX;
-@property (nonatomic) CGFloat minOffsetRangeStartY;
-@property (nonatomic) CGFloat minOffsetRangeEndY;
-@property (nonatomic) CGFloat maxOffsetRangeStartY;
-@property (nonatomic) CGFloat maxOffsetRangeEndY;
+@property (nonatomic) CGFloat activeOffsetStartX;
+@property (nonatomic) CGFloat activeOffsetEndX;
+@property (nonatomic) CGFloat failOffsetStartX;
+@property (nonatomic) CGFloat failOffsetEndX;
+@property (nonatomic) CGFloat activeOffsetStartY;
+@property (nonatomic) CGFloat activeOffsetEndY;
+@property (nonatomic) CGFloat failOffsetStartY;
+@property (nonatomic) CGFloat failOffsetEndY;
 
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
@@ -45,14 +45,14 @@
     _minVelocityX = NAN;
     _minVelocityY = NAN;
     _minVelocitySq = NAN;
-    _minOffsetRangeStartX = NAN;
-    _minOffsetRangeEndX = NAN;
-    _maxOffsetRangeStartX = NAN;
-    _maxOffsetRangeEndX = NAN;
-    _minOffsetRangeStartY = NAN;
-    _minOffsetRangeEndY = NAN;
-    _maxOffsetRangeStartY = NAN;
-    _maxOffsetRangeEndY = NAN;
+    _activeOffsetStartX = NAN;
+    _activeOffsetEndX = NAN;
+    _failOffsetStartX = NAN;
+    _failOffsetEndX = NAN;
+    _activeOffsetStartY = NAN;
+    _activeOffsetEndY = NAN;
+    _failOffsetStartY = NAN;
+    _failOffsetEndY = NAN;
     _hasCustomActivationCriteria = NO;
     _realMinimumNumberOfTouches = self.minimumNumberOfTouches;
   }
@@ -117,25 +117,25 @@
 {
   _hasCustomActivationCriteria = !isnan(_minDistSq)
   || !isnan(_minVelocityX) || !isnan(_minVelocityY) || !isnan(_minVelocitySq)
-  || !isnan(_minOffsetRangeStartX) || !isnan(_minOffsetRangeEndX) || !isnan(_maxOffsetRangeStartX)
-  || !isnan(_maxOffsetRangeEndX) || !isnan(_minOffsetRangeStartY) || !isnan(_minOffsetRangeEndY)
-  || !isnan(_maxOffsetRangeStartY) || !isnan(_maxOffsetRangeEndY);
+  || !isnan(_activeOffsetStartX) || !isnan(_activeOffsetEndX) || !isnan(_failOffsetStartX)
+  || !isnan(_failOffsetEndX) || !isnan(_activeOffsetStartY) || !isnan(_activeOffsetEndY)
+  || !isnan(_failOffsetStartY) || !isnan(_failOffsetEndY);
 }
 
 - (BOOL)shouldFailUnderCustomCriteria
 {
   CGPoint trans = [self translationInView:self.view];
   
-  if (TEST_MIN_IF_NOT_NAN(trans.x, _maxOffsetRangeStartX)) {
+  if (TEST_MIN_IF_NOT_NAN(trans.x, _failOffsetStartX)) {
     return YES;
   }
-  if (TEST_MAX_IF_NOT_NAN(trans.x, _maxOffsetRangeEndX)) {
+  if (TEST_MAX_IF_NOT_NAN(trans.x, _failOffsetEndX)) {
     return YES;
   }
-  if (TEST_MIN_IF_NOT_NAN(trans.y, _maxOffsetRangeStartY)) {
+  if (TEST_MIN_IF_NOT_NAN(trans.y, _failOffsetStartY)) {
     return YES;
   }
-  if (TEST_MAX_IF_NOT_NAN(trans.y, _maxOffsetRangeEndY)) {
+  if (TEST_MAX_IF_NOT_NAN(trans.y, _failOffsetEndY)) {
     return YES;
   }
   
@@ -146,16 +146,16 @@
 - (BOOL)shouldActivateUnderCustomCriteria
 {
   CGPoint trans = [self translationInView:self.view];
-  if (TEST_MIN_IF_NOT_NAN(trans.x, _minOffsetRangeStartX)) {
+  if (TEST_MIN_IF_NOT_NAN(trans.x, _activeOffsetStartX)) {
     return YES;
   }
-  if (TEST_MAX_IF_NOT_NAN(trans.x, _minOffsetRangeEndX)) {
+  if (TEST_MAX_IF_NOT_NAN(trans.x, _activeOffsetEndX)) {
     return YES;
   }
-  if (TEST_MIN_IF_NOT_NAN(trans.y, _minOffsetRangeStartY)) {
+  if (TEST_MIN_IF_NOT_NAN(trans.y, _activeOffsetStartY)) {
     return YES;
   }
-  if (TEST_MAX_IF_NOT_NAN(trans.y, _minOffsetRangeEndY)) {
+  if (TEST_MAX_IF_NOT_NAN(trans.y, _activeOffsetEndY)) {
     return YES;
   }
   
@@ -196,14 +196,14 @@
   
   APPLY_FLOAT_PROP(minVelocityX);
   APPLY_FLOAT_PROP(minVelocityY);
-  APPLY_FLOAT_PROP(minOffsetRangeStartX);
-  APPLY_FLOAT_PROP(minOffsetRangeEndX);
-  APPLY_FLOAT_PROP(maxOffsetRangeStartX);
-  APPLY_FLOAT_PROP(maxOffsetRangeEndX);
-  APPLY_FLOAT_PROP(minOffsetRangeStartY);
-  APPLY_FLOAT_PROP(minOffsetRangeEndY);
-  APPLY_FLOAT_PROP(maxOffsetRangeStartY);
-  APPLY_FLOAT_PROP(maxOffsetRangeEndY);
+  APPLY_FLOAT_PROP(activeOffsetStartX);
+  APPLY_FLOAT_PROP(activeOffsetEndX);
+  APPLY_FLOAT_PROP(failOffsetStartX);
+  APPLY_FLOAT_PROP(failOffsetEndX);
+  APPLY_FLOAT_PROP(activeOffsetStartY);
+  APPLY_FLOAT_PROP(activeOffsetEndY);
+  APPLY_FLOAT_PROP(failOffsetStartY);
+  APPLY_FLOAT_PROP(failOffsetEndY);
   
   
   APPLY_NAMED_INT_PROP(minimumNumberOfTouches, @"minPointers");

--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -12,16 +12,19 @@
 
 @interface RNBetterPanGestureRecognizer : UIPanGestureRecognizer
 
-@property (nonatomic) CGFloat minDeltaX;
-@property (nonatomic) CGFloat minDeltaY;
-@property (nonatomic) CGFloat minOffsetX;
-@property (nonatomic) CGFloat minOffsetY;
 @property (nonatomic) CGFloat minDistSq;
 @property (nonatomic) CGFloat minVelocityX;
 @property (nonatomic) CGFloat minVelocityY;
 @property (nonatomic) CGFloat minVelocitySq;
-@property (nonatomic) CGFloat maxDeltaX;
-@property (nonatomic) CGFloat maxDeltaY;
+@property (nonatomic) CGFloat minOffsetRangeStartX;
+@property (nonatomic) CGFloat minOffsetRangeEndX;
+@property (nonatomic) CGFloat maxOffsetRangeStartX;
+@property (nonatomic) CGFloat maxOffsetRangeEndX;
+@property (nonatomic) CGFloat minOffsetRangeStartY;
+@property (nonatomic) CGFloat minOffsetRangeEndY;
+@property (nonatomic) CGFloat maxOffsetRangeStartY;
+@property (nonatomic) CGFloat maxOffsetRangeEndY;
+
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
 
@@ -29,136 +32,149 @@
 
 
 @implementation RNBetterPanGestureRecognizer {
-    __weak RNGestureHandler *_gestureHandler;
-    NSUInteger _realMinimumNumberOfTouches;
-    BOOL _hasCustomActivationCriteria;
+  __weak RNGestureHandler *_gestureHandler;
+  NSUInteger _realMinimumNumberOfTouches;
+  BOOL _hasCustomActivationCriteria;
 }
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
 {
-    if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
-        _gestureHandler = gestureHandler;
-        _minDeltaX = NAN;
-        _minDeltaY = NAN;
-        _maxDeltaX = NAN;
-        _maxDeltaY = NAN;
-        _minOffsetX = NAN;
-        _minOffsetY = NAN;
-        _minDistSq = NAN;
-        _minVelocityX = NAN;
-        _minVelocityY = NAN;
-        _minVelocitySq = NAN;
-        _hasCustomActivationCriteria = NO;
-        _realMinimumNumberOfTouches = self.minimumNumberOfTouches;
-    }
-    return self;
+  if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
+    _gestureHandler = gestureHandler;
+    _minDistSq = NAN;
+    _minVelocityX = NAN;
+    _minVelocityY = NAN;
+    _minVelocitySq = NAN;
+    _minOffsetRangeStartX = NAN;
+    _minOffsetRangeEndX = NAN;
+    _maxOffsetRangeStartX = NAN;
+    _maxOffsetRangeEndX = NAN;
+    _minOffsetRangeStartY = NAN;
+    _minOffsetRangeEndY = NAN;
+    _maxOffsetRangeStartY = NAN;
+    _maxOffsetRangeEndY = NAN;
+    _hasCustomActivationCriteria = NO;
+    _realMinimumNumberOfTouches = self.minimumNumberOfTouches;
+  }
+  return self;
 }
 
 - (void)setMinimumNumberOfTouches:(NSUInteger)minimumNumberOfTouches
 {
-    _realMinimumNumberOfTouches = minimumNumberOfTouches;
+  _realMinimumNumberOfTouches = minimumNumberOfTouches;
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    if (_hasCustomActivationCriteria) {
-        // We use "minimumNumberOfTouches" property to prevent pan handler from recognizing
-        // the gesture too early before we are sure that all criteria (e.g. minimum distance
-        // etc. are met)
-        super.minimumNumberOfTouches = 20;
-    } else {
-        super.minimumNumberOfTouches = _realMinimumNumberOfTouches;
-    }
-    [super touchesBegan:touches withEvent:event];
+  if (_hasCustomActivationCriteria) {
+    // We use "minimumNumberOfTouches" property to prevent pan handler from recognizing
+    // the gesture too early before we are sure that all criteria (e.g. minimum distance
+    // etc. are met)
+    super.minimumNumberOfTouches = 20;
+  } else {
+    super.minimumNumberOfTouches = _realMinimumNumberOfTouches;
+  }
+  [super touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [super touchesMoved:touches withEvent:event];
-    if (self.state == UIGestureRecognizerStatePossible && [self shouldFailUnderCustomCriteria]) {
-        self.state = UIGestureRecognizerStateFailed;
-        return;
+  [super touchesMoved:touches withEvent:event];
+  if (self.state == UIGestureRecognizerStatePossible && [self shouldFailUnderCustomCriteria]) {
+    self.state = UIGestureRecognizerStateFailed;
+    return;
+  }
+  if ((self.state == UIGestureRecognizerStatePossible || self.state == UIGestureRecognizerStateChanged) && _gestureHandler.shouldCancelWhenOutside) {
+    CGPoint pt = [self locationInView:self.view];
+    if (!CGRectContainsPoint(self.view.bounds, pt)) {
+      // If the previous recognizer state is UIGestureRecognizerStateChanged
+      // then UIGestureRecognizer's sate machine will only transition to
+      // UIGestureRecognizerStateCancelled even if you set the state to
+      // UIGestureRecognizerStateFailed here. Making the behavior explicit.
+      self.state = (self.state == UIGestureRecognizerStatePossible)
+      ? UIGestureRecognizerStateFailed
+      : UIGestureRecognizerStateCancelled;
+      [self reset];
+      return;
     }
-    if ((self.state == UIGestureRecognizerStatePossible || self.state == UIGestureRecognizerStateChanged) && _gestureHandler.shouldCancelWhenOutside) {
-        CGPoint pt = [self locationInView:self.view];
-        if (!CGRectContainsPoint(self.view.bounds, pt)) {
-            // If the previous recognizer state is UIGestureRecognizerStateChanged
-            // then UIGestureRecognizer's sate machine will only transition to
-            // UIGestureRecognizerStateCancelled even if you set the state to
-            // UIGestureRecognizerStateFailed here. Making the behavior explicit.
-            self.state = (self.state == UIGestureRecognizerStatePossible)
-            ? UIGestureRecognizerStateFailed
-            : UIGestureRecognizerStateCancelled;
-            [self reset];
-            return;
-        }
+  }
+  if (_hasCustomActivationCriteria && self.state == UIGestureRecognizerStatePossible && [self shouldActivateUnderCustomCriteria]) {
+    super.minimumNumberOfTouches = _realMinimumNumberOfTouches;
+    if ([self numberOfTouches] >= _realMinimumNumberOfTouches) {
+      self.state = UIGestureRecognizerStateBegan;
+      [self setTranslation:CGPointMake(0, 0) inView:self.view];
     }
-    if (_hasCustomActivationCriteria && self.state == UIGestureRecognizerStatePossible && [self shouldActivateUnderCustomCriteria]) {
-        super.minimumNumberOfTouches = _realMinimumNumberOfTouches;
-        if ([self numberOfTouches] >= _realMinimumNumberOfTouches) {
-            self.state = UIGestureRecognizerStateBegan;
-            [self setTranslation:CGPointMake(0, 0) inView:self.view];
-        }
-    }
+  }
 }
 
 - (void)reset
 {
-    self.enabled = YES;
-    [super reset];
+  self.enabled = YES;
+  [super reset];
 }
 
 - (void)updateHasCustomActivationCriteria
 {
-    _hasCustomActivationCriteria = !isnan(_minDistSq) || !isnan(_minDeltaX) || !isnan(_minDeltaY)
-    || !isnan(_minOffsetX) || !isnan(_minOffsetY)
-    || !isnan(_minVelocityX) || !isnan(_minVelocityY) || !isnan(_minVelocitySq);
+  _hasCustomActivationCriteria = !isnan(_minDistSq)
+  || !isnan(_minVelocityX) || !isnan(_minVelocityY) || !isnan(_minVelocitySq)
+  || !isnan(_minOffsetRangeStartX) || !isnan(_minOffsetRangeEndX) || !isnan(_maxOffsetRangeStartX)
+  || !isnan(_maxOffsetRangeEndX) || !isnan(_minOffsetRangeStartY) || !isnan(_minOffsetRangeEndY)
+  || !isnan(_maxOffsetRangeStartY) || !isnan(_maxOffsetRangeEndY);
 }
 
 - (BOOL)shouldFailUnderCustomCriteria
 {
-    CGPoint trans = [self translationInView:self.view];
-    if (TEST_MAX_IF_NOT_NAN(fabs(trans.x), _maxDeltaX)) {
-        return YES;
-    }
-    if (TEST_MAX_IF_NOT_NAN(fabs(trans.y), _maxDeltaY)) {
-        return YES;
-    }
-
-    return NO;
+  CGPoint trans = [self translationInView:self.view];
+  
+  if (TEST_MIN_IF_NOT_NAN(trans.x, _maxOffsetRangeStartX)) {
+    return YES;
+  }
+  if (TEST_MAX_IF_NOT_NAN(trans.x, _maxOffsetRangeEndX)) {
+    return YES;
+  }
+  if (TEST_MIN_IF_NOT_NAN(trans.y, _maxOffsetRangeStartY)) {
+    return YES;
+  }
+  if (TEST_MAX_IF_NOT_NAN(trans.y, _maxOffsetRangeEndY)) {
+    return YES;
+  }
+  
+  
+  return NO;
 }
 
 - (BOOL)shouldActivateUnderCustomCriteria
 {
-    CGPoint trans = [self translationInView:self.view];
-    if (TEST_MIN_IF_NOT_NAN(fabs(trans.x), _minDeltaX)) {
-        return YES;
-    }
-    if (TEST_MIN_IF_NOT_NAN(fabs(trans.y), _minDeltaY)) {
-        return YES;
-    }
-    if (TEST_MIN_IF_NOT_NAN(trans.x, _minOffsetX)) {
-        return YES;
-    }
-    if (TEST_MIN_IF_NOT_NAN(trans.y, _minOffsetY)) {
-        return YES;
-    }
-    if (TEST_MIN_IF_NOT_NAN(VEC_LEN_SQ(trans), _minDistSq)) {
-        return YES;
-    }
-
-    CGPoint velocity = [self velocityInView:self.view];
-    if (TEST_MIN_IF_NOT_NAN(velocity.x, _minVelocityX)) {
-        return YES;
-    }
-    if (TEST_MIN_IF_NOT_NAN(velocity.y, _minVelocityY)) {
-        return YES;
-    }
-    if (TEST_MIN_IF_NOT_NAN(VEC_LEN_SQ(velocity), _minVelocitySq)) {
-        return YES;
-    }
-
-    return NO;
+  CGPoint trans = [self translationInView:self.view];
+  if (TEST_MIN_IF_NOT_NAN(trans.x, _minOffsetRangeStartX)) {
+    return YES;
+  }
+  if (TEST_MAX_IF_NOT_NAN(trans.x, _minOffsetRangeEndX)) {
+    return YES;
+  }
+  if (TEST_MIN_IF_NOT_NAN(trans.y, _minOffsetRangeStartY)) {
+    return YES;
+  }
+  if (TEST_MAX_IF_NOT_NAN(trans.y, _minOffsetRangeEndY)) {
+    return YES;
+  }
+  
+  if (TEST_MIN_IF_NOT_NAN(VEC_LEN_SQ(trans), _minDistSq)) {
+    return YES;
+  }
+  
+  CGPoint velocity = [self velocityInView:self.view];
+  if (TEST_MIN_IF_NOT_NAN(velocity.x, _minVelocityX)) {
+    return YES;
+  }
+  if (TEST_MIN_IF_NOT_NAN(velocity.y, _minVelocityY)) {
+    return YES;
+  }
+  if (TEST_MIN_IF_NOT_NAN(VEC_LEN_SQ(velocity), _minVelocitySq)) {
+    return YES;
+  }
+  
+  return NO;
 }
 
 @end
@@ -167,51 +183,54 @@
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
-    if ((self = [super initWithTag:tag])) {
-        _recognizer = [[RNBetterPanGestureRecognizer alloc] initWithGestureHandler:self];
-    }
-    return self;
+  if ((self = [super initWithTag:tag])) {
+    _recognizer = [[RNBetterPanGestureRecognizer alloc] initWithGestureHandler:self];
+  }
+  return self;
 }
 
 - (void)configure:(NSDictionary *)config
 {
-    [super configure:config];
-    RNBetterPanGestureRecognizer *recognizer = (RNBetterPanGestureRecognizer *)_recognizer;
-
-    APPLY_FLOAT_PROP(minDeltaX);
-    APPLY_FLOAT_PROP(minDeltaY);
-    APPLY_FLOAT_PROP(maxDeltaX);
-    APPLY_FLOAT_PROP(maxDeltaY);
-    APPLY_FLOAT_PROP(minOffsetX);
-    APPLY_FLOAT_PROP(minOffsetY);
-    APPLY_FLOAT_PROP(minVelocityX);
-    APPLY_FLOAT_PROP(minVelocityY);
-
-    APPLY_NAMED_INT_PROP(minimumNumberOfTouches, @"minPointers");
-    APPLY_NAMED_INT_PROP(maximumNumberOfTouches, @"maxPointers");
-
-    id prop = config[@"minDist"];
-    if (prop != nil) {
-        CGFloat dist = [RCTConvert CGFloat:prop];
-        recognizer.minDistSq = dist * dist;
-    }
-
-    prop = config[@"minVelocity"];
-    if (prop != nil) {
-        CGFloat velocity = [RCTConvert CGFloat:prop];
-        recognizer.minVelocitySq = velocity * velocity;
-    }
-    [recognizer updateHasCustomActivationCriteria];
+  [super configure:config];
+  RNBetterPanGestureRecognizer *recognizer = (RNBetterPanGestureRecognizer *)_recognizer;
+  
+  APPLY_FLOAT_PROP(minVelocityX);
+  APPLY_FLOAT_PROP(minVelocityY);
+  APPLY_FLOAT_PROP(minOffsetRangeStartX);
+  APPLY_FLOAT_PROP(minOffsetRangeEndX);
+  APPLY_FLOAT_PROP(maxOffsetRangeStartX);
+  APPLY_FLOAT_PROP(maxOffsetRangeEndX);
+  APPLY_FLOAT_PROP(minOffsetRangeStartY);
+  APPLY_FLOAT_PROP(minOffsetRangeEndY);
+  APPLY_FLOAT_PROP(maxOffsetRangeStartY);
+  APPLY_FLOAT_PROP(maxOffsetRangeEndY);
+  
+  
+  APPLY_NAMED_INT_PROP(minimumNumberOfTouches, @"minPointers");
+  APPLY_NAMED_INT_PROP(maximumNumberOfTouches, @"maxPointers");
+  
+  id prop = config[@"minDist"];
+  if (prop != nil) {
+    CGFloat dist = [RCTConvert CGFloat:prop];
+    recognizer.minDistSq = dist * dist;
+  }
+  
+  prop = config[@"minVelocity"];
+  if (prop != nil) {
+    CGFloat velocity = [RCTConvert CGFloat:prop];
+    recognizer.minVelocitySq = velocity * velocity;
+  }
+  [recognizer updateHasCustomActivationCriteria];
 }
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIPanGestureRecognizer *)recognizer
 {
-    return [RNGestureHandlerEventExtraData
-            forPan:[recognizer locationInView:recognizer.view]
-            withAbsolutePosition:[recognizer locationInView:recognizer.view.window]
-            withTranslation:[recognizer translationInView:recognizer.view]
-            withVelocity:[recognizer velocityInView:recognizer.view.window]
-            withNumberOfTouches:recognizer.numberOfTouches];
+  return [RNGestureHandlerEventExtraData
+          forPan:[recognizer locationInView:recognizer.view]
+          withAbsolutePosition:[recognizer locationInView:recognizer.view.window]
+          withTranslation:[recognizer translationInView:recognizer.view]
+          withVelocity:[recognizer velocityInView:recognizer.view.window]
+          withNumberOfTouches:recognizer.numberOfTouches];
 }
 
 @end

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -239,26 +239,22 @@ declare module 'react-native-gesture-handler' {
   }
 
   export interface PanGestureHandlerProperties extends GestureHandlerProperties {
-    /** @deprecated  use minOffsetRangeStartX and minOffsetRangeEndX*/
+    /** @deprecated  use activeOffsetX*/
     minDeltaX?: number;
-    /** @deprecated  use minOffsetRangeStartY and minOffsetRangeEndY*/
+    /** @deprecated  use activeOffsetY*/
     minDeltaY?: number;
-    /** @deprecated  use maxOffsetRangeStartX and maxOffsetRangeEndX*/
+    /** @deprecated  use failOffsetX*/
     maxDeltaX?: number;
-    /** @deprecated  use maxOffsetRangeStartY and maxOffsetRangeEndY*/
+    /** @deprecated  use failOffsetY*/
     maxDeltaY?: number;
-    /** @deprecated  use minOffsetRangeStartX or minOffsetRangeEndX*/
+    /** @deprecated  use activeOffsetX*/
     minOffsetX?: number;
-    /** @deprecated  use minOffsetRangeStartY or minOffsetRangeEndY*/
+    /** @deprecated  use failOffsetY*/
     minOffsetY?: number;
-    minOffsetRangeStartX?: number;
-    minOffsetRangeEndX?: number;
-    maxOffsetRangeStartX?: number;
-    maxOffsetRangeEndX?: number;
-    minOffsetRangeStartY?: number;
-    minOffsetRangeEndY?: number;
-    maxOffsetRangeStartY?: number;
-    maxOffsetRangeEndY?: number;    
+    activeOffsetY?: number | number[];
+    activeOffsetX?: number | number[];
+    failOffsetY?: number | number[];
+    failOffsetX?: number | number[];
     minDist?: number;
     minVelocity?: number;
     minVelocityX?: number;

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -239,12 +239,26 @@ declare module 'react-native-gesture-handler' {
   }
 
   export interface PanGestureHandlerProperties extends GestureHandlerProperties {
+    /** @deprecated  use minOffsetRangeStartX and minOffsetRangeEndX*/
     minDeltaX?: number;
+    /** @deprecated  use minOffsetRangeStartY and minOffsetRangeEndY*/
     minDeltaY?: number;
+    /** @deprecated  use maxOffsetRangeStartX and maxOffsetRangeEndX*/
     maxDeltaX?: number;
+    /** @deprecated  use maxOffsetRangeStartY and maxOffsetRangeEndY*/
     maxDeltaY?: number;
+    /** @deprecated  use minOffsetRangeStartX or minOffsetRangeEndX*/
     minOffsetX?: number;
+    /** @deprecated  use minOffsetRangeStartY or minOffsetRangeEndY*/
     minOffsetY?: number;
+    minOffsetRangeStartX?: number;
+    minOffsetRangeEndX?: number;
+    maxOffsetRangeStartX?: number;
+    maxOffsetRangeEndX?: number;
+    minOffsetRangeStartY?: number;
+    minOffsetRangeEndY?: number;
+    maxOffsetRangeStartY?: number;
+    maxOffsetRangeEndY?: number;    
     minDist?: number;
     minVelocity?: number;
     minVelocityX?: number;


### PR DESCRIPTION
## Motivation
We now can set a range for when gesture can be activated (have minOffsetY and minDeltaY) but the criteria for cancelling can only be specified as a delta (that is we can only have symmetrical range in both directions using maxDeltaY)

The usecase for that would be when we want to have PanGestureHandler that can activate after pulling down 20 pts but immediately cancel when pulling up. Then if we have another handler waiting for that Pan we have to cancel instead of staying idle while pulling up.

I think the improvement we may try to make is to change the set of parameters on the native side to accept "minOffsetRangeStart" and "minOffsetRangeEnd" for both X and Y and then also have "maxOffsetRangeStart" and "maxOffsetRangeEnd" for both X and Y. Then we can use these to implement "minDelta", "minOffset" and "maxDelta" for compatibility (of course some mix of these props will not be supported)