### PR TITLE
Fix problem with cancelling RootViewHandler

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
@@ -323,7 +323,12 @@ public class GestureHandlerOrchestrator {
    * for this handler and changing its state to failed of end appear to be good enough solution.
    */
   private boolean isViewAttachedUnderWrapper(@Nullable View view) {
-    if (view == null) return false;
+    if (view == null) {
+      return false;
+    }
+    if (view == mWrapperView) {
+      return true;
+    }
     @Nullable ViewParent parent = view.getParent();
     while (parent != null && parent != mWrapperView) {
       parent = parent.getParent();


### PR DESCRIPTION
PR #385 introduced a regression on Android that'd prevent regular RN touch events from propagating. That PR was ought to address crashes in which we were still passing touch events to handlers even so the corresponding views has been detached. For this purpose `isViewAttachedUnderWrapper` has been added that was meant to detect if a given view is attached under root view wrapper. This method however did not work if the view provided as an argument was the root view. As a result handlers (root view handler) attached to the wrapper view were getting immediately cancelled.

Fixes #422