### PR TITLE
Copy classes methods properly in _refHandler

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -660,17 +660,20 @@ function createNativeWrapper(Component, config = {}) {
 
     _refHandler = node => {
       // bind native component's methods
-      for (let methodName in node) {
-        const method = node[methodName];
-        if (
-          !methodName.startsWith('_') && // private methods
-          !methodName.startsWith('component') && // lifecycle methods
-          !NATIVE_WRAPPER_BIND_BLACKLIST.has(methodName) && // other
-          typeof method === 'function' &&
-          this[methodName] === undefined
-        ) {
-          this[methodName] = method;
+      let source = node;
+      while (source != null) {
+        for (let methodName of Object.getOwnPropertyNames(source)) {
+          if (
+            !methodName.startsWith('_') && // private methods
+            !methodName.startsWith('component') && // lifecycle methods
+            !NATIVE_WRAPPER_BIND_BLACKLIST.has(methodName) && // other
+            typeof source[methodName] === 'function' &&
+            this[methodName] === undefined
+          ) {
+            this[methodName] = source[methodName].bind(node);
+          }
         }
+        source = Object.getPrototypeOf(source);
       }
     };
 


### PR DESCRIPTION
I noticed some methods missing from the gesture handler wrapped components since updating RN to latest master. It happens because a lot of core components were changed to use classes instead of React.createClass and the logic to copy methods did not handle classes properly.

This fixes it by looping through the prototype and using `Object. getOwnPropertyNames` to get methods instead of `for ... in`. This way it handles classes and regular objects properly.