### PR TITLE
Fix problem with missing even name definition on React-Native 58

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -40,9 +40,10 @@ UIManager.clearJSResponder = () => {
   oldClearJSResponder();
 };
 
-// Add gesture specific events to RCTView's directEventTypes object exported via UIManager.
-// Once new event types are registered with react it is possible to dispatch these to other
-// view types as well.
+// Add gesture specific events to genericDirectEventTypes object exported from UIManager
+// native module.
+// Once new event types are registered with react it is possible to dispatch these
+// events to all kind of native views.
 UIManager.genericDirectEventTypes = {
   ...UIManager.genericDirectEventTypes,
   onGestureHandlerEvent: { registrationName: 'onGestureHandlerEvent' },


### PR DESCRIPTION
With RN 58 there was new change introduced that broke event registration gesture handler was relying on. 

In RNGH we need to register `onGestureHandlerEvent` and `onGestureHandlerStateChange` events in `ReactNativeViewConfigRegistry` so that react knows how to handle the events when they are dispatched. Most of libs that rely on new event types usually have their own native view managers which can expose event configuration. With Gesture Handler we need to be able to send aforementioned events to all native view types (depending on what you wrap into handler component), so the normal approach of registering events does not work.

With this change we now rely on `genericDirectEventTypes` attribute from `UIManager` that is later used to extend list of supported event types and their configuration – see it [here](https://github.com/facebook/react-native/blob/4148976a83ab96029de1b26b515ff95d3cb58c10/Libraries/ReactNative/getNativeComponentAttributes.js#L109). As this is not a part of public API there is a chance we will have to adapt to changes made to RN core in the future, but for now this seem to be the easiest way.
