### PR TITLE
Add exclusive touch prop on Android

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/NativeViewGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/NativeViewGestureHandler.java
@@ -5,6 +5,8 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.swmansion.gesturehandler.react.RNGestureHandlerButtonViewManager;
+
 public class NativeViewGestureHandler extends GestureHandler<NativeViewGestureHandler> {
 
   private boolean mShouldActivateOnStart;
@@ -86,7 +88,14 @@ public class NativeViewGestureHandler extends GestureHandler<NativeViewGestureHa
         view.onTouchEvent(event);
         activate();
       } else if (state != STATE_BEGAN) {
-        begin();
+        // setting flag for exclusive touch for buttons
+        if (view instanceof RNGestureHandlerButtonViewManager.ButtonViewGroup) {
+          if (((RNGestureHandlerButtonViewManager.ButtonViewGroup) view).setResponder()) {
+            begin();
+          }
+        } else {
+          begin();
+        }
       }
     } else if (state == STATE_ACTIVE) {
       view.onTouchEvent(event);

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
@@ -21,10 +21,10 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 public class RNGestureHandlerButtonViewManager extends
         ViewGroupManager<RNGestureHandlerButtonViewManager.ButtonViewGroup> {
 
-  static class ButtonViewGroup extends ViewGroup {
+  public static class ButtonViewGroup extends ViewGroup {
 
     static TypedValue sResolveOutValue = new TypedValue();
-    static ButtonViewGroup sResponder;
+    public static ButtonViewGroup sResponder;
 
     int mBackgroundColor = Color.TRANSPARENT;
     // Using object because of handling null representing no value set.
@@ -32,6 +32,7 @@ public class RNGestureHandlerButtonViewManager extends
     boolean mUseForeground = false;
     boolean mUseBorderless = false;
     float mBorderRadius = 0;
+    private boolean mExclusive = true;
     boolean mNeedBackgroundUpdate = false;
 
 
@@ -48,6 +49,10 @@ public class RNGestureHandlerButtonViewManager extends
     public void setBackgroundColor(int color) {
       mBackgroundColor = color;
       mNeedBackgroundUpdate = true;
+    }
+
+    public void setExclusive(Boolean exclusive) {
+      mExclusive = exclusive == null || exclusive;
     }
 
     public void setRippleColor(Integer color) {
@@ -167,14 +172,20 @@ public class RNGestureHandlerButtonViewManager extends
       }
     }
 
+    public boolean setResponder() {
+      if (sResponder == null) {
+        if (mExclusive) {
+          sResponder = this;
+        }
+        return true;
+      }
+      return false;
+    }
+
     @Override
     public void setPressed(boolean pressed) {
-      if (pressed && sResponder == null) {
-        // first button to be pressed grabs button responder
-        sResponder = this;
-      }
-      if (!pressed || sResponder == this) {
-        // we set pressed state only for current responder
+      if (!pressed || sResponder == this || (sResponder == null && !mExclusive)) {
+        // we set pressed state only for current responder if exclusive
         super.setPressed(pressed);
       }
       if (!pressed && sResponder == this) {
@@ -223,6 +234,11 @@ public class RNGestureHandlerButtonViewManager extends
   @ReactProp(name = "rippleColor")
   public void setRippleColor(ButtonViewGroup view, Integer rippleColor) {
     view.setRippleColor(rippleColor);
+  }
+
+  @ReactProp(name = "exclusive")
+  public void setExclusive(ButtonViewGroup view, Boolean  exclusive) {
+    view.setExclusive(exclusive);
   }
 
   @Override


### PR DESCRIPTION
## Motivation
The main issue which is the source of this problem is an inconsistent behavior of touchables on android and iOS. The main case was a feedback of touchables (e.g. fading in `TouchableOpacity`) which was not exclusive (it means that it could also occurs on on multiple buttons) even that exclusive-related logic was already done in RNGH (in was impossible to make two buttons `active` in the same time)

## Changes
I decided that buttons by default should not only be forbidden to activate simultaneously but also they shouldn't even begin immediately (it's a behavior on iOS)! It was an important point because touchables' feedback was hooked to beginning of gesture, not activation. I can't simple change it because on Android buttons do not become active immediately.
I moved catching responder to a bit earlier phase and connect it with `begin()` in `NativeViewGestureHandler` which might appears to be a bit dirty, but it was necessary. Catching responder (mutex for exclusive touch) is not handled by `setResponder` method.
Then it became extremely easy to make exclusiveness configurable. We could simply "not catch" responder it there's `exclusive` prop set to `false` which follows iOS behavior.