### PR TITLE
Remove unnecessary binding for component's method

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -671,10 +671,14 @@ function createNativeWrapper(Component, config = {}) {
             !methodName.startsWith('component') && // lifecycle methods
             !NATIVE_WRAPPER_BIND_BLACKLIST.has(methodName) && // other
             typeof source[methodName] === 'function' &&
-            source[methodName].prototype !== undefined && // determine if it's not bounded already
             this[methodName] === undefined
           ) {
-            this[methodName] = source[methodName].bind(node);
+            if (source[methodName].prototype) {
+              // determine if it's not bound already
+              this[methodName] = source[methodName].bind(node);
+            } else {
+              this[methodName] = source[methodName];
+            }
           }
         }
         source = Object.getPrototypeOf(source);

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -671,6 +671,7 @@ function createNativeWrapper(Component, config = {}) {
             !methodName.startsWith('component') && // lifecycle methods
             !NATIVE_WRAPPER_BIND_BLACKLIST.has(methodName) && // other
             typeof source[methodName] === 'function' &&
+            source[methodName].prototype !== undefined && // determine if it's not bounded already
             this[methodName] === undefined
           ) {
             this[methodName] = source[methodName].bind(node);


### PR DESCRIPTION
## Motivation
Following this issue https://github.com/kmagiera/react-native-gesture-handler/issues/421. 

## Changes
Since react is automatically binding some components' methods, there's no need to bind then again which provides to unwanted warnings. 

In order to fix it (and resolve more general issue of rebinding methods) I added simple check for determining whether given method is already bounded or not.  
I have managed to achieve it following https://stackoverflow.com/questions/35686850/determine-if-a-javascript-function-is-a-bound-function/35687230. Bounded method does not have prototype defined and for common use cases is fairly effective check. 