### PR TITLE
Optimize DrawerLayout by avoiding setState during animation

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -289,6 +289,20 @@ function createHandler(
       }
     }
 
+    setNativeProps(updates) {
+      const mergedProps = { ...this.props, ...updates };
+      const newConfig = filterConfig(
+        transformProps ? transformProps(mergedProps) : mergedProps,
+        { ...this.constructor.propTypes, ...customNativeProps },
+        config
+      );
+      this._config = newConfig;
+      RNGestureHandlerModule.updateGestureHandler(
+        this._handlerTag,
+        this._config
+      );
+    }
+
     render() {
       let gestureEventHandler = this._onGestureHandlerEvent;
       const { onGestureEvent, onGestureHandlerEvent } = this.props;


### PR DESCRIPTION
This PR adds two optimizations that makes using DrawerLayout implementation much more enjoyable, specifically by minimizing junked caused by the fact we need to do JS roundtip in between the end of a gesture and start of the animation.

Optimizations made:
 - avoid keeping `drawerShown` in state. Instead we keep references to a couple of views that we need to update and call `setNativeProps` directly
 - added `setNativeProps` implementation to gesture handler component so that it can be updated via ref without re-rendering
 - predict next animation position when using native driver after the gesture is release. Previously it was causing an extra frame of deley as even when the animation has started it'd still start from the last position of a drawer and only with the next frame it'd start moving. Now we force it to move a bit before starting the animation as we know that the animation will start delayed.
 