### PR TITLE
[Android][Regression] Fix gestures not being delivered to RN

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
@@ -281,7 +281,6 @@ public class GestureHandlerOrchestrator {
 
   private void deliverEventToGestureHandler(GestureHandler handler, MotionEvent event) {
     if (!isViewAttachedUnderWrapper(handler.getView())) {
-      handler.cancel();
       return;
     }
     if (!handler.wantEvents()) {


### PR DESCRIPTION
Version 1.0.14 introduced a regression: on Android gestures made outside of RNGH elements can't make it to RN elements.

The regression comes from https://github.com/kmagiera/react-native-gesture-handler/commit/3def2e1d72f8556dd368cb85570f9a4ab00b0fec.

Apparently, `handler.cancel()` line is to blame. My fix works, but I'm not sure if it's correct. Is it ok to just `return;` here without canceling a handler, just like in similar `if`s below?

Fixes #422.