### PR TITLE
Add containerStyle Prop

### DIFF
--- a/Swipeable.js
+++ b/Swipeable.js
@@ -45,6 +45,7 @@ export type PropType = {
   ) => any,
   useNativeAnimations: boolean,
   animationOptions?: Object,
+  containerStyle?: Object,
 };
 type StateType = {
   dragX: Animated.Value,
@@ -321,7 +322,7 @@ export default class Swipeable extends Component<PropType, StateType> {
         minDeltaX={10}
         onGestureEvent={this._onGestureEvent}
         onHandlerStateChange={this._onHandlerStateChange}>
-        <Animated.View onLayout={this._onRowLayout} style={styles.container}>
+        <Animated.View onLayout={this._onRowLayout} style={[styles.container, this.props.containerStyle]}>
           {left}
           {right}
           <TapGestureHandler

--- a/docs/component-swipeable.md
+++ b/docs/component-swipeable.md
@@ -81,6 +81,10 @@ method that is expected to return an action panel that is going to be revealed f
 ### `renderRightActions`
 method that is expected to return an action panel that is going to be revealed from the right side when user swipes left.
 
+---
+### `containerStyle`
+style object for the container (Animated.View), for example to override `overflow: 'hidden'`.
+
 ## Methods
 Using reference to `Swipeable` it's possible to trigger some actions on it
 

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -510,6 +510,7 @@ declare module 'react-native-gesture-handler/DrawerLayout' {
     hideStatusBar?: boolean;
     statusBarAnimation?: StatusBarAnimation;
     overlayColor?: string;
+    containerStyle?: StyleProp<ViewStyle>;
   }
 
   interface DrawerMovementOptionType {


### PR DESCRIPTION
PR for the issue #403 

This will add `containerStyle` as a property. This is for example useful to override the `overflow: 'hidden'` style.