### PR TITLE
Fixed Xcode warning for UIImpactFeedbackGenerator

### DIFF
--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -76,7 +76,7 @@
 
 - (void)performFeedbackIfRequired
 {
-  if (_feedbackOnActivation) {
+  if (_feedbackOnActivation && @available(iOS 10.0, *)) {
     [[[UIImpactFeedbackGenerator alloc] initWithStyle:(UIImpactFeedbackStyleMedium)] impactOccurred];
   }
 }


### PR DESCRIPTION
Fixed Xcode warning about minimum available iOS version when using UIImpactFeedbackGenerator