### PR TITLE
Only include the ios folder in the podspec

### DIFF
--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author       = { package["author"]["name"] => package["author"]["email"] }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/kmagiera/react-native-gesture-handler", :tag => "#{s.version}" }
-  s.source_files = "**/*.{h,m}"
+  s.source_files = "ios/**/*.{h,m}"
 
   s.dependency "React"
 


### PR DESCRIPTION
I migrated my app to use cocoapods instead of manually linking projects and had a build issue when depending on react-native-gesture-handler from github. What happens is when installing from github it also includes the Example project and the podspec sources pattern also includes the code from it. This causes a duplicate symbol error because the project will contain 2 AppDelegate classes.

To fix this I simply make the sources pattern only include the ios directory.