### PR TITLE
Fix for Swipeable freezing app (due to change in interpolate implementation)

### DIFF
--- a/Swipeable.js
+++ b/Swipeable.js
@@ -129,21 +129,25 @@ export default class Swipeable extends Component<PropType, StateType> {
       ],
     });
     this._transX = transX;
-    this._showLeftAction = transX.interpolate({
-      inputRange: [-1, 0, leftWidth],
-      outputRange: [0, 0, 1],
-      extrapolate: 'clamp',
-    });
+    this._showLeftAction = leftWidth > 0 
+      ? transX.interpolate({
+          inputRange: [-1, 0, leftWidth],
+          outputRange: [0, 0, 1],
+          extrapolate: 'clamp',
+        })
+      : new Animated.Value(0);
     this._leftActionTranslate = this._showLeftAction.interpolate({
       inputRange: [0, Number.MIN_VALUE],
       outputRange: [-10000, 0],
       extrapolate: 'clamp',
     });
-    this._showRightAction = transX.interpolate({
-      inputRange: [-rightWidth, 0, 1],
-      outputRange: [1, 0, 0],
-      extrapolate: 'clamp',
-    });
+    this._showRightAction = rightWidth > 0 
+      ? transX.interpolate({
+          inputRange: [-rightWidth, 0, 1],
+          outputRange: [1, 0, 0],
+          extrapolate: 'clamp',
+        })
+      : new Animated.Value(0);
     this._rightActionTranslate = this._showRightAction.interpolate({
       inputRange: [0, Number.MIN_VALUE],
       outputRange: [-10000, 0],


### PR DESCRIPTION
This is fix for broken behavior of Swipeable on newer version of React Native (where interpolate do not accept inputRange elements that are not growing/descending).

When `rigthWidth` is set to `0` (like when we load data to `Swipeable`) app is freezing for few seconds. 
I expect that similar behavior could be reproduced for `leftWidth`. 