### PR TITLE
Add handleSwipeableLeftRelease/handleSwipeableRightRelease Props

### DIFF
--- a/docs/component-swipeable.md
+++ b/docs/component-swipeable.md
@@ -74,6 +74,16 @@ method that is called when action panel starts animating on open (either right o
 method that is called when action panel starts animating on close.
 
 ---
+### `handleSwipeableLeftRelease` and `handleSwipeableRightRelease`
+Methods that are called when the user releases the swipeable. The callback function is called with animation parameters and may be used to customize the resulting animation by returning an object that will be merged in. For example:
+```javascript
+handleSwipeableLeftRelease={({toValue, startOffset, velocity}) => {
+ //Use parameters if desired...
+ return { toValue: toValue 0 } //For example, this will prevent the action panel from opening
+}}
+```
+
+---
 ### `renderLeftActions`
 method that is expected to return an action panel that is going to be revealed from the left side when user swipes right.
 


### PR DESCRIPTION
I was trying to implement a swipeable row that on release animates back to the closed position. This is useful for instance on swipe to toggle functionality (For example, simply swiping right on the Gmail app causes the email to be archived)

To support this, I added two props: `handleSwipeableLeftRelease` and `handleSwipeableRightRelease`. They come with the "handle" prefix because the return value is merged into the animation options. In my specific use case I'm just returning `{ toValue: 0 }` to prevent the opening  animation, but its flexible enough to other use cases. 