### PR TITLE
Add Pod Spec [BREAKING]

### DIFF
--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -2,7 +2,7 @@ require "json"
 
 Pod::Spec.new do |s|
   # NPM package specification
-  package = JSON.parse(File.read(File.join(File.dirname(__FILE__), "../package.json")))
+  package = JSON.parse(File.read(File.join(File.dirname(__FILE__), "package.json")))
 
   s.name         = "RNGestureHandler"
   s.version      = package["version"]

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "DrawerLayout.js",
     "gestureHandlerRootHOC.android.js",
     "gestureHandlerRootHOC.ios.js",
-    "react-native-gesture-handler.d.ts"
+    "react-native-gesture-handler.d.ts",
+    "RNGestureHandler.podspec"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
The other PR #209 use use different project name than ios/RNGestureHandler.podspec, this might create some conflict.

Also podspec file need to be included with `package.json`, otherwise it will be ignored during `npm install`.


**[BREAKING]** Podspec location has been changed from `./ios/RNGestureHandler.podspec` to `./RNGestureHandler.podspec`. The previous consumers of the podspec should update their podfile to reflect that change
