### PR TITLE
Exclude the "Example" folder in the podspec

### DIFF
--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -4,15 +4,16 @@ Pod::Spec.new do |s|
   # NPM package specification
   package = JSON.parse(File.read(File.join(File.dirname(__FILE__), "package.json")))
 
-  s.name         = "RNGestureHandler"
-  s.version      = package["version"]
-  s.summary      = package["description"]
-  s.homepage     = "https://github.com/kmagiera/react-native-gesture-handler"
-  s.license      = "MIT"
-  s.author       = { package["author"]["name"] => package["author"]["email"] }
-  s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/kmagiera/react-native-gesture-handler", :tag => "#{s.version}" }
-  s.source_files = "ios/**/*.{h,m}"
+  s.name          = "RNGestureHandler"
+  s.version       = package["version"]
+  s.summary       = package["description"]
+  s.homepage      = "https://github.com/kmagiera/react-native-gesture-handler"
+  s.license       = "MIT"
+  s.author        = { package["author"]["name"] => package["author"]["email"] }
+  s.platform      = :ios, "7.0"
+  s.source        = { :git => "https://github.com/kmagiera/react-native-gesture-handler", :tag => "#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+  s.exclude_files = "Example/**/*"
 
   s.dependency "React"
 


### PR DESCRIPTION
This needs to be done because the `s.source_files  = "ios/**/*.{h,m}"` was also picking up files inside `Example/ios/*`. Inside this folder, there is a file called `AppDelegate` which was causing duplicate symbol errors when using this library through cocoapods.

This is fixed by explicitly excluding the entire `Example` folder.