### PR TITLE
Send more transition state-related events from iOS

### DIFF
--- a/ios/Handlers/RNFlingHandler.m
+++ b/ios/Handlers/RNFlingHandler.m
@@ -1,11 +1,35 @@
 #import "RNFlingHandler.h"
 
+@interface RNSwipeGestureRecognizer : UISwipeGestureRecognizer
+
+- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+
+@end
+
+@implementation RNSwipeGestureRecognizer {
+  __weak RNGestureHandler *_gestureHandler;
+}
+
+- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
+{
+  if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
+    _gestureHandler = gestureHandler;
+  }
+  return self;
+}
+-(void) setState:(UIGestureRecognizerState)state {
+  [super setState:state];
+  [_gestureHandler handleGestureStateTransition:self];
+}
+
+@end
+
 @implementation RNFlingGestureHandler
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
     if ((self = [super initWithTag:tag])) {
-        _recognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleGesture:)];
+        _recognizer = [[RNSwipeGestureRecognizer alloc] initWithGestureHandler:self];
         
     }
     return self;
@@ -14,7 +38,7 @@
 - (void)configure:(NSDictionary *)config
 {
     [super configure:config];
-    UISwipeGestureRecognizer *recognizer = (UISwipeGestureRecognizer *)_recognizer;
+    UISwipeGestureRecognizer *recognizer = (RNSwipeGestureRecognizer *)_recognizer;
 
     id prop = config[@"direction"];
     if (prop != nil) {

--- a/ios/Handlers/RNLongPressHandler.m
+++ b/ios/Handlers/RNLongPressHandler.m
@@ -30,6 +30,11 @@
     return self;
 }
 
+-(void) setState:(UIGestureRecognizerState)state {
+  [super setState:state];
+  [_gestureHandler handleGestureStateTransition:self];
+}
+
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
     [super touchesMoved:touches withEvent:event];

--- a/ios/Handlers/RNNativeViewHandler.m
+++ b/ios/Handlers/RNNativeViewHandler.m
@@ -97,21 +97,21 @@
         }
     }
 
