### PR TITLE
Respect hitSlop for shouldCancelWhenOutside property

### DIFF
--- a/ios/Handlers/RNLongPressHandler.m
+++ b/ios/Handlers/RNLongPressHandler.m
@@ -19,28 +19,24 @@
 @end
 
 @implementation RNBetterLongPressGestureRecognizer {
-    __weak RNGestureHandler *_gestureHandler;
+  __weak RNGestureHandler *_gestureHandler;
 }
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
 {
-    if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
-        _gestureHandler = gestureHandler;
-    }
-    return self;
+  if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
+    _gestureHandler = gestureHandler;
+  }
+  return self;
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [super touchesMoved:touches withEvent:event];
-
-    if (_gestureHandler.shouldCancelWhenOutside) {
-        CGPoint pt = [self locationInView:self.view];
-        if (!CGRectContainsPoint(self.view.bounds, pt)) {
-            self.enabled = NO;
-            self.enabled = YES;
-        }
-    }
+  [super touchesMoved:touches withEvent:event];
+  if (_gestureHandler.shouldCancelWhenOutside && ![_gestureHandler containsPointInView]) {
+    self.enabled = NO;
+    self.enabled = YES;
+  }
 }
 
 @end
@@ -50,38 +46,38 @@
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
-    if ((self = [super initWithTag:tag])) {
-        _recognizer = [[RNBetterLongPressGestureRecognizer alloc] initWithGestureHandler:self];
-    }
-    return self;
+  if ((self = [super initWithTag:tag])) {
+    _recognizer = [[RNBetterLongPressGestureRecognizer alloc] initWithGestureHandler:self];
+  }
+  return self;
 }
 
 - (void)configure:(NSDictionary *)config
 {
-    [super configure:config];
-    UILongPressGestureRecognizer *recognizer = (UILongPressGestureRecognizer *)_recognizer;
-
-    id prop = config[@"minDurationMs"];
-    if (prop != nil) {
-        recognizer.minimumPressDuration = [RCTConvert CGFloat:prop] / 1000.0;
-    }
-
-    prop = config[@"maxDist"];
-    if (prop != nil) {
-        recognizer.allowableMovement = [RCTConvert CGFloat:prop];
-    }
+  [super configure:config];
+  UILongPressGestureRecognizer *recognizer = (UILongPressGestureRecognizer *)_recognizer;
+  
+  id prop = config[@"minDurationMs"];
+  if (prop != nil) {
+    recognizer.minimumPressDuration = [RCTConvert CGFloat:prop] / 1000.0;
+  }
+  
+  prop = config[@"maxDist"];
+  if (prop != nil) {
+    recognizer.allowableMovement = [RCTConvert CGFloat:prop];
+  }
 }
 
 - (RNGestureHandlerState)state
 {
-    // For long press recognizer we treat "Began" state as "active"
-    // as it changes its state to "Began" as soon as the the minimum
-    // hold duration timeout is reached, whereas state "Changed" is
-    // only set after "Began" phase if there is some movement.
-    if (_recognizer.state == UIGestureRecognizerStateBegan) {
-        return RNGestureHandlerStateActive;
-    }
-    return [super state];
+  // For long press recognizer we treat "Began" state as "active"
+  // as it changes its state to "Began" as soon as the the minimum
+  // hold duration timeout is reached, whereas state "Changed" is
+  // only set after "Began" phase if there is some movement.
+  if (_recognizer.state == UIGestureRecognizerStateBegan) {
+    return RNGestureHandlerStateActive;
+  }
+  return [super state];
 }
 @end
 

--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -84,9 +84,8 @@
     self.state = UIGestureRecognizerStateFailed;
     return;
   }
