### PR TITLE
Add docs for touchables

### DIFF
--- a/docs/component-touchables.md
+++ b/docs/component-touchables.md
@@ -43,7 +43,7 @@ import {
 } from 'react-native-gesture-handler'
 ```
 
-For more deep comparison of these implementation, see our [touchables example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/touchables/index.js)
+For a comparison of both touchable implementations see our [touchables example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/touchables/index.js)
 
 
 

--- a/docs/component-touchables.md
+++ b/docs/component-touchables.md
@@ -18,7 +18,7 @@ React Native's touchables API can be found here:
  gesture ecosystem and could be connected with other native components (e.g. `ScrollView`) and Gesture Handlers easily and in a more predictable way, which 
  follows native apps' behavior.
  
- Our intention was to make switch for these touchables as simple as possible. In order to use RNGH's touchables you
+ Our intention was to make switch for these touchables as simple as possible. In order to use RNGH's touchables the only thing you need to do is to change library from which you import touchable components.
  need only to change imports of touchables.
  
  ### Example:

--- a/docs/component-touchables.md
+++ b/docs/component-touchables.md
@@ -3,7 +3,7 @@ id: component-touchables
 title: Touchables
 sidebar_label: Touchables
 ---
-Basing on [native buttons](component-buttons.md) Gesture Handler exposes reimplementation of touchables, which follows expected behavior of these imported from React Native.
+Gesture Handler library provides an implementation of RN's touchable components that are based on [native buttons](component-buttons.md) and does not rely on JS responder system utilized by RN. Our touchable implementation follows the same API and aims to be a drop-in replacement for touchables available in React Native.
 
 React Native's touchables API could be found here:
  - [Touchable Highlight](https://facebook.github.io/react-native/docs/touchablehighlight)

--- a/docs/component-touchables.md
+++ b/docs/component-touchables.md
@@ -5,7 +5,7 @@ sidebar_label: Touchables
 ---
 Gesture Handler library provides an implementation of RN's touchable components that are based on [native buttons](component-buttons.md) and does not rely on JS responder system utilized by RN. Our touchable implementation follows the same API and aims to be a drop-in replacement for touchables available in React Native.
 
-React Native's touchables API could be found here:
+React Native's touchables API can be found here:
  - [Touchable Highlight](https://facebook.github.io/react-native/docs/touchablehighlight)
  - [Touchable Opacity](https://facebook.github.io/react-native/docs/touchableopacity)
  - [Touchable Highlight](https://facebook.github.io/react-native/docs/touchablehighlight)

--- a/docs/component-touchables.md
+++ b/docs/component-touchables.md
@@ -1,0 +1,6 @@
+---
+id: component-touchables
+title: Touchables
+sidebar_label: Touchables
+---
+

--- a/docs/component-touchables.md
+++ b/docs/component-touchables.md
@@ -13,7 +13,7 @@ React Native's touchables API can be found here:
  
  All major touchable properties (except from `pressRetentionOffset`) have been adopted and should behave in a similar way as with RN's touchables. 
  
- The motivation for using RNGH touchables as a replacement for these imported from React Native is to follow native behavior more strictly.
+ The motivation for using RNGH touchables as a replacement for these imported from React Native is to follow built-in native bahavior more closely by utilizing platform native touch system instead of relying on the JS responder system.
  These touchables and their feedback behavior are deeply integrated with native
  gesture ecosystem and could be connected with other native components (e.g. `ScrollView`) and Gesture Handlers easily and in a more predictable way, which 
  follows native apps' behavior.

--- a/docs/component-touchables.md
+++ b/docs/component-touchables.md
@@ -11,7 +11,7 @@ React Native's touchables API could be found here:
  - [Touchable Highlight](https://facebook.github.io/react-native/docs/touchablehighlight)
  - [Touchable Without Feedback](https://facebook.github.io/react-native/docs/touchablewithoutfeedback)
  
- All important props (but for `pressRetentionOffset`) has been copied and should behave in a similar way to original components. 
+ All major touchable properties (except from `pressRetentionOffset`) have been adopted and should behave in a similar way as with RN's touchables. 
  
  The motivation for using RNGH touchables as a replacement for these imported from React Native is to follow native behavior more strictly.
  These touchables and their feedback behavior are deeply integrated with native

--- a/docs/component-touchables.md
+++ b/docs/component-touchables.md
@@ -5,7 +5,7 @@ sidebar_label: Touchables
 ---
 Basing on [native buttons](component-buttons.md) Gesture Handler exposes reimplementation of touchables, which follows expected behavior of these imported from React Native.
 
-React Native could be found here:
+React Native's touchables API could be found here:
  - [Touchable Highlight](https://facebook.github.io/react-native/docs/touchablehighlight)
  - [Touchable Opacity](https://facebook.github.io/react-native/docs/touchableopacity)
  - [Touchable Highlight](https://facebook.github.io/react-native/docs/touchablehighlight)

--- a/docs/component-touchables.md
+++ b/docs/component-touchables.md
@@ -3,4 +3,49 @@ id: component-touchables
 title: Touchables
 sidebar_label: Touchables
 ---
+Basing on [native buttons](component-buttons.md) Gesture Handler exposes reimplementation of touchables, which follows expected behavior of these imported from React Native.
 
+Generally this implementation follows React Native's API, which could be could be found here:
+ - [Touchable Highlight](https://facebook.github.io/react-native/docs/touchablehighlight)
+ - [Touchable Opacity](https://facebook.github.io/react-native/docs/touchableopacity)
+ - [Touchable Highlight](https://facebook.github.io/react-native/docs/touchablehighlight)
+ - [Touchable Without Feedback](https://facebook.github.io/react-native/docs/touchablewithoutfeedback)
+ 
+ All important props (but for `pressRetentionOffset`) has been copied and should behave in a similar way to original components. 
+ 
+ The motivation for using RNGH touchables as a replacement for these imported from React Native is to follow native behavior more strictly.
+ These touchables and their feedback behavior are deeply integrated with native
+ gesture ecosystem and could be connected with other native components (e.g. `ScrollView`) and Gesture Handlers easily and in a more predictable way, which 
+ follows native apps' behavior.
+ 
+ Our intention was to make switch for these touchables as simple as possible. In order to use RNGH's touchables you
+ need only to change imports of touchables.
+ 
+ ### Example:
+ 
+ ```javascript
+import {
+  TouchableNativeFeedback,
+  TouchableHighlight,
+  TouchableOpacity,
+  TouchableWithoutFeedback
+} from 'react-native'
+```
+
+has to be replaced with:
+
+ ```javascript
+import {
+  TouchableNativeFeedback,
+  TouchableHighlight,
+  TouchableOpacity,
+  TouchableWithoutFeedback
+} from 'react-native-gesture-handler'
+```
+
+For more deep comparison of these implementation, see our [touchables example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/touchables/index.js)
+
+
+
+
+ 

--- a/docs/component-touchables.md
+++ b/docs/component-touchables.md
@@ -44,8 +44,3 @@ import {
 ```
 
 For a comparison of both touchable implementations see our [touchables example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/touchables/index.js)