-    [self sendEventsInState:RNGestureHandlerStateActive
+    [self sendStateTransitions:RNGestureHandlerStateActive
              forViewWithTag:sender.reactTag
               withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES]];
 }
 
 - (void)handleTouchUpOutside:(UIView *)sender forEvent:(UIEvent *)event
 {
-    [self sendEventsInState:RNGestureHandlerStateEnd
+    [self sendStateTransitions:RNGestureHandlerStateEnd
              forViewWithTag:sender.reactTag
               withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
 }
 
 - (void)handleTouchUpInside:(UIView *)sender forEvent:(UIEvent *)event
 {
-    [self sendEventsInState:RNGestureHandlerStateEnd
+    [self sendStateTransitions:RNGestureHandlerStateEnd
              forViewWithTag:sender.reactTag
               withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES]];
 }
@@ -122,11 +122,11 @@
     if (self.shouldCancelWhenOutside) {
         UIControl *control = (UIControl *)sender;
         [control cancelTrackingWithEvent:event];
-        [self sendEventsInState:RNGestureHandlerStateEnd
+        [self sendStateTransitions:RNGestureHandlerStateEnd
                  forViewWithTag:sender.reactTag
                   withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
     } else {
-        [self sendEventsInState:RNGestureHandlerStateActive
+        [self sendStateTransitions:RNGestureHandlerStateActive
                  forViewWithTag:sender.reactTag
                   withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
     }
@@ -134,14 +134,14 @@
 
 - (void)handleDragEnter:(UIView *)sender forEvent:(UIEvent *)event
 {
-    [self sendEventsInState:RNGestureHandlerStateActive
+    [self sendStateTransitions:RNGestureHandlerStateActive
              forViewWithTag:sender.reactTag
               withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES]];
 }
 
 - (void)handleTouchCancel:(UIView *)sender forEvent:(UIEvent *)event
 {
-    [self sendEventsInState:RNGestureHandlerStateCancelled
+    [self sendStateTransitions:RNGestureHandlerStateCancelled
              forViewWithTag:sender.reactTag
               withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
 }

--- a/ios/Handlers/RNNativeViewHandler.m
+++ b/ios/Handlers/RNNativeViewHandler.m
@@ -97,21 +97,21 @@
         }
     }
 
-    [self sendStateTransitions:RNGestureHandlerStateActive
+    [self sendStateTransitionIfNeeded:RNGestureHandlerStateActive
              forViewWithTag:sender.reactTag
               withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES]];
 }
 
 - (void)handleTouchUpOutside:(UIView *)sender forEvent:(UIEvent *)event
 {
-    [self sendStateTransitions:RNGestureHandlerStateEnd
+    [self sendStateTransitionIfNeeded:RNGestureHandlerStateEnd
              forViewWithTag:sender.reactTag
               withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
 }
 
 - (void)handleTouchUpInside:(UIView *)sender forEvent:(UIEvent *)event
 {
-    [self sendStateTransitions:RNGestureHandlerStateEnd
+    [self sendStateTransitionIfNeeded:RNGestureHandlerStateEnd
              forViewWithTag:sender.reactTag
               withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES]];
 }
@@ -122,11 +122,11 @@
     if (self.shouldCancelWhenOutside) {
         UIControl *control = (UIControl *)sender;
         [control cancelTrackingWithEvent:event];
-        [self sendStateTransitions:RNGestureHandlerStateEnd
+        [self sendStateTransitionIfNeeded:RNGestureHandlerStateEnd
                  forViewWithTag:sender.reactTag
                   withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
     } else {
-        [self sendStateTransitions:RNGestureHandlerStateActive
+        [self sendStateTransitionIfNeeded:RNGestureHandlerStateActive
                  forViewWithTag:sender.reactTag
                   withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
     }
@@ -134,14 +134,14 @@
 
 - (void)handleDragEnter:(UIView *)sender forEvent:(UIEvent *)event
 {
-    [self sendStateTransitions:RNGestureHandlerStateActive
+    [self sendStateTransitionIfNeeded:RNGestureHandlerStateActive
              forViewWithTag:sender.reactTag
               withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES]];
 }
 
 - (void)handleTouchCancel:(UIView *)sender forEvent:(UIEvent *)event
 {
-    [self sendStateTransitions:RNGestureHandlerStateCancelled
+    [self sendStateTransitionIfNeeded:RNGestureHandlerStateCancelled
              forViewWithTag:sender.reactTag
               withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
 }

--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -64,6 +64,11 @@
   _realMinimumNumberOfTouches = minimumNumberOfTouches;
 }
 
+-(void) setState:(UIGestureRecognizerState)state {
+  [super setState:state];
+  [_gestureHandler handleGestureStateTransition:self];
+}
+
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   if (_hasCustomActivationCriteria) {

--- a/ios/Handlers/RNPinchHandler.m
+++ b/ios/Handlers/RNPinchHandler.m
@@ -8,17 +8,41 @@
 
 #import "RNPinchHandler.h"
 
+@interface RNPinchGestureRecognizer : UIPinchGestureRecognizer
+
+- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+
+@end
+
+@implementation RNPinchGestureRecognizer {
+  __weak RNGestureHandler *_gestureHandler;
+}
+
+- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
+{
+  if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
+    _gestureHandler = gestureHandler;
+  }
+  return self;
+}
+-(void) setState:(UIGestureRecognizerState)state {
+  [super setState:state];
+  [_gestureHandler handleGestureStateTransition:self];
+}
+
+@end
+
 @implementation RNPinchGestureHandler
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
     if ((self = [super initWithTag:tag])) {
-        _recognizer = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(handleGesture:)];
+        _recognizer = [[RNPinchGestureRecognizer alloc] initWithGestureHandler:self];
     }
     return self;
 }
 
-- (RNGestureHandlerEventExtraData *)eventExtraData:(UIPinchGestureRecognizer *)recognizer
+- (RNGestureHandlerEventExtraData *)eventExtraData:(RNPinchGestureRecognizer *)recognizer
 {
     return [RNGestureHandlerEventExtraData
             forPinch:recognizer.scale

--- a/ios/Handlers/RNRotationHandler.m
+++ b/ios/Handlers/RNRotationHandler.m
@@ -8,12 +8,36 @@
 
 #import "RNRotationHandler.h"
 
+@interface RNRotationGestureRecognizer : UIRotationGestureRecognizer
+
+- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+
+@end
+
+@implementation RNRotationGestureRecognizer {
+  __weak RNGestureHandler *_gestureHandler;
+}
+  
+  - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
+  {
+    if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
+      _gestureHandler = gestureHandler;
+    }
+    return self;
+  }
+  -(void) setState:(UIGestureRecognizerState)state {
+    [super setState:state];
+    [_gestureHandler handleGestureStateTransition:self];
+  }
+
+@end
+
 @implementation RNRotationGestureHandler
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
     if ((self = [super initWithTag:tag])) {
-        _recognizer = [[UIRotationGestureRecognizer alloc] initWithTarget:self action:@selector(handleGesture:)];
+        _recognizer = [[RNRotationGestureRecognizer alloc] initWithGestureHandler:self];
     }
     return self;
 }

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -85,11 +85,6 @@
     [self triggerAction];
 }
 
--(void) setState:(UIGestureRecognizerState)state {
-  [super setState:state];
-  [_gestureHandler handleGestureStateTransition:self];
-}
-
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
     [super touchesMoved:touches withEvent:event];

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -85,6 +85,11 @@
     [self triggerAction];
 }
 
+-(void) setState:(UIGestureRecognizerState)state {
+  [super setState:state];
+  [_gestureHandler handleGestureStateTransition:self];
+}
+
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
     [super touchesMoved:touches withEvent:event];

--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -69,7 +69,7 @@ if (value != nil) recognizer.prop = [RCTConvert type:value]; \
            forViewWithTag:(nonnull NSNumber *)reactTag
             withExtraData:(RNGestureHandlerEventExtraData *)extraData;
 
-- (void)sendStateTransitions:(RNGestureHandlerState)state
+- (void)sendStateTransitionIfNeeded:(RNGestureHandlerState)state
            forViewWithTag:(nonnull NSNumber *)reactTag
             withExtraData:(RNGestureHandlerEventExtraData *)extraData;
 

--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -60,11 +60,16 @@ if (value != nil) recognizer.prop = [RCTConvert type:value]; \
 - (void)unbindFromView;
 - (void)configure:(nullable NSDictionary *)config NS_REQUIRES_SUPER;
 - (void)handleGesture:(nonnull id)recognizer;
+- (void)handleGestureStateTransition:(nonnull id)recognizer;
 - (RNGestureHandlerState)state;
 - (nullable RNGestureHandlerEventExtraData *)eventExtraData:(nonnull id)recognizer;
 
 - (void)reset;
 - (void)sendEventsInState:(RNGestureHandlerState)state
+           forViewWithTag:(nonnull NSNumber *)reactTag
+            withExtraData:(RNGestureHandlerEventExtraData *)extraData;
+
+- (void)sendStateTransitions:(RNGestureHandlerState)state
            forViewWithTag:(nonnull NSNumber *)reactTag
             withExtraData:(RNGestureHandlerEventExtraData *)extraData;
 

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -157,7 +157,7 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
 - (void)handleGestureStateTransition:(UIGestureRecognizer *)recognizer
 {
   RNGestureHandlerEventExtraData *eventData = [self eventExtraData:recognizer];
-  [self sendStateTransitions:self.state forViewWithTag:recognizer.view.reactTag withExtraData:eventData];
+  [self sendStateTransitionIfNeeded:self.state forViewWithTag:recognizer.view.reactTag withExtraData:eventData];
   if (_lastState == UIGestureRecognizerStatePossible && (self.state == UIGestureRecognizerStateFailed || self.state == UIGestureRecognizerStateCancelled)) {
    // [self reset];
   }
@@ -173,13 +173,13 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
                                                          extraData:extraData];
 
   
-
+    [self sendStateTransitionIfNeeded:state forViewWithTag:reactTag withExtraData:extraData];
     if (state == RNGestureHandlerStateActive) {
         [self.emitter sendTouchEvent:touchEvent];
     }
 }
 
-- (void) sendStateTransitions:(RNGestureHandlerState)state
+- (void) sendStateTransitionIfNeeded:(RNGestureHandlerState)state
                forViewWithTag:(nonnull NSNumber *)reactTag
                 withExtraData:(RNGestureHandlerEventExtraData *)extraData {
   if (state != _lastState) {


### PR DESCRIPTION
## Motivation 
Cancellation from `UIGestureRecognizerStatePossible` of GH on iOS was previously done silently. Now it's being sent.

## Changes
Split sending-related logic to two methods
Add invoking state changes-related sender from state setter