-  if ((self.state == UIGestureRecognizerStatePossible || self.state == UIGestureRecognizerStateChanged) && _gestureHandler.shouldCancelWhenOutside) {
-    CGPoint pt = [self locationInView:self.view];
-    if (!CGRectContainsPoint(self.view.bounds, pt)) {
+  if ((self.state == UIGestureRecognizerStatePossible || self.state == UIGestureRecognizerStateChanged)) {
+    if (_gestureHandler.shouldCancelWhenOutside && ![_gestureHandler containsPointInView]) {
       // If the previous recognizer state is UIGestureRecognizerStateChanged
       // then UIGestureRecognizer's sate machine will only transition to
       // UIGestureRecognizerStateCancelled even if you set the state to

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -32,92 +32,91 @@
 @end
 
 @implementation RNBetterTapGestureRecognizer {
-    __weak RNGestureHandler *_gestureHandler;
-    NSUInteger _tapsSoFar;
-    CGPoint _initPosition;
-    NSInteger _maxNumberOfTouches;
+  __weak RNGestureHandler *_gestureHandler;
+  NSUInteger _tapsSoFar;
+  CGPoint _initPosition;
+  NSInteger _maxNumberOfTouches;
 }
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
 {
-    if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
-        _gestureHandler = gestureHandler;
-        _tapsSoFar = 0;
-        _numberOfTaps = 1;
-        _minPointers = 1;
-        _maxDelay = 0.2;
-        _maxDuration = NAN;
-        _maxDeltaX = NAN;
-        _maxDeltaY = NAN;
-        _maxDistSq = NAN;
-    }
-    return self;
+  if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
+    _gestureHandler = gestureHandler;
+    _tapsSoFar = 0;
+    _numberOfTaps = 1;
+    _minPointers = 1;
+    _maxDelay = 0.2;
+    _maxDuration = NAN;
+    _maxDeltaX = NAN;
+    _maxDeltaY = NAN;
+    _maxDistSq = NAN;
+  }
+  return self;
 }
 
 - (void)triggerAction
 {
-    [_gestureHandler handleGesture:self];
+  [_gestureHandler handleGesture:self];
 }
 
 - (void)cancel
 {
-    self.enabled = NO;
+  self.enabled = NO;
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [super touchesBegan:touches withEvent:event];
-    if (_tapsSoFar == 0) {
-        _initPosition = [self locationInView:self.view];
-    }
-    _tapsSoFar++;
-    if (_tapsSoFar) {
-        [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
-    }
-    NSInteger numberOfTouches = [touches count];
-    if (numberOfTouches > _maxNumberOfTouches) {
-        _maxNumberOfTouches = numberOfTouches;
-    }
-    if (!isnan(_maxDuration)) {
-        [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDuration];
-    }
-    self.state = UIGestureRecognizerStatePossible;
-    [self triggerAction];
+  [super touchesBegan:touches withEvent:event];
+  if (_tapsSoFar == 0) {
+    _initPosition = [self locationInView:self.view];
+  }
+  _tapsSoFar++;
+  if (_tapsSoFar) {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
+  }
+  NSInteger numberOfTouches = [touches count];
+  if (numberOfTouches > _maxNumberOfTouches) {
+    _maxNumberOfTouches = numberOfTouches;
+  }
+  if (!isnan(_maxDuration)) {
+    [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDuration];
+  }
+  self.state = UIGestureRecognizerStatePossible;
+  [self triggerAction];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [super touchesMoved:touches withEvent:event];
-    NSInteger numberOfTouches = [touches count];
-    if (numberOfTouches > _maxNumberOfTouches) {
-        _maxNumberOfTouches = numberOfTouches;
-    }
-
-    if (self.state != UIGestureRecognizerStatePossible) {
-        return;
-    }
-    
-    if ([self shouldFailUnderCustomCriteria]) {
-        self.state = UIGestureRecognizerStateFailed;
-        [self triggerAction];
-        [self reset];
-        return;
-    }
-
-    self.state = UIGestureRecognizerStatePossible;
+  [super touchesMoved:touches withEvent:event];
+  NSInteger numberOfTouches = [touches count];
+  if (numberOfTouches > _maxNumberOfTouches) {
+    _maxNumberOfTouches = numberOfTouches;
+  }
+  
+  if (self.state != UIGestureRecognizerStatePossible) {
+    return;
+  }
+  
+  if ([self shouldFailUnderCustomCriteria]) {
+    self.state = UIGestureRecognizerStateFailed;
     [self triggerAction];
+    [self reset];
+    return;
+  }
+  
+  self.state = UIGestureRecognizerStatePossible;
+  [self triggerAction];
 }
 
 - (CGPoint)translationInView {
-    CGPoint currentPosition = [self locationInView:self.view];
-    return CGPointMake(currentPosition.x - _initPosition.x, currentPosition.y - _initPosition.y);
+  CGPoint currentPosition = [self locationInView:self.view];
+  return CGPointMake(currentPosition.x - _initPosition.x, currentPosition.y - _initPosition.y);
 }
 
 - (BOOL)shouldFailUnderCustomCriteria
 {
   if (_gestureHandler.shouldCancelWhenOutside) {
-    CGPoint pt = [self locationInView:self.view];
-    if (!CGRectContainsPoint(self.view.bounds, pt)) {
+    if (![_gestureHandler containsPointInView]) {
       return YES;
     }
   }
@@ -137,32 +136,32 @@
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [super touchesEnded:touches withEvent:event];
-    if (_numberOfTaps == _tapsSoFar && _maxNumberOfTouches >= _minPointers) {
-        self.state = UIGestureRecognizerStateEnded;
-        [self reset];
-    } else {
-        [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDelay];
-    }
+  [super touchesEnded:touches withEvent:event];
+  if (_numberOfTaps == _tapsSoFar && _maxNumberOfTouches >= _minPointers) {
+    self.state = UIGestureRecognizerStateEnded;
+    [self reset];
+  } else {
+    [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDelay];
+  }
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [super touchesCancelled:touches withEvent:event];
-    self.state = UIGestureRecognizerStateCancelled;
-    [self reset];
+  [super touchesCancelled:touches withEvent:event];
+  self.state = UIGestureRecognizerStateCancelled;
+  [self reset];
 }
 
 - (void)reset
 {
-    if (self.state == UIGestureRecognizerStateFailed) {
-        [self triggerAction];
-    }
-    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
-    _tapsSoFar = 0;
-    _maxNumberOfTouches = 0;
-    self.enabled = YES;
-    [super reset];
+  if (self.state == UIGestureRecognizerStateFailed) {
+    [self triggerAction];
+  }
+  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
+  _tapsSoFar = 0;
+  _maxNumberOfTouches = 0;
+  self.enabled = YES;
+  [super reset];
 }
 
 @end
@@ -171,37 +170,37 @@
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
-    if ((self = [super initWithTag:tag])) {
-        _recognizer = [[RNBetterTapGestureRecognizer alloc] initWithGestureHandler:self];
-    }
-    return self;
+  if ((self = [super initWithTag:tag])) {
+    _recognizer = [[RNBetterTapGestureRecognizer alloc] initWithGestureHandler:self];
+  }
+  return self;
 }
 
 - (void)configure:(NSDictionary *)config
 {
-    [super configure:config];
-    RNBetterTapGestureRecognizer *recognizer = (RNBetterTapGestureRecognizer *)_recognizer;
-
-    APPLY_INT_PROP(numberOfTaps);
-    APPLY_INT_PROP(minPointers);
-    APPLY_FLOAT_PROP(maxDeltaX);
-    APPLY_FLOAT_PROP(maxDeltaY);
+  [super configure:config];
+  RNBetterTapGestureRecognizer *recognizer = (RNBetterTapGestureRecognizer *)_recognizer;
   
-    id prop = config[@"maxDelayMs"];
-    if (prop != nil) {
-        recognizer.maxDelay = [RCTConvert CGFloat:prop] / 1000.0;
-    }
-
-    prop = config[@"maxDurationMs"];
-    if (prop != nil) {
-        recognizer.maxDuration = [RCTConvert CGFloat:prop] / 1000.0;
-    }
+  APPLY_INT_PROP(numberOfTaps);
+  APPLY_INT_PROP(minPointers);
+  APPLY_FLOAT_PROP(maxDeltaX);
+  APPLY_FLOAT_PROP(maxDeltaY);
   
-    prop = config[@"maxDist"];
-    if (prop != nil) {
-        CGFloat dist = [RCTConvert CGFloat:prop];
-        recognizer.maxDistSq = dist * dist;
-    }
+  id prop = config[@"maxDelayMs"];
+  if (prop != nil) {
+    recognizer.maxDelay = [RCTConvert CGFloat:prop] / 1000.0;
+  }
+  
+  prop = config[@"maxDurationMs"];
+  if (prop != nil) {
+    recognizer.maxDuration = [RCTConvert CGFloat:prop] / 1000.0;
+  }
+  
+  prop = config[@"maxDist"];
+  if (prop != nil) {
+    CGFloat dist = [RCTConvert CGFloat:prop];
+    recognizer.maxDistSq = dist * dist;
+  }
 }
 
 @end

--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -60,6 +60,7 @@ if (value != nil) recognizer.prop = [RCTConvert type:value]; \
 - (void)unbindFromView;
 - (void)configure:(nullable NSDictionary *)config NS_REQUIRES_SUPER;
 - (void)handleGesture:(nonnull id)recognizer;
+- (BOOL)containsPointInView;
 - (RNGestureHandlerState)state;
 - (nullable RNGestureHandlerEventExtraData *)eventExtraData:(nonnull id)recognizer;
 

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -284,6 +284,13 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     _lastState = RNGestureHandlerStateUndetermined;
 }
 
+ - (BOOL)containsPointInView
+ {
+     CGPoint pt = [_recognizer locationInView:_recognizer.view];
+     CGRect hitFrame = RNGHHitSlopInsetRect(_recognizer.view.bounds, _hitSlop);
+     return CGRectContainsPoint(hitFrame, pt);
+ }
+
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
     [self reset];


### PR DESCRIPTION
This PR updates iOS implementation of gesture handler to properly respect hitSlop property when handling `shouldCancelWhenOutside` property and also in long press handler. Before we've been only testing if touch point was within view bounds now we also verify that fits within bounds that are adjusted by hit slop whenever it is set.