### PR TITLE
Workaround metro not compiling static properties correctly.

### DIFF
--- a/touchables/GenericTouchable.js
+++ b/touchables/GenericTouchable.js
@@ -16,45 +16,54 @@ export const TOUCHABLE_STATE = {
   MOVED_OUTSIDE: 2,
 };
 
+
+const PublicPropTypes = {
+  // Decided to drop not used fields from RN's implementation.
+  // e.g. onBlur and onFocus as well as deprecated props.
+  accessible: PropTypes.bool,
+  accessibilityLabel: PropTypes.node,
+  accessibilityHint: PropTypes.string,
+  hitSlop: PropTypes.shape({
+    top: PropTypes.number,
+    left: PropTypes.number,
+    bottom: PropTypes.number,
+    right: PropTypes.number,
+  }),
+  disabled: PropTypes.bool,
+  onPress: PropTypes.func,
+  onPressIn: PropTypes.func,
+  onPressOut: PropTypes.func,
+  onLayout: PropTypes.func,
+  onLongPress: PropTypes.func,
+  nativeID: PropTypes.string,
+  testID: PropTypes.string,
+  delayPressIn: PropTypes.number,
+  delayPressOut: PropTypes.number,
+  delayLongPress: PropTypes.number,
+};
+
+
+const InternalPropTypes = {
+  extraButtonProps: PropTypes.object,
+  onStateChange: PropTypes.func,
+};
+
+
 /**
  * GenericTouchable is not intented to be used as it.
  * Should be treated as a source for the rest of touchables
  */
 
 export default class GenericTouchable extends Component {
-  static publicPropTypes = {
-    // Decided to drop not used fields from RN's implementation.
-    // e.g. onBlur and onFocus as well as deprecated props.
-    accessible: PropTypes.bool,
-    accessibilityLabel: PropTypes.node,
-    accessibilityHint: PropTypes.string,
-    hitSlop: PropTypes.shape({
-      top: PropTypes.number,
-      left: PropTypes.number,
-      bottom: PropTypes.number,
-      right: PropTypes.number,
-    }),
-    disabled: PropTypes.bool,
-    onPress: PropTypes.func,
-    onPressIn: PropTypes.func,
-    onPressOut: PropTypes.func,
-    onLayout: PropTypes.func,
-    onLongPress: PropTypes.func,
-    nativeID: PropTypes.string,
-    testID: PropTypes.string,
-    delayPressIn: PropTypes.number,
-    delayPressOut: PropTypes.number,
-    delayLongPress: PropTypes.number,
-  };
+  static publicPropTypes = PublicPropTypes;
+  static internalPropTypes = InternalPropTypes;
 
-  static internalPropTypes = {
-    extraButtonProps: PropTypes.object,
-    onStateChange: PropTypes.func,
-  };
-
+  // The prop type collections have to be outside of the class, as metro
+  // at this time does not compile `this.foo` correctly if HMR is enabled.
+  // https://github.com/kmagiera/react-native-gesture-handler/pull/406#issuecomment-453779977
   static propTypes = {
-    ...this.internalPropTypes,
-    ...this.publicPropTypes,
+    ...InternalPropTypes,
+    ...PublicPropTypes,
   };
 
   static defaultProps = {


### PR DESCRIPTION
Fixes the issue we encountered https://github.com/kmagiera/react-native-gesture-handler/pull/406#issuecomment-453783652

To review, the problem is as follows:

The correct syntax is:

```
static propTypes = {
    ...GenericTouchable.internalPropTypes
}
```

Metro/Babel compiles this to:

```
// Define GenericTouchable
GenericTouchable.propTypes = (0, _objectSpread2.default)({}, GenericTouchable.internalPropTypes, GenericTouchable.publicPropTypes);
```

But when metro then runs the HMR transform, this becomes:

```
// Create _class
_class.propTypes = (0, _objectSpread2.default)({}, GenericTouchable.internalPropTypes, GenericTouchable.publicPropTypes),
```

It rewrites the class name to `_class` during initialization, but misses the references in the spread, which then causes a undefined-access exception.

See this Gist for full outputs: https://gist.github.com/miracle2k/3bc7f1c50080397dbf0d92cfb3101677#file-generictouchable-babel-with-metro-preset-js

Part of the problem seems to be that metro uses a very old version of [react-hot-loader](https://github.com/facebook/metro/issues/336).

The code as it is currently in the library, using `...this.publicPropTypes` has two problems: First, it does not compile at all with babel, when this library becomes imported as part of using `react-native-web`.

Second, while it does compile using metro, the generated code instead will be:

```
// Create _class
_class.propTypes = (0, _objectSpread2.default)({}, this.internalPropTypes, this.publicPropTypes),
```

With `this` probably referring to the window or global scope, thus not causing a crash, but not actually setting the proptypes correctly.