### PR TITLE
Remove peerDependencies for web

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,10 +59,7 @@
   },
   "peerDependencies": {
     "react": ">= 16.3.2",
-    "react-art": ">= 16.3.2",
-    "react-dom": ">= 16.3.2",
-    "react-native": ">= 0.54.0",
-    "react-native-web": ">= 0.7"
+    "react-native": ">= 0.54.0"
   },
   "jest": {
     "preset": "jest-react-native"


### PR DESCRIPTION
react-native-web shouldn't be a peerDep, and I'm not sure why react-art is there. I think we could also remove react and react-native and just put them as `'*'` and specify more clear version requirements in the README / installation instructions, because it all just gets lots in the peerDependencies warning mess that react-native is in.

<img width="1552" alt="screen shot 2019-03-01 at 12 15 01 pm" src="https://user-images.githubusercontent.com/90494/53663842-aca83880-3c1b-11e9-81b7-3b29d0f6ee97.png">
