### PR TITLE
Force Touch  GH

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -19,6 +19,7 @@ import ChatHeads from './chatHeads';
 import { ComboWithGHScroll, ComboWithRNScroll } from './combo';
 import BottomSheet from './bottomSheet/index';
 import doubleScalePinchAndRotate from './doubleScalePinchAndRotate';
+import forceTouch from './forcetouch';
 
 YellowBox.ignoreWarnings([
   'Warning: isMounted(...) is deprecated',
@@ -71,6 +72,10 @@ const SCREENS = {
   doubleDraggable: {
     screen: doubleDraggable,
     title: 'Two handlers simultaneously',
+  },
+  forceTouch: {
+    screen: forceTouch,
+    title: 'Force touch',
   },
 };
 

--- a/Example/forcetouch/index.js
+++ b/Example/forcetouch/index.js
@@ -30,11 +30,6 @@ export default class Example extends Component {
           Force touch works only on some Apple devices (iPhones 6s+ excluding
           XR) and should be used only as a supportive one{' '}
         </Text>
-        {ForceTouchGestureHandler.isAvailable || (
-          <Text style={{ textAlign: 'center', width: '80%' }}>
-            NOT SUPPORTED ON THIS DEVICE
-          </Text>
-        )}
         <ForceTouchGestureHandler
           feedbackOnActivation
           onGestureEvent={this._onGestureEvent}

--- a/Example/forcetouch/index.js
+++ b/Example/forcetouch/index.js
@@ -1,0 +1,63 @@
+import React, { Component } from 'react';
+import { Animated, StyleSheet, View, Text } from 'react-native';
+
+import { State, ForceTouchGestureHandler } from 'react-native-gesture-handler';
+
+import { USE_NATIVE_DRIVER } from '../config';
+
+export default class Example extends Component {
+  force = new Animated.Value(0);
+  _onGestureEvent = Animated.event(
+    [
+      {
+        nativeEvent: {
+          force: this.force,
+        },
+      },
+    ],
+    { useNativeDriver: USE_NATIVE_DRIVER }
+  );
+  _onHandlerStateChange = event => {
+    if (event.nativeEvent.oldState === State.ACTIVE) {
+      this.force.setValue(0);
+    }
+  };
+  render() {
+    return (
+      <View style={styles.view}>
+        <Text style={{ textAlign: 'center', width: '80%' }}>
+          {' '}
+          Force touch works only on some Apple devices (iPhones 6s+ excluding
+          XR) and should be used only as a supportive one{' '}
+        </Text>
+        <ForceTouchGestureHandler
+          minForce={0}
+          onGestureEvent={this._onGestureEvent}
+          onHandlerStateChange={this._onHandlerStateChange}>
+          <Animated.View
+            style={[
+              styles.box,
+              { transform: [{ scale: Animated.add(1, this.force) }] },
+            ]}
+          />
+        </ForceTouchGestureHandler>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  view: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  box: {
+    width: 150,
+    height: 150,
+
+    backgroundColor: 'mediumspringgreen',
+    margin: 10,
+    zIndex: 200,
+  },
+});

--- a/Example/forcetouch/index.js
+++ b/Example/forcetouch/index.js
@@ -36,7 +36,7 @@ export default class Example extends Component {
           </Text>
         )}
         <ForceTouchGestureHandler
-          minForce={0}
+          feedbackOnActivation
           onGestureEvent={this._onGestureEvent}
           onHandlerStateChange={this._onHandlerStateChange}>
           <Animated.View

--- a/Example/forcetouch/index.js
+++ b/Example/forcetouch/index.js
@@ -25,11 +25,6 @@ export default class Example extends Component {
   render() {
     return (
       <View style={styles.view}>
-        <Text style={{ textAlign: 'center', width: '80%' }}>
-          {' '}
-          Force touch works only on some Apple devices (iPhones 6s+ excluding
-          XR) and should be used only as a supportive one{' '}
-        </Text>
         <ForceTouchGestureHandler
           minForce={0}
           onGestureEvent={this._onGestureEvent}

--- a/Example/forcetouch/index.js
+++ b/Example/forcetouch/index.js
@@ -25,6 +25,16 @@ export default class Example extends Component {
   render() {
     return (
       <View style={styles.view}>
+        <Text style={{ textAlign: 'center', width: '80%' }}>
+          {' '}
+          Force touch works only on some Apple devices (iPhones 6s+ excluding
+          XR) and should be used only as a supportive one{' '}
+        </Text>
+        {ForceTouchGestureHandler.isAvailable || (
+          <Text style={{ textAlign: 'center', width: '80%' }}>
+            NOT SUPPORTED ON THIS DEVICE
+          </Text>
+        )}
         <ForceTouchGestureHandler
           minForce={0}
           onGestureEvent={this._onGestureEvent}

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -4,6 +4,7 @@ import {
   requireNativeComponent,
   Animated,
   NativeModules,
+  Text,
   ScrollView,
   Slider,
   Switch,
@@ -411,18 +412,20 @@ const FlingGestureHandler = createHandler(
 
 const ForceTouchFallback = props => props.children;
 
-const ForceTouchGestureHandler =
-  Platform.OS === 'ios'
-    ? createHandler(
-        'ForceTouchGestureHandler',
-        {
-          minForce: PropTypes.number,
-          maxForce: PropTypes.number,
-          feedbackOnActivation: PropTypes.bool,
-        },
-        {}
-      )
-    : ForceTouchFallback;
+const ForceTouchGestureHandler = NativeModules.PlatformConstants
+  .forceTouchAvailable ? (
+  createHandler(
+    'ForceTouchGestureHandler',
+    {
+      minForce: PropTypes.number,
+      maxForce: PropTypes.number,
+      feedbackOnActivation: PropTypes.bool,
+    },
+    {}
+  )
+) : (
+  <Text>Force Touch is not available on this platform</Text>
+);
 
 ForceTouchGestureHandler.forceTouchAvailable =
   NativeModules.PlatformConstants.forceTouchAvailable || false;

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -418,7 +418,7 @@ const ForceTouchGestureHandler =
         {
           minForce: PropTypes.number,
           maxForce: PropTypes.number,
-          feedbackOnActivation: PropTypes.boolean,
+          feedbackOnActivation: PropTypes.bool,
         },
         {}
       )

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -409,6 +409,12 @@ const FlingGestureHandler = createHandler(
   {}
 );
 
+const ForceTouchGestureHandler = createHandler(
+  'ForceTouchGestureHandler',
+  {},
+  {}
+);
+
 const LongPressGestureHandler = createHandler(
   'LongPressGestureHandler',
   {
@@ -885,6 +891,7 @@ export {
   NativeViewGestureHandler,
   TapGestureHandler,
   FlingGestureHandler,
+  ForceTouchGestureHandler,
   LongPressGestureHandler,
   PanGestureHandler,
   PinchGestureHandler,

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -409,7 +409,7 @@ const FlingGestureHandler = createHandler(
   {}
 );
 
-const AndroidForceTouchFallback = props => props.children;
+const ForceTouchFallback = props => props.children;
 
 const ForceTouchGestureHandler =
   Platform.OS === 'ios'
@@ -422,7 +422,7 @@ const ForceTouchGestureHandler =
         },
         {}
       )
-    : AndroidForceTouchFallback;
+    : ForceTouchFallback;
 
 ForceTouchGestureHandler.isAvailable =
   NativeModules.PlatformConstants.forceTouchAvailable || false;

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -424,7 +424,7 @@ const ForceTouchGestureHandler =
       )
     : ForceTouchFallback;
 
-ForceTouchGestureHandler.isAvailable =
+ForceTouchGestureHandler.forceTouchAvailable =
   NativeModules.PlatformConstants.forceTouchAvailable || false;
 
 const LongPressGestureHandler = createHandler(

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -4,7 +4,6 @@ import {
   requireNativeComponent,
   Animated,
   NativeModules,
-  Text,
   ScrollView,
   Slider,
   Switch,
@@ -410,11 +409,14 @@ const FlingGestureHandler = createHandler(
   {}
 );
 
-const ForceTouchFallback = props => (
-  <Text style={{ color: 'red' }}>
-    Force Touch is not available on this platform
-  </Text>
-);
+class ForceTouchFallback extends React.Component {
+  componentDidMount() {
+    console.warn('Force Touch is not available on this platform');
+  }
+  render() {
+    return this.props.children;
+  }
+}
 
 const ForceTouchGestureHandler = NativeModules.PlatformConstants
   .forceTouchAvailable

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -410,22 +410,24 @@ const FlingGestureHandler = createHandler(
   {}
 );
 
-const ForceTouchFallback = props => props.children;
+const ForceTouchFallback = props => (
+  <Text style={{ color: 'red' }}>
+    Force Touch is not available on this platform
+  </Text>
+);
 
 const ForceTouchGestureHandler = NativeModules.PlatformConstants
-  .forceTouchAvailable ? (
-  createHandler(
-    'ForceTouchGestureHandler',
-    {
-      minForce: PropTypes.number,
-      maxForce: PropTypes.number,
-      feedbackOnActivation: PropTypes.bool,
-    },
-    {}
-  )
-) : (
-  <Text>Force Touch is not available on this platform</Text>
-);
+  .forceTouchAvailable
+  ? createHandler(
+      'ForceTouchGestureHandler',
+      {
+        minForce: PropTypes.number,
+        maxForce: PropTypes.number,
+        feedbackOnActivation: PropTypes.bool,
+      },
+      {}
+    )
+  : ForceTouchFallback;
 
 ForceTouchGestureHandler.forceTouchAvailable =
   NativeModules.PlatformConstants.forceTouchAvailable || false;

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -418,6 +418,7 @@ const ForceTouchGestureHandler =
         {
           minForce: PropTypes.number,
           maxForce: PropTypes.number,
+          feedbackOnActivation: PropTypes.boolean,
         },
         {}
       )

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -423,6 +423,9 @@ const ForceTouchGestureHandler =
       )
     : AndroidForceTouchFallback;
 
+ForceTouchGestureHandler.isAvailable =
+  NativeModules.PlatformConstants.forceTouchAvailable || false;
+
 const LongPressGestureHandler = createHandler(
   'LongPressGestureHandler',
   {

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -409,11 +409,19 @@ const FlingGestureHandler = createHandler(
   {}
 );
 
-const ForceTouchGestureHandler = createHandler(
-  'ForceTouchGestureHandler',
-  {},
-  {}
-);
+const AndroidForceTouchFallback = props => props.children;
+
+const ForceTouchGestureHandler =
+  Platform.OS === 'ios'
+    ? createHandler(
+        'ForceTouchGestureHandler',
+        {
+          minForce: PropTypes.number,
+          maxForce: PropTypes.number,
+        },
+        {}
+      )
+    : AndroidForceTouchFallback;
 
 const LongPressGestureHandler = createHandler(
   'LongPressGestureHandler',

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -411,7 +411,7 @@ const FlingGestureHandler = createHandler(
 
 class ForceTouchFallback extends React.Component {
   componentDidMount() {
-    console.warn('Force Touch is not available on this platform');
+    console.warn('ForceTouchGestureHandler is not available on this platform. Please use ForceTouchGestureHandler.forceTouchAvailable to conditionally render other components that would provide a fallback behavior specific to your usecase');
   }
   render() {
     return this.props.children;

--- a/docs/about-handlers.md
+++ b/docs/about-handlers.md
@@ -29,6 +29,7 @@ Currently the library provides the following list of gestures. Their parameters 
  - [`RotationGestureHandler`](handler-rotation.md)
  - [`FlingGestureHandler`](handler-fling.md)
  - [`PinchGestureHandler`](handler-pinch.md)
+ - [`ForceTouchGestureHandler`](handler-force.md)
 
 ---
 ### Discrete vs continuous

--- a/docs/handler-force.md
+++ b/docs/handler-force.md
@@ -4,14 +4,14 @@ title: ForceTouchGestureHandler (iOS only)
 sidebar_label: ForceTouchGestureHandler
 ---
 
-A continuous gesture handler that recognizes force touch. It allows for tracking pressure of touch on some iOS devices.
+A continuous gesture handler that recognizes force of a touch. It allows for tracking pressure of touch on some iOS devices.
 The handler [activates](state.md#active) when pressure of touch if greater or equal than `minForce`. It fails if pressure is greater than `maxForce`
 Gesture callback can be used for continuous tracking of the touch pressure. It provides information for one finger (the first one).
 
 At the beginning of the gesture, the pressure factor is 0.0. As the pressure increases, the pressure factor increases proportionally. The maximum pressure is 1.0.
 
 The handler is implemented using custom [UIGestureRecognizer](https://developer.apple.com/documentation/uikit/uigesturerecognizer) on iOS. There's no implementation provided on Android and it simply render children without any wrappers.
-Since this behaviour is only provided on some iOS devices, this handler should not be used for defining any crucial behaviors. Use it only as additional improvements and make all features to be accessed without this handler as well.
+Since this behaviour is only provided on some iOS devices, this handler should not be used for defining any crucial behaviors. Use it only as an additional improvement and make all features to be accessed without this handler as well.
 
 # Properties
 
@@ -31,7 +31,7 @@ See [set of event attributes from base handler class](handler-common.md#event-da
 
 ---
 ### `force`
-The pressure of touch.
+The pressure of a touch.
 
 
 ## Static method

--- a/docs/handler-force.md
+++ b/docs/handler-force.md
@@ -1,0 +1,53 @@
+---
+id: handler-force
+title: ForceTouchGestureHandler (iOS only)
+sidebar_label: ForceTouchGestureHandler
+---
+
+A continuous gesture handler that recognizes force touch. It allows for tracking pressure of touch on some iOS devices.
+The handler [activates](state.md#active) when pressure of touch if greater or equal than `minForce`. It fails if pressure is greater than `maxForce`
+Gesture callback can be used for continuous tracking of the touch pressure. It provides information for one finger (the first one).
+
+At the beginning of the gesture, the pressure factor is 0.0. As the pressure increases, the pressure factor increases proportionally. The maximum pressure is 1.0.
+
+The handler is implemented using custom [UIGestureRecognizer](https://developer.apple.com/documentation/uikit/uigesturerecognizer) on iOS. There's no implementation provided on Android and it simply render children without any wrappers.
+Since this behaviour is only provided on some iOS devices, this handler should not be used for defining any crucial behaviors. Use it only as additional improvements and make all features to be accessed without this handler as well.
+
+# Properties
+
+See [set of properties inherited from base handler class](handler-common.md#properties). Below is a list of properties specific to `ForceTouchGestureHandler` component:
+
+---
+### `minForce`
+A minimal pressure that is required before handler can [activate](state.md#active). Should be a value from range `[0.0, 1.0]`.
+
+---
+### `maxForce`
+A maximal pressure that could be applied for handler. If the pressure is greater, handler [fails](state.md#failed). Should be a value from range `[0.0, 1.0]`.
+
+
+## Event data
+See [set of event attributes from base handler class](handler-common.md#event-data). Below is a list of gesture event attributes specific to `ForceTouchGestureHandler`:
+
+---
+### `force`
+The pressure of touch.
+
+
+## Example
+
+See the [force touch handler example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/forcetouch/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
+
+```js
+<ForceTouchGestureHandler
+  minForce={0}
+  onGestureEvent={this._onGestureEvent}
+  onHandlerStateChange={this._onHandlerStateChange}>
+  <Animated.View
+    style={[
+      styles.box,
+      { transform: [{ scale: Animated.add(1, this.force) }] },
+    ]}
+  />
+</ForceTouchGestureHandler>
+```

--- a/docs/handler-force.md
+++ b/docs/handler-force.md
@@ -41,8 +41,8 @@ The pressure of a touch.
 ## Static method
 
 ---
-### `isAvailable`
-You may check if it's possible to use `ForceTouchGestureHandler` with `ForceTouchGestureHandler.isAvailable()`
+### `forceTouchAvailable`
+You may check if it's possible to use `ForceTouchGestureHandler` with `ForceTouchGestureHandler.forceTouchAvailable`
 
 ## Example
 

--- a/docs/handler-force.md
+++ b/docs/handler-force.md
@@ -25,6 +25,10 @@ A minimal pressure that is required before handler can [activate](state.md#activ
 ### `maxForce`
 A maximal pressure that could be applied for handler. If the pressure is greater, handler [fails](state.md#failed). Should be a value from range `[0.0, 1.0]`.
 
+---
+### `feedbackOnActivation`
+Boolean value defining if haptic feedback has to be performed on activation.
+
 
 ## Event data
 See [set of event attributes from base handler class](handler-common.md#event-data). Below is a list of gesture event attributes specific to `ForceTouchGestureHandler`:

--- a/docs/handler-force.md
+++ b/docs/handler-force.md
@@ -19,7 +19,7 @@ See [set of properties inherited from base handler class](handler-common.md#prop
 
 ---
 ### `minForce`
-A minimal pressure that is required before handler can [activate](state.md#active). Should be a value from range `[0.0, 1.0]`.
+A minimal pressure that is required before handler can [activate](state.md#active). Should be a value from range `[0.0, 1.0]`. Default is `0.2`.
 
 ---
 ### `maxForce`

--- a/docs/handler-force.md
+++ b/docs/handler-force.md
@@ -34,6 +34,12 @@ See [set of event attributes from base handler class](handler-common.md#event-da
 The pressure of touch.
 
 
+## Static method
+
+---
+### `isAvailable`
+You may check if it's possible to use `ForceTouchGestureHandler` with `ForceTouchGestureHandler.isAvailable()`
+
 ## Example
 
 See the [force touch handler example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/forcetouch/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -12,6 +12,7 @@ Here are a gesture recognizers currently available in the package:
  - `PinchGestureHandler`
  - `RotationGestureHandler`
  - `FlingGestureHandler`
+ - `ForceTouchGestureHandler`
 
 Whenever you use a native component that should handle touch events you can either wrap it with `NativeViewGestureHandler` or import wrapper component exported by the library instead of importing it from `react-native` package. Here is the list of available components:
  - `ScrollView`

--- a/ios/Handlers/RNForceTouchHandler.h
+++ b/ios/Handlers/RNForceTouchHandler.h
@@ -1,0 +1,4 @@
+#import "RNGestureHandler.h"
+
+@interface RNForceTouchHandler : RNGestureHandler
+@end

--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -62,7 +62,7 @@
 }
 
 - (BOOL) shouldFail {
-  return (_maxForce != NAN && _force >= _maxForce);
+  return (_maxForce != NAN && _force > _maxForce);
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event

--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -47,7 +47,7 @@
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   if (![touches containsObject:_firstTouch]) {
-    // We're interested only on the very first touch
+    // Considered only the very first touch
     return;
   }
   [super touchesMoved:touches withEvent:event];
@@ -84,7 +84,7 @@
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   if (![touches containsObject:_firstTouch]) {
-    // We're interested only on the very first touch
+    // Considered only the very first touch
     return;
   }
   [super touchesEnded:touches withEvent:event];

--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -9,6 +9,7 @@
 @property (nonatomic) CGFloat maxForce;
 @property (nonatomic) CGFloat minForce;
 @property (nonatomic) CGFloat force;
+@property (nonatomic) BOOL feedbackOnActivation;
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
 
@@ -27,6 +28,7 @@
     _force = 0;
     _minForce = 0.2;
     _maxForce = NAN;
+    _feedbackOnActivation = NO;
   }
   return self;
 }
@@ -53,6 +55,7 @@
   
   [self handleForceWithTouches:touches];
   if (self.state == UIGestureRecognizerStatePossible && [self shouldActivate]) {
+    [self performFeedbackIfNeeded];
     self.state = UIGestureRecognizerStateBegan;
   }
 }
@@ -63,6 +66,13 @@
 
 - (BOOL) shouldFail {
   return (_maxForce != NAN && _force > _maxForce);
+}
+
+- (void)performFeedbackIfNeeded
+{
+  if (_feedbackOnActivation) {
+    [[[UIImpactFeedbackGenerator alloc] initWithStyle:(UIImpactFeedbackStyleMedium)] impactOccurred];
+  }
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
@@ -108,6 +118,11 @@
 
   APPLY_FLOAT_PROP(maxForce);
   APPLY_FLOAT_PROP(minForce);
+  id prop = config[@"feedbackOnActivation"];
+  if (prop != nil) {
+    recognizer.feedbackOnActivation = [RCTConvert BOOL:prop];
+  }
+  
 }
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(RNForceTouchGestureRecognizer *)recognizer

--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -1,0 +1,58 @@
+#import "RNForceTouchHandler.h"
+
+#import <UIKit/UIGestureRecognizerSubclass.h>
+
+#import <React/RCTConvert.h>
+
+@interface RNForceTouchGestureRecognizer : UIGestureRecognizer
+
+@property (nonatomic) CGFloat maxForce;
+@property (nonatomic) CGFloat minForce;
+@property (nonatomic) BOOL avgForce;
+
+
+@end
+
+@implementation RNForceTouchGestureRecognizer
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  
+}
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [touches anyObject]
+  
+}
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  
+}
+@end
+
+@implementation RNForceTouchHandler
+
+- (instancetype)initWithTag:(NSNumber *)tag
+{
+  if ((self = [super initWithTag:tag])) {
+    _recognizer = [[RNForceTouchGestureRecognizer alloc] init];
+  }
+  return self;
+}
+
+- (void)configure:(NSDictionary *)config
+{
+  [super configure:config];
+  RNForceTouchGestureRecognizer *recognizer = (RNForceTouchGestureRecognizer *)_recognizer;
+  
+
+  APPLY_FLOAT_PROP(maxForce);
+  APPLY_FLOAT_PROP(minForce);
+  
+  id prop = config[@"avgForce"];
+  if (prop != nil) {
+    recognizer.avgForce = [RCTConvert BOOL:prop];
+  }
+}
+
+@end
+

--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -95,11 +95,11 @@
   }
 }
 
-- (void) handleForceWithTouches:(NSSet<UITouch *> *)touches {
+- (void)handleForceWithTouches:(NSSet<UITouch *> *)touches {
   _force = _firstTouch.force / _firstTouch.maximumPossibleForce;
 }
 
-- (void) reset {
+- (void)reset {
   [super reset];
   _force = 0;
   _firstTouch = NULL;

--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -44,6 +44,7 @@
   [self handleForceWithTouches:touches];
   self.state = UIGestureRecognizerStatePossible;
 }
+
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   if (![touches containsObject:_firstTouch]) {
@@ -58,7 +59,6 @@
     self.state = UIGestureRecognizerStateFailed;
     return;
   }
-  
   
   if (self.state == UIGestureRecognizerStatePossible && [self shouldActivate]) {
     [self performFeedbackIfRequired];
@@ -99,11 +99,12 @@
   self.force=_firstTouch.force / _firstTouch.maximumPossibleForce;
 }
 
--(void) reset {
+- (void) reset {
   [super reset];
   self.force = 0;
   _firstTouch = NULL;
 }
+
 @end
 
 @implementation RNForceTouchHandler
@@ -120,15 +121,14 @@
 {
   [super configure:config];
   RNForceTouchGestureRecognizer *recognizer = (RNForceTouchGestureRecognizer *)_recognizer;
-  
-  
+
   APPLY_FLOAT_PROP(maxForce);
   APPLY_FLOAT_PROP(minForce);
+
   id prop = config[@"feedbackOnActivation"];
   if (prop != nil) {
     recognizer.feedbackOnActivation = [RCTConvert BOOL:prop];
   }
-  
 }
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(RNForceTouchGestureRecognizer *)recognizer

--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -66,11 +66,11 @@
   }
 }
 
-- (BOOL) shouldActivate {
+- (BOOL)shouldActivate {
   return (_force >= _minForce);
 }
 
-- (BOOL) shouldFail {
+- (BOOL)shouldFail {
   return TEST_MAX_IF_NOT_NAN(_force, _maxForce);
 }
 
@@ -96,12 +96,12 @@
 }
 
 - (void) handleForceWithTouches:(NSSet<UITouch *> *)touches {
-  self.force=_firstTouch.force / _firstTouch.maximumPossibleForce;
+  _force = _firstTouch.force / _firstTouch.maximumPossibleForce;
 }
 
 - (void) reset {
   [super reset];
-  self.force = 0;
+  _force = 0;
   _firstTouch = NULL;
 }
 

--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -58,11 +58,11 @@
 }
 
 - (BOOL) shouldActivate {
-  return (_force > _minForce);
+  return (_force >= _minForce);
 }
 
 - (BOOL) shouldFail {
-  return (_maxForce != NAN && _force > _maxForce);
+  return (_maxForce != NAN && _force >= _maxForce);
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event

--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -71,7 +71,7 @@
 }
 
 - (BOOL) shouldFail {
-  return (_maxForce != NAN && _force > _maxForce);
+  return TEST_MAX_IF_NOT_NAN(_force, _maxForce);
 }
 
 - (void)performFeedbackIfRequired

--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -8,24 +8,85 @@
 
 @property (nonatomic) CGFloat maxForce;
 @property (nonatomic) CGFloat minForce;
-@property (nonatomic) BOOL avgForce;
+@property (nonatomic) CGFloat force;
 
+- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
 
 @end
 
-@implementation RNForceTouchGestureRecognizer
+@implementation RNForceTouchGestureRecognizer {
+  __weak RNGestureHandler *_gestureHandler;
+  UITouch *_firstTouch;
+}
+
+
+- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
+{
+  if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
+    _gestureHandler = gestureHandler;
+    _force = 0;
+    _minForce = 0.2;
+    _maxForce = NAN;
+  }
+  return self;
+}
+
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-  
+  [super touchesBegan:touches withEvent:event];
+  _firstTouch = [touches anyObject];
+  [self handleForceWithTouches:touches];
+  self.state = UIGestureRecognizerStatePossible;
 }
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-  [touches anyObject]
+  [super touchesMoved:touches withEvent:event];
+  if ([self shouldFail]) {
+    self.state = UIGestureRecognizerStateFailed;
+    return;
+  }
   
+  if (![touches containsObject:_firstTouch] && self.state == UIGestureRecognizerStateBegan){
+    self.state = UIGestureRecognizerStateEnded;
+    return;
+  }
+  
+  [self handleForceWithTouches:touches];
+  if (self.state == UIGestureRecognizerStatePossible && [self shouldActivate]) {
+    self.state = UIGestureRecognizerStateBegan;
+  }
 }
+
+- (BOOL) shouldActivate {
+  return (_force > _minForce);
+}
+
+- (BOOL) shouldFail {
+  return (_maxForce != NAN && _force > _maxForce);
+}
+
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-  
+  [super touchesEnded:touches withEvent:event];
+  if (self.state == UIGestureRecognizerStateBegan || self.state == UIGestureRecognizerStateChanged) {
+    self.state = UIGestureRecognizerStateEnded;
+  } else {
+    self.state = UIGestureRecognizerStateFailed;
+  }
+}
+
+- (void) handleForceWithTouches:(NSSet<UITouch *> *)touches {
+  if ([touches count] != 1) {
+    self.state = UIGestureRecognizerStateFailed;
+    return;
+  }
+
+  self.force=_firstTouch.force / _firstTouch.maximumPossibleForce;
+}
+
+-(void) reset {
+  [super reset];
+  self.force = 0;
 }
 @end
 
@@ -34,7 +95,7 @@
 - (instancetype)initWithTag:(NSNumber *)tag
 {
   if ((self = [super initWithTag:tag])) {
-    _recognizer = [[RNForceTouchGestureRecognizer alloc] init];
+    _recognizer = [[RNForceTouchGestureRecognizer alloc] initWithGestureHandler:self];
   }
   return self;
 }
@@ -47,11 +108,15 @@
 
   APPLY_FLOAT_PROP(maxForce);
   APPLY_FLOAT_PROP(minForce);
-  
-  id prop = config[@"avgForce"];
-  if (prop != nil) {
-    recognizer.avgForce = [RCTConvert BOOL:prop];
-  }
+}
+
+- (RNGestureHandlerEventExtraData *)eventExtraData:(RNForceTouchGestureRecognizer *)recognizer
+{
+  return [RNGestureHandlerEventExtraData
+          forForce: recognizer.force
+          forPosition:[recognizer locationInView:recognizer.view]
+          withAbsolutePosition:[recognizer locationInView:recognizer.view.window]
+          withNumberOfTouches:recognizer.numberOfTouches];
 }
 
 @end

--- a/ios/RNGestureHandler.xcodeproj/project.pbxproj
+++ b/ios/RNGestureHandler.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		44BE34481F1E1AAA008679D1 /* RNGestureHandlerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 44BE34471F1E1AAA008679D1 /* RNGestureHandlerManager.m */; };
 		44BE344A1F1E1ABA008679D1 /* RNGestureHandlerManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 44BE34491F1E1ABA008679D1 /* RNGestureHandlerManager.h */; };
 		660F46742080D8F700B7B50D /* RNGestureHandlerDirection.h in Headers */ = {isa = PBXBuildFile; fileRef = 660F46732080D8F600B7B50D /* RNGestureHandlerDirection.h */; };
+		668E083C21BDD70900EDDF40 /* RNForceTouchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 668E083A21BDD70900EDDF40 /* RNForceTouchHandler.h */; };
+		668E083D21BDD70900EDDF40 /* RNForceTouchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 668E083B21BDD70900EDDF40 /* RNForceTouchHandler.m */; };
 		66A291D5207D032400809C27 /* RNFlingHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 66A291D3207D032400809C27 /* RNFlingHandler.m */; };
 		66A291D6207D032400809C27 /* RNFlingHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 66A291D4207D032400809C27 /* RNFlingHandler.h */; };
 /* End PBXBuildFile section */
@@ -81,6 +83,8 @@
 		44BE34471F1E1AAA008679D1 /* RNGestureHandlerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNGestureHandlerManager.m; sourceTree = "<group>"; };
 		44BE34491F1E1ABA008679D1 /* RNGestureHandlerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNGestureHandlerManager.h; sourceTree = "<group>"; };
 		660F46732080D8F600B7B50D /* RNGestureHandlerDirection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNGestureHandlerDirection.h; sourceTree = "<group>"; };
+		668E083A21BDD70900EDDF40 /* RNForceTouchHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNForceTouchHandler.h; path = Handlers/RNForceTouchHandler.h; sourceTree = "<group>"; };
+		668E083B21BDD70900EDDF40 /* RNForceTouchHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RNForceTouchHandler.m; path = Handlers/RNForceTouchHandler.m; sourceTree = "<group>"; };
 		66A291D3207D032400809C27 /* RNFlingHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RNFlingHandler.m; path = Handlers/RNFlingHandler.m; sourceTree = "<group>"; };
 		66A291D4207D032400809C27 /* RNFlingHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNFlingHandler.h; path = Handlers/RNFlingHandler.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -107,6 +111,8 @@
 		44AEC7221F8FA1150086889F /* Handlers */ = {
 			isa = PBXGroup;
 			children = (
+				668E083A21BDD70900EDDF40 /* RNForceTouchHandler.h */,
+				668E083B21BDD70900EDDF40 /* RNForceTouchHandler.m */,
 				66A291D4207D032400809C27 /* RNFlingHandler.h */,
 				66A291D3207D032400809C27 /* RNFlingHandler.m */,
 				44AEC7231F8FA1270086889F /* RNLongPressHandler.h */,
@@ -156,6 +162,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				668E083C21BDD70900EDDF40 /* RNForceTouchHandler.h in Headers */,
 				66A291D6207D032400809C27 /* RNFlingHandler.h in Headers */,
 				44AEC72F1F8FA1270086889F /* RNLongPressHandler.h in Headers */,
 				446E7FE61ED6E177009282E7 /* RNGestureHandlerModule.h in Headers */,
@@ -233,6 +240,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				44AEC7201F8FA0700086889F /* RNGestureHandlerButton.m in Sources */,
+				668E083D21BDD70900EDDF40 /* RNForceTouchHandler.m in Sources */,
 				44BE34481F1E1AAA008679D1 /* RNGestureHandlerManager.m in Sources */,
 				44AEC7301F8FA1270086889F /* RNLongPressHandler.m in Sources */,
 				446E7FF81ED89A4B009282E7 /* RNGestureHandlerEvents.m in Sources */,

--- a/ios/RNGestureHandlerEvents.h
+++ b/ios/RNGestureHandlerEvents.h
@@ -19,6 +19,10 @@
                            withTranslation:(CGPoint)translation
                               withVelocity:(CGPoint)velocity
                        withNumberOfTouches:(NSUInteger)numberOfTouches;
++ (RNGestureHandlerEventExtraData *)forForce:(CGFloat)force
+                                 forPosition:(CGPoint)position
+                        withAbsolutePosition:(CGPoint)absolutePosition
+                         withNumberOfTouches:(NSUInteger)numberOfTouches;
 + (RNGestureHandlerEventExtraData *)forPinch:(CGFloat)scale
                               withFocalPoint:(CGPoint)focalPoint
                                 withVelocity:(CGFloat)velocity

--- a/ios/RNGestureHandlerEvents.m
+++ b/ios/RNGestureHandlerEvents.m
@@ -49,7 +49,6 @@
                         withAbsolutePosition:(CGPoint)absolutePosition
                          withNumberOfTouches:(NSUInteger)numberOfTouches
 {
-  {
     return [[RNGestureHandlerEventExtraData alloc]
             initWithData:@{
                            @"x": @(position.x),
@@ -58,7 +57,6 @@
                            @"absoluteY": @(absolutePosition.y),
                            @"force": @(force),
                            @"numberOfPointers": @(numberOfTouches)}];
-  }
   
 }
 

--- a/ios/RNGestureHandlerEvents.m
+++ b/ios/RNGestureHandlerEvents.m
@@ -44,6 +44,24 @@
                            @"numberOfPointers": @(numberOfTouches)}];
 }
 
++ (RNGestureHandlerEventExtraData *)forForce:(CGFloat)force
+                                 forPosition:(CGPoint)position
+                        withAbsolutePosition:(CGPoint)absolutePosition
+                         withNumberOfTouches:(NSUInteger)numberOfTouches
+{
+  {
+    return [[RNGestureHandlerEventExtraData alloc]
+            initWithData:@{
+                           @"x": @(position.x),
+                           @"y": @(position.y),
+                           @"absoluteX": @(absolutePosition.x),
+                           @"absoluteY": @(absolutePosition.y),
+                           @"force": @(force),
+                           @"numberOfPointers": @(numberOfTouches)}];
+  }
+  
+}
+
 + (RNGestureHandlerEventExtraData *)forPinch:(CGFloat)scale
                               withFocalPoint:(CGPoint)focalPoint
                                 withVelocity:(CGFloat)velocity

--- a/ios/RNGestureHandlerManager.m
+++ b/ios/RNGestureHandlerManager.m
@@ -18,6 +18,7 @@
 #import "Handlers/RNNativeViewHandler.h"
 #import "Handlers/RNPinchHandler.h"
 #import "Handlers/RNRotationHandler.h"
+#import "Handlers/RNForceTouchHandler.h"
 
 // We use the method below instead of RCTLog because we log out messages after the bridge gets
 // turned down in some cases. Which normally with RCTLog would cause a crash in DEBUG mode
@@ -62,6 +63,7 @@
                 @"NativeViewGestureHandler": [RNNativeViewGestureHandler class],
                 @"PinchGestureHandler": [RNPinchGestureHandler class],
                 @"RotationGestureHandler": [RNRotationGestureHandler class],
+                @"ForceTouchGestureHandler": [RNForceTouchHandler class],
                 };
     });
     

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -253,6 +253,7 @@ declare module 'react-native-gesture-handler' {
   export interface ForceTouchGestureHandlerProperties extends GestureHandlerProperties {
     minForce?: number,
     maxForce?: number,
+    feedbackOnActivation?: boolean,
     onGestureEvent?: (event: ForceTouchGestureHandlerGestureEvent) => void;
     onHandlerStateChange?: (event: ForceTouchGestureHandlerStateChangeEvent) => void;
   }

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -84,6 +84,14 @@ declare module 'react-native-gesture-handler' {
     absoluteY: number;
   }
 
+  interface ForceTouchGestureHandlerEventExtra {
+    x: number;
+    y: number;
+    absoluteX: number;
+    absoluteY: number;
+    force: number;
+  }
+
   export interface TapGestureHandlerStateChangeEvent
     extends GestureHandlerStateChangeEvent {
     nativeEvent: GestureHandlerStateChangeNativeEvent &
@@ -96,10 +104,22 @@ declare module 'react-native-gesture-handler' {
       TapGestureHandlerEventExtra;
   }
 
+  export interface ForceTouchGestureHandlerGestureEvent
+    extends GestureHandlerGestureEvent {
+    nativeEvent: GestureHandlerGestureEventNativeEvent &
+      ForceTouchGestureHandlerEventExtra;
+  }
+
   export interface LongPressGestureHandlerStateChangeEvent
     extends GestureHandlerStateChangeEvent {
     nativeEvent: GestureHandlerStateChangeNativeEvent &
       LongPressGestureHandlerEventExtra;
+  }
+
+  export interface ForceTouchGestureHandlerStateChangeEvent
+    extends GestureHandlerStateChangeEvent {
+    nativeEvent: GestureHandlerStateChangeNativeEvent &
+      ForceTouchGestureHandlerEventExtra;
   }
 
   interface LongPressGestureHandlerEventExtra {
@@ -230,6 +250,13 @@ declare module 'react-native-gesture-handler' {
     onHandlerStateChange?: (event: TapGestureHandlerStateChangeEvent) => void;
   }
 
+  export interface ForceTouchGestureHandlerProperties extends GestureHandlerProperties {
+    minForce?: number,
+    maxForce?: number,
+    onGestureEvent?: (event: ForceTouchGestureHandlerGestureEvent) => void;
+    onHandlerStateChange?: (event: ForceTouchGestureHandlerStateChangeEvent) => void;
+  }
+
   export interface LongPressGestureHandlerProperties
     extends GestureHandlerProperties {
     minDurationMs?: number;
@@ -318,6 +345,10 @@ declare module 'react-native-gesture-handler' {
     FlingGestureHandlerProperties
   > {}
 
+  export class ForceTouchGestureHandler extends React.Component<
+    ForceTouchGestureHandlerProperties
+  > {}
+
   /* BUTTONS PROPERTIES */
 
   export interface RawButtonProperties
@@ -400,7 +431,7 @@ declare module 'react-native-gesture-handler' {
 
 declare module 'react-native-gesture-handler/Swipeable' {
   import { Animated } from 'react-native';
-  
+
   interface SwipeableProperties {
     friction?: number;
     leftThreshold?: number;
@@ -455,11 +486,11 @@ declare module 'react-native-gesture-handler/DrawerLayout' {
     statusBarAnimation?: StatusBarAnimation;
     overlayColor?: string;
   }
-  
+
   interface DrawerMovementOptionType {
     velocity?: number;
   }
-  
+
   export default class DrawerLayout extends React.Component<DrawerLayoutProperties> {
     openDrawer: (options?: DrawerMovementOptionType) => void;
     closeDrawer: (options?: DrawerMovementOptionType) => void;

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -21,6 +21,8 @@
     "BaseGestureHandler": "BaseGestureHandler",
     "handler-fling": "FlingGestureHandler",
     "FlingGestureHandler": "FlingGestureHandler",
+    "handler-force": "ForceTouchGestureHandler (iOS only)",
+    "ForceTouchGestureHandler": "ForceTouchGestureHandler",
     "handler-longpress": "LongPressGestureHandler",
     "LongPressGestureHandler": "LongPressGestureHandler",
     "handler-pan": "PanGestureHandler",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -14,7 +14,8 @@
       "handler-longpress",
       "handler-rotation",
       "handler-fling",
-      "handler-pinch"
+      "handler-pinch",
+      "handler-force"
     ],
     "Components": ["component-buttons", "component-swipeable", "component-drawer-layout"],
     "Other": ["contributing", "troubleshooting", "resources", "credits"]


### PR DESCRIPTION
## Motivation
Add possibility of handling force touch gesture. 

## Changes
Add proper handler on iOS and no-op fallback on Android. On iOS for calculating force touch only first finger is concerned which is normal behaviour I observed on iOS. Force is expressed as value greater of equal 0 and lesser or equal 1.
I added two options of customisation.

### `minForce`
`minForce` is a minimal pressure which has to be applied in order to activate handler.

### `maxForce`
`minForce` is a maximal force which could be applied. If greater force applied, handler fails. 

On releasing first finger gesture fails or ends (if has been activated already).


And added simple check method to determine is it possible to use `forceTouch` on current device which exporting RN's constant.