### PR TITLE
Add childrenContainerStyle prop

### DIFF
--- a/Swipeable.js
+++ b/Swipeable.js
@@ -46,6 +46,7 @@ export type PropType = {
   useNativeAnimations: boolean,
   animationOptions?: Object,
   containerStyle?: Object,
+  childrenContainerStyle?: Object,
 };
 type StateType = {
   dragX: Animated.Value,
@@ -330,9 +331,12 @@ export default class Swipeable extends Component<PropType, StateType> {
             onHandlerStateChange={this._onTapHandlerStateChange}>
             <Animated.View
               pointerEvents={rowState === 0 ? 'auto' : 'box-only'}
-              style={{
-                transform: [{ translateX: this._transX }],
-              }}>
+              style={[
+                {
+                  transform: [{ translateX: this._transX }],
+                },
+                this.props.childrenContainerStyle
+              ]}>
               {children}
             </Animated.View>
           </TapGestureHandler>

--- a/docs/component-swipeable.md
+++ b/docs/component-swipeable.md
@@ -85,6 +85,10 @@ method that is expected to return an action panel that is going to be revealed f
 ### `containerStyle`
 style object for the container (Animated.View), for example to override `overflow: 'hidden'`.
 
+---
+### `childrenContainerStyle`
+style object for the children container (Animated.View), for example to apply `flex: 1`.
+
 ## Methods
 Using reference to `Swipeable` it's possible to trigger some actions on it
 


### PR DESCRIPTION
To apply `flex: 1` all the way down the hierarchy, the developer needs to customize the children container style.