### PR TITLE
Properly assign initial color for highlight in TouchableHighligh polyfill

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -20,7 +20,7 @@ import { ComboWithGHScroll, ComboWithRNScroll } from './combo';
 import BottomSheet from './bottomSheet/index';
 import doubleScalePinchAndRotate from './doubleScalePinchAndRotate';
 import forceTouch from './forcetouch';
-import touchables from './touchables';
+import { TouchablesIndex, TouchableExample } from './touchables';
 
 YellowBox.ignoreWarnings([
   'Warning: isMounted(...) is deprecated',
@@ -75,7 +75,7 @@ const SCREENS = {
     title: 'Two handlers simultaneously',
   },
   touchables: {
-    screen: touchables,
+    screen: TouchablesIndex,
     title: 'Touchables',
   },
   forceTouch: {
@@ -125,6 +125,10 @@ const ExampleApp = createStackNavigator(
   {
     Main: { screen: MainScreen },
     ...SCREENS,
+    TouchableExample: {
+      screen: TouchableExample,
+      title: 'Touchables',
+    },
   },
   {
     initialRouteName: 'Main',

--- a/Example/touchables/index.js
+++ b/Example/touchables/index.js
@@ -17,7 +17,6 @@ import {
   TouchableWithoutFeedback,
   ScrollView,
 } from 'react-native-gesture-handler';
-import { createStackNavigator } from 'react-navigation';
 
 const BOX_SIZE = 80;
 
@@ -121,6 +120,7 @@ const TOUCHABLES = [
   {
     type: TouchableHighlight,
     props: {
+      underlayColor: 'white',
       onPressIn: () => console.warn('press in'),
       onPressOut: () => console.warn('press out'),
       onPress: () => console.warn('press'),
@@ -288,10 +288,7 @@ class Item extends React.Component {
   }
 }
 
-class TouchableExample extends Component {
-  static navigationOptions = {
-    title: 'Animated & GH',
-  };
+export class TouchableExample extends Component {
   state = {
     useScrollView: true,
   };
@@ -340,10 +337,8 @@ class TouchableExample extends Component {
     );
   }
 }
-class Touchables extends Component {
-  static navigationOptions = {
-    header: null,
-  };
+
+export class TouchablesIndex extends Component {
   render() {
     return (
       <FlatList
@@ -355,7 +350,7 @@ class Touchables extends Component {
           <Item
             {...props}
             onPressItem={() =>
-              this.props.navigation.navigate('Example', {
+              this.props.navigation.navigate('TouchableExample', {
                 item: props.item.text,
               })
             }
@@ -365,16 +360,6 @@ class Touchables extends Component {
     );
   }
 }
-
-export default createStackNavigator(
-  {
-    Main: { screen: Touchables },
-    Example: { screen: TouchableExample },
-  },
-  {
-    initialRouteName: 'Main',
-  }
-);
 
 const styles = StyleSheet.create({
   list: {

--- a/touchables/TouchableHighlight.js
+++ b/touchables/TouchableHighlight.js
@@ -23,12 +23,15 @@ export default class TouchableHighlight extends Component {
     onHideUnderlay: PropTypes.func,
   };
 
-  state = {
-    extraChildStyle: null,
-    extraUnderlayStyle: {
-      backgroundColor: 'black',
-    },
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      extraChildStyle: null,
+      extraUnderlayStyle: {
+        backgroundColor: 'black',
+      },
+    };
+  }
 
   // Copied from RN
   showUnderlay = () => {


### PR DESCRIPTION
In TouchableHighlight polyfill we were always using black underlayColor for the initial render instead of the color provided via props.