### PR TITLE
Fix newProps calculation on update

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -278,8 +278,8 @@ function createHandler(
 
     _update() {
       const newConfig = filterConfig(
-        this.props,
-        this.constructor.propTypes,
+        transformProps ? transformProps(this.props) : this.props,
+        { ...this.constructor.propTypes, ...customNativeProps },
         config
       );
       if (!deepEqual(this._config, newConfig)) {
@@ -382,7 +382,6 @@ const TapGestureHandler = createHandler(
     numberOfTaps: PropTypes.number,
     maxDeltaX: PropTypes.number,
     maxDeltaY: PropTypes.number,
-    minPointers: PropTypes.number,
     maxDist: PropTypes.number,
     minPointers: PropTypes.number,
   },


### PR DESCRIPTION
Inspired by https://github.com/kmagiera/react-native-gesture-handler/issues/311
With with props I forgot to update calculation mechanism on `componentDidUpdate`