### PR TITLE
Fix Xcode warning

### DIFF
--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -76,8 +76,10 @@
 
 - (void)performFeedbackIfRequired
 {
-  if (_feedbackOnActivation && @available(iOS 10.0, *)) {
-    [[[UIImpactFeedbackGenerator alloc] initWithStyle:(UIImpactFeedbackStyleMedium)] impactOccurred];
+  if (_feedbackOnActivation) {
+    if (@available(iOS 10.0, *)) {
+      [[[UIImpactFeedbackGenerator alloc] initWithStyle:(UIImpactFeedbackStyleMedium)] impactOccurred];
+    }
   }
 }
 

--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -76,7 +76,7 @@
 
 - (void)performFeedbackIfRequired
 {
-  if (_feedbackOnActivation) {
+  if (_feedbackOnActivation && @available(iOS 10.0, *)) {
     [[[UIImpactFeedbackGenerator alloc] initWithStyle:(UIImpactFeedbackStyleMedium)] impactOccurred];
   }
 }


### PR DESCRIPTION
Sorry that my last PR didn't cover this, but Xcode gives me a warning (and we treat warnings as errors) when the available check is on the same line / part of a multi-condition if statement.

Xcode is great.
