### PR TITLE
Export exclusiveTouch property on iOS and make touchables exclusive on Android

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -748,6 +748,7 @@ const RawButton = createNativeWrapper(
 class BaseButton extends React.Component {
   static propTypes = {
     ...RawButton.propTypes,
+    exclusiveTouch: PropTypes.bool,
     onPress: PropTypes.func,
     onActiveStateChange: PropTypes.func,
   };

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -748,9 +748,13 @@ const RawButton = createNativeWrapper(
 class BaseButton extends React.Component {
   static propTypes = {
     ...RawButton.propTypes,
-    exclusiveTouch: PropTypes.bool,
+    exclusive: PropTypes.bool,
     onPress: PropTypes.func,
     onActiveStateChange: PropTypes.func,
+  };
+
+  static defaultProps = {
+    exclusive: true,
   };
 
   constructor(props) {

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -753,10 +753,6 @@ class BaseButton extends React.Component {
     onActiveStateChange: PropTypes.func,
   };
 
-  static defaultProps = {
-    exclusive: true,
-  };
-
   constructor(props) {
     super(props);
     this._lastActive = false;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
@@ -83,8 +83,7 @@ public class RNGestureHandlerButtonViewManager extends
       onTouchEvent(ev);
 
       // This workaround is made in order setting button as pressed immediately
-      int action = ev.getActionMasked();
-      if (action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_POINTER_DOWN) {
+      if (ev.getActionMasked() == MotionEvent.ACTION_DOWN) {
         setPressed(true);
       }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
@@ -81,6 +81,13 @@ public class RNGestureHandlerButtonViewManager extends
       // We call `onTouchEvent` to and wait until button changes state to `pressed`, if it's pressed
       // we return true so that the gesture handler can activate
       onTouchEvent(ev);
+
+      // This workaround is made in order setting button as pressed immediately
+      int action = ev.getActionMasked();
+      if (action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_POINTER_DOWN) {
+        setPressed(true);
+      }
+
       if (isPressed()) {
         return true;
       }

--- a/ios/RNGestureHandlerButton.m
+++ b/ios/RNGestureHandlerButton.m
@@ -38,6 +38,7 @@
   self = [super init];
   if (self) {
     _hitTestEdgeInsets = UIEdgeInsetsZero;
+    [self setExclusiveTouch:YES];
   }
   return self;
 }

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -29,7 +29,7 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 
 RCT_CUSTOM_VIEW_PROPERTY(exclusive, BOOL, RNGestureHandlerButton)
 {
-  [view setExclusiveTouch: json == nil ? true : [RCTConvert BOOL: json];];
+  [view setExclusiveTouch: json == nil ? YES : [RCTConvert BOOL: json];];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(hitSlop, UIEdgeInsets, RNGestureHandlerButton)

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -27,7 +27,10 @@ RCT_EXPORT_MODULE(RNGestureHandlerButton)
 
 RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 
-RCT_EXPORT_VIEW_PROPERTY(exclusiveTouch, BOOL)
+RCT_CUSTOM_VIEW_PROPERTY(exclusive, BOOL, RNGestureHandlerButton)
+{
+  [view setExclusiveTouch:[RCTConvert BOOL: json]];
+}
 
 RCT_CUSTOM_VIEW_PROPERTY(hitSlop, UIEdgeInsets, RNGestureHandlerButton)
 {

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -29,7 +29,7 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 
 RCT_CUSTOM_VIEW_PROPERTY(exclusive, BOOL, RNGestureHandlerButton)
 {
-  [view setExclusiveTouch: json == nil ? YES : [RCTConvert BOOL: json];];
+  [view setExclusiveTouch: json == nil ? YES : [RCTConvert BOOL: json]];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(hitSlop, UIEdgeInsets, RNGestureHandlerButton)

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -27,6 +27,8 @@ RCT_EXPORT_MODULE(RNGestureHandlerButton)
 
 RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 
+RCT_EXPORT_VIEW_PROPERTY(exclusiveTouch, BOOL)
+
 RCT_CUSTOM_VIEW_PROPERTY(hitSlop, UIEdgeInsets, RNGestureHandlerButton)
 {
   if (json) {

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -29,7 +29,7 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 
 RCT_CUSTOM_VIEW_PROPERTY(exclusive, BOOL, RNGestureHandlerButton)
 {
-  [view setExclusiveTouch: [RCTConvert BOOL: json]];
+  [view setExclusiveTouch: json == nil ? true : [RCTConvert BOOL: json];];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(hitSlop, UIEdgeInsets, RNGestureHandlerButton)

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -29,7 +29,7 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 
 RCT_CUSTOM_VIEW_PROPERTY(exclusive, BOOL, RNGestureHandlerButton)
 {
-  [view setExclusiveTouch:[RCTConvert BOOL: json]];
+  [view setExclusiveTouch: [RCTConvert BOOL: json]];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(hitSlop, UIEdgeInsets, RNGestureHandlerButton)

--- a/touchables/GenericTouchable.js
+++ b/touchables/GenericTouchable.js
@@ -16,6 +16,7 @@ export const TOUCHABLE_STATE = {
   MOVED_OUTSIDE: 2,
 };
 
+
 const PublicPropTypes = {
   // Decided to drop not used fields from RN's implementation.
   // e.g. onBlur and onFocus as well as deprecated props.
@@ -41,10 +42,12 @@ const PublicPropTypes = {
   delayLongPress: PropTypes.number,
 };
 
+
 const InternalPropTypes = {
   extraButtonProps: PropTypes.object,
   onStateChange: PropTypes.func,
 };
+
 
 /**
  * GenericTouchable is not intented to be used as it.

--- a/touchables/GenericTouchable.js
+++ b/touchables/GenericTouchable.js
@@ -120,17 +120,17 @@ export default class GenericTouchable extends Component {
     clearTimeout(this.pressOutTimeout);
     if (this.props.delayPressOut) {
       this.pressOutTimeout = setTimeout(() => {
-        if (this.STATE === TOUCHABLE_STATE.UNDETERMINED) {
+        if (
+          this.STATE === TOUCHABLE_STATE.UNDETERMINED &&
+          this.pressInTimeout
+        ) {
           this.moveToState(TOUCHABLE_STATE.BEGAN);
         }
         this.moveToState(TOUCHABLE_STATE.UNDETERMINED);
         this.pressOutTimeout = null;
       }, this.props.delayPressOut);
     } else {
-      if (
-        this.STATE === TOUCHABLE_STATE.UNDETERMINED &&
-        this.props.delayPressIn
-      ) {
+      if (this.STATE === TOUCHABLE_STATE.UNDETERMINED && this.pressInTimeout) {
         this.moveToState(TOUCHABLE_STATE.BEGAN);
       }
       this.moveToState(TOUCHABLE_STATE.UNDETERMINED);

--- a/touchables/GenericTouchable.js
+++ b/touchables/GenericTouchable.js
@@ -120,10 +120,19 @@ export default class GenericTouchable extends Component {
     clearTimeout(this.pressOutTimeout);
     if (this.props.delayPressOut) {
       this.pressOutTimeout = setTimeout(() => {
+        if (this.STATE === TOUCHABLE_STATE.UNDETERMINED) {
+          this.moveToState(TOUCHABLE_STATE.BEGAN);
+        }
         this.moveToState(TOUCHABLE_STATE.UNDETERMINED);
         this.pressOutTimeout = null;
       }, this.props.delayPressOut);
     } else {
+      if (
+        this.STATE === TOUCHABLE_STATE.UNDETERMINED &&
+        this.props.delayPressIn
+      ) {
+        this.moveToState(TOUCHABLE_STATE.BEGAN);
+      }
       this.moveToState(TOUCHABLE_STATE.UNDETERMINED);
     }
   };
@@ -194,7 +203,9 @@ export default class GenericTouchable extends Component {
     } else if (state === State.END) {
       const shouldCallOnPress =
         !this.longPressDetected &&
-        this.STATE === TOUCHABLE_STATE.BEGAN &&
+        (this.STATE === TOUCHABLE_STATE.BEGAN ||
+          (this.STATE === TOUCHABLE_STATE.UNDETERMINED &&
+            this.pressInTimeout)) &&
         this.pressOutTimeout === null;
       this.handleGoToUndetermined();
       if (shouldCallOnPress) {

--- a/touchables/GenericTouchable.js
+++ b/touchables/GenericTouchable.js
@@ -195,10 +195,7 @@ export default class GenericTouchable extends Component {
       // Need to handle case with external cancellation (e.g. by ScrollView)
       this.moveToState(TOUCHABLE_STATE.UNDETERMINED);
     } else if (
-      // This platform check is an implication of slightly different behavior of handlers on different platform.
-      // And Android "Active" state is achieving on first move of a finger, not on press in.
-      // On iOS event on "Began" is not delivered.
-      state === (Platform.OS === 'ios' ? State.ACTIVE : State.BEGAN) &&
+      state === State.ACTIVE &&
       this.STATE === TOUCHABLE_STATE.UNDETERMINED
     ) {
       // Moving inside requires
@@ -259,6 +256,7 @@ export default class GenericTouchable extends Component {
 
     return (
       <BaseButton
+        exclusive={false}
         onHandlerStateChange={this.props.disabled || this.onHandlerStateChange}
         onGestureEvent={this.onGestureEvent}
         hitSlop={this.props.hitSlop}

--- a/touchables/GenericTouchable.js
+++ b/touchables/GenericTouchable.js
@@ -16,7 +16,6 @@ export const TOUCHABLE_STATE = {
   MOVED_OUTSIDE: 2,
 };
 
-
 const PublicPropTypes = {
   // Decided to drop not used fields from RN's implementation.
   // e.g. onBlur and onFocus as well as deprecated props.
@@ -42,12 +41,10 @@ const PublicPropTypes = {
   delayLongPress: PropTypes.number,
 };
 
-
 const InternalPropTypes = {
   extraButtonProps: PropTypes.object,
   onStateChange: PropTypes.func,
 };
-
 
 /**
  * GenericTouchable is not intented to be used as it.
@@ -262,6 +259,7 @@ export default class GenericTouchable extends Component {
         onHandlerStateChange={this.props.disabled || this.onHandlerStateChange}
         onGestureEvent={this.onGestureEvent}
         hitSlop={this.props.hitSlop}
+        exclusiveTouch
         {...this.props.extraButtonProps}>
         <Animated.View {...coreProps} style={this.props.style}>
           {this.props.children}

--- a/touchables/GenericTouchable.js
+++ b/touchables/GenericTouchable.js
@@ -247,7 +247,6 @@ export default class GenericTouchable extends Component {
 
     return (
       <BaseButton
-        exclusive={false}
         onHandlerStateChange={this.props.disabled || this.onHandlerStateChange}
         onGestureEvent={this.onGestureEvent}
         hitSlop={this.props.hitSlop}

--- a/touchables/GenericTouchable.js
+++ b/touchables/GenericTouchable.js
@@ -16,7 +16,6 @@ export const TOUCHABLE_STATE = {
   MOVED_OUTSIDE: 2,
 };
 
-
 const PublicPropTypes = {
   // Decided to drop not used fields from RN's implementation.
   // e.g. onBlur and onFocus as well as deprecated props.
@@ -42,12 +41,10 @@ const PublicPropTypes = {
   delayLongPress: PropTypes.number,
 };
 
-
 const InternalPropTypes = {
   extraButtonProps: PropTypes.object,
   onStateChange: PropTypes.func,
 };
-
 
 /**
  * GenericTouchable is not intented to be used as it.
@@ -123,16 +120,10 @@ export default class GenericTouchable extends Component {
     clearTimeout(this.pressOutTimeout);
     if (this.props.delayPressOut) {
       this.pressOutTimeout = setTimeout(() => {
-        if (this.STATE === TOUCHABLE_STATE.UNDETERMINED) {
-          this.moveToState(TOUCHABLE_STATE.BEGAN);
-        }
         this.moveToState(TOUCHABLE_STATE.UNDETERMINED);
         this.pressOutTimeout = null;
       }, this.props.delayPressOut);
     } else {
-      if (this.STATE === TOUCHABLE_STATE.UNDETERMINED) {
-        this.moveToState(TOUCHABLE_STATE.BEGAN);
-      }
       this.moveToState(TOUCHABLE_STATE.UNDETERMINED);
     }
   };
@@ -203,7 +194,7 @@ export default class GenericTouchable extends Component {
     } else if (state === State.END) {
       const shouldCallOnPress =
         !this.longPressDetected &&
-        this.STATE !== TOUCHABLE_STATE.MOVED_OUTSIDE &&
+        this.STATE === TOUCHABLE_STATE.BEGAN &&
         this.pressOutTimeout === null;
       this.handleGoToUndetermined();
       if (shouldCallOnPress) {

--- a/touchables/GenericTouchable.js
+++ b/touchables/GenericTouchable.js
@@ -259,7 +259,6 @@ export default class GenericTouchable extends Component {
         onHandlerStateChange={this.props.disabled || this.onHandlerStateChange}
         onGestureEvent={this.onGestureEvent}
         hitSlop={this.props.hitSlop}
-        exclusiveTouch
         {...this.props.extraButtonProps}>
         <Animated.View {...coreProps} style={this.props.style}>
           {this.props.children}


### PR DESCRIPTION
and make it default behavior in touchables

## Changes
Export `excluding` from iOS and make it default. 

Change activation logic in Android buttons. Now it becomes active on the very first touch. Previously in was activating by native handlers which are waiting some time from first move action. That was the reason I made touchables active on beginning instead of activating and it was leading to unwanted effect -- excluding other touched was not performed correctly and some blinkings were present.
Now Android buttons are excluding each other since all excluding logic is related to activation which is performed on first touch.

Clean up `GenericTouchable` code.

Lint

