### PR TITLE
Fix style in touchables

### DIFF
--- a/touchables/TouchableHighlight.js
+++ b/touchables/TouchableHighlight.js
@@ -94,10 +94,7 @@ export default class TouchableHighlight extends Component {
     return (
       <GenericTouchable
         {...rest}
-        style={{
-          ...style,
-          ...extraUnderlayStyle,
-        }}
+        style={[style, extraUnderlayStyle]}
         onStateChange={this.onStateChange}>
         {this.renderChildren()}
       </GenericTouchable>

--- a/touchables/TouchableOpacity.js
+++ b/touchables/TouchableOpacity.js
@@ -51,10 +51,12 @@ export default class TouchableOpacity extends Component {
     return (
       <GenericTouchable
         {...rest}
-        style={{
-          ...style,
-          opacity: this.opacity,
-        }}
+        style={[
+          style,
+          {
+            opacity: this.opacity,
+          },
+        ]}
         onStateChange={this.onStateChange}>
         {this.props.children ? this.props.children : <View />}
       </GenericTouchable>


### PR DESCRIPTION
## Motivation
**https://github.com/kmagiera/react-native-gesture-handler/issues/488**
Style could be apply to `TouchableHighlight` and `TouchableOpacity` but passing as array of style leads to unexpected behavior (style is not applying then).\

## Changes
Instead of using spread operated style is now wrapped into arrays and it is handled well RN.