### PR TITLE
Remove dependency on React CocoaPod

### DIFF
--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -14,6 +14,4 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/kmagiera/react-native-gesture-handler", :tag => "#{s.version}" }
   s.source_files = "ios/**/*.{h,m}"
 
-  s.dependency "React"
-
 end


### PR DESCRIPTION
This resolves an issue where adding RNGestureHandler using CocoaPods also added an ancient version of React Native (0.11 specifically) and caused the build to fail. It's pretty easy to reproduce the issue this solves:

1. Bootstrap a new project with `react-native init`
2. Set up CocoaPods for the project's iOS app by running `pod init` while in the `<project name>/ios/` directory
3. Add `react-native-gesture-handler` by running `yarn add react-native-gesture-handler`
4. Run `react-native link react-native-gesture-handler` to update the project's Podfile
5. Install dependencies  by running `pod install` while in the `<project name>/ios/` directory
6. Attempt to build the iOS project