-
-
-
-
- 

--- a/docs/component-touchables.md
+++ b/docs/component-touchables.md
@@ -5,7 +5,7 @@ sidebar_label: Touchables
 ---
 Basing on [native buttons](component-buttons.md) Gesture Handler exposes reimplementation of touchables, which follows expected behavior of these imported from React Native.
 
-Generally this implementation follows React Native's API, which could be could be found here:
+React Native could be found here:
  - [Touchable Highlight](https://facebook.github.io/react-native/docs/touchablehighlight)
  - [Touchable Opacity](https://facebook.github.io/react-native/docs/touchableopacity)
  - [Touchable Highlight](https://facebook.github.io/react-native/docs/touchablehighlight)

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -12,6 +12,8 @@
     "DrawerLayout": "DrawerLayout",
     "component-swipeable": "Swipeable",
     "Swipeable": "Swipeable",
+    "component-touchables": "Touchales",
+    "Touchables": "Touchables",
     "contributing": "Contributing",
     "credits": "Credits",
     "example": "Running Example App",

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -12,7 +12,7 @@
     "DrawerLayout": "DrawerLayout",
     "component-swipeable": "Swipeable",
     "Swipeable": "Swipeable",
-    "component-touchables": "Touchales",
+    "component-touchables": "Touchables",
     "Touchables": "Touchables",
     "contributing": "Contributing",
     "credits": "Credits",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -17,7 +17,7 @@
       "handler-pinch",
       "handler-force"
     ],
-    "Components": ["component-buttons", "component-swipeable", "component-drawer-layout"],
+    "Components": ["component-buttons", "component-swipeable", "component-touchables", "component-drawer-layout"],
     "Other": ["contributing", "troubleshooting", "resources", "credits"]
   }
 }


### PR DESCRIPTION
## Motivation
https://github.com/kmagiera/react-native-gesture-handler/pull/372
Liked PR is adding touchables polyfill. It was merged but there are still missing docs.

## Changes
In this PR I explain my motivation for adding this implementation and elaborate a bit how to use them.