### PR TITLE
overshootFriction prop on Swipeable component

### DIFF
--- a/Swipeable.js
+++ b/Swipeable.js
@@ -26,6 +26,7 @@ export type PropType = {
   rightThreshold?: number,
   overshootLeft?: boolean,
   overshootRight?: boolean,
+  overshootFriction?: number,
   onSwipeableLeftOpen?: Function,
   onSwipeableRightOpen?: Function,
   onSwipeableOpen?: Function,
@@ -57,6 +58,7 @@ type StateType = {
 export default class Swipeable extends Component<PropType, StateType> {
   static defaultProps = {
     friction: 1,
+    overshootFriction: 1,
     useNativeAnimations: true,
   };
   _onGestureEvent: ?AnimatedEvent;
@@ -90,6 +92,7 @@ export default class Swipeable extends Component<PropType, StateType> {
       this.props.friction !== props.friction ||
       this.props.overshootLeft !== props.overshootLeft ||
       this.props.overshootRight !== props.overshootRight ||
+      this.props.overshootFriction !== props.overshootFriction ||
       this.state.leftWidth !== state.leftWidth ||
       this.state.rightOffset !== state.rightOffset ||
       this.state.rowWidth !== state.rowWidth
@@ -99,7 +102,7 @@ export default class Swipeable extends Component<PropType, StateType> {
   }
 
   _updateAnimatedEvent = (props: PropType, state: StateType) => {
-    const { friction, useNativeAnimations } = props;
+    const { friction, overshootFriction, useNativeAnimations } = props;
     const { dragX, rowTranslation, leftWidth = 0, rowWidth = 0 } = state;
     const { rightOffset = rowWidth } = state;
     const rightWidth = Math.max(0, rowWidth - rightOffset);
@@ -116,12 +119,17 @@ export default class Swipeable extends Component<PropType, StateType> {
         outputRange: [0, 1],
       })
     ).interpolate({
-      inputRange: [-rightWidth - 1, -rightWidth, leftWidth, leftWidth + 1],
-      outputRange: [
-        -rightWidth - (overshootRight ? 1 : 0),
+      inputRange: [
+        -rightWidth - (overshootRight ? 1 : overshootFriction),
         -rightWidth,
         leftWidth,
-        leftWidth + (overshootLeft ? 1 : 0),
+        leftWidth + (overshootLeft ? 1 : overshootFriction),
+      ],
+      outputRange: [
+        -rightWidth - (overshootRight || overshootFriction > 1 ? 1 : 0),
+        -rightWidth,
+        leftWidth,
+        leftWidth + (overshootLeft || overshootFriction > 1 ? 1 : 0),
       ],
     });
     this._transX = transX;
@@ -130,7 +138,6 @@ export default class Swipeable extends Component<PropType, StateType> {
         ? transX.interpolate({
             inputRange: [-1, 0, leftWidth],
             outputRange: [0, 0, 1],
-            extrapolate: 'clamp',
           })
         : new Animated.Value(0);
     this._leftActionTranslate = this._showLeftAction.interpolate({
@@ -143,7 +150,6 @@ export default class Swipeable extends Component<PropType, StateType> {
         ? transX.interpolate({
             inputRange: [-rightWidth, 0, 1],
             outputRange: [1, 0, 0],
-            extrapolate: 'clamp',
           })
         : new Animated.Value(0);
     this._rightActionTranslate = this._showRightAction.interpolate({

--- a/docs/component-swipeable.md
+++ b/docs/component-swipeable.md
@@ -38,6 +38,10 @@ a boolean value indicating if the swipeable panel can be pulled further than the
 a boolean value indicating if the swipeable panel can be pulled further than the right actions panel's width. It is set to `true` by default as long as the right panel render method is present.
 
 ---
+### `overshootFriction`
+a number that specifies how much the visual interaction will be delayed compared to the gesture distance at overshoot. Default value is 1, it mean no friction, for a native feel, try 8 or above.
+
+---
 ### `onSwipeableLeftOpen`
 method that is called when left action panel gets open.
 

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -439,6 +439,7 @@ declare module 'react-native-gesture-handler/Swipeable' {
     rightThreshold?: number;
     overshootLeft?: boolean;
     overshootRight?: boolean;
+    overshootFriction?: number,
     onSwipeableLeftOpen?: () => void;
     onSwipeableRightOpen?: () => void;
     onSwipeableOpen?: () => void;


### PR DESCRIPTION
An `overshootFriction` prop to create a more native feel on interaction on Swipeable component.

````jsx
<Swipeable
  rightThreshold={30}
  overshootRight={false}
  overshootFriction={8}
  renderRightActions={this.renderRightActions}
>
````

![overshoot-friction](https://user-images.githubusercontent.com/1412159/51237908-d5c77f00-1975-11e9-8710-14d2225ca7bf.gif)