### PR TITLE
Except exclusiveTouch from TV build

### DIFF
--- a/ios/RNGestureHandlerButton.m
+++ b/ios/RNGestureHandlerButton.m
@@ -38,7 +38,9 @@
   self = [super init];
   if (self) {
     _hitTestEdgeInsets = UIEdgeInsetsZero;
+#if !TARGET_OS_TV
     [self setExclusiveTouch:YES];
+#endif
   }
   return self;
 }

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -29,7 +29,9 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 
 RCT_CUSTOM_VIEW_PROPERTY(exclusive, BOOL, RNGestureHandlerButton)
 {
+#if !TARGET_OS_TV
   [view setExclusiveTouch: json == nil ? YES : [RCTConvert BOOL: json]];
+#endif
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(hitSlop, UIEdgeInsets, RNGestureHandlerButton)


### PR DESCRIPTION
Fixes https://github.com/kmagiera/react-native-gesture-handler/issues/502

This method is not available on TV.