### PR TITLE
Migration to latest AndroidX

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+    repositories {
+        jcenter()
+        google()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.3.1'
+    }
+}
+
 apply plugin: 'com.android.library'
 
 def safeExtGet(prop, fallback) {
@@ -5,12 +15,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 25)
-    buildToolsVersion safeExtGet("buildToolsVersion", '25.0.2')
+    compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 25)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
         ndk {
@@ -24,6 +33,11 @@ android {
     sourceSets {
         main.java.srcDirs += 'lib/src/main/java'
     }
+}
+
+repositories {
+    mavenCentral()
+    google()
 }
 
 dependencies {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -18,3 +18,5 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # org.gradle.parallel=true
 
 android.useDeprecatedNdk=true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Feb 11 12:16:44 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -2,15 +2,15 @@ apply plugin: 'com.android.library'
 
 repositories {
     maven { url 'http://repo1.maven.org/maven2' }
+    google()
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -23,6 +23,6 @@ android {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    testImplementation 'junit:junit:4.12'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.java
@@ -1,6 +1,6 @@
 package com.swmansion.gesturehandler.react;
 
-import android.support.v4.util.Pools;
+import androidx.core.util.Pools;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.java
@@ -1,6 +1,6 @@
 package com.swmansion.gesturehandler.react;
 
-import android.support.v4.util.Pools;
+import androidx.core.util.Pools;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;


### PR DESCRIPTION
Whenever anyone tries to use `react-native-gesture-handler` with the latest android sdk library simply AndroidX. We got the error for old `appcompat` libraries used. 

Then the developer has to manually remove older appcompat libraries and to add new androidx libraries. That's I created this PR with migrating react-native-gesture-handler to androidx.