### PR TITLE
Remove ViewPager and Slider in favor of exporting createNativeWrapper

### DIFF
--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -126,6 +126,7 @@ android {
 }
 
 dependencies {
+    implementation project(':@react-native-community_slider')
     compile project(':react-native-vector-icons')
     compile project(':react-native-gesture-handler')
     compile fileTree(dir: "libs", include: ["*.jar"])

--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -126,6 +126,7 @@ android {
 }
 
 dependencies {
+    implementation project(':@react-native-community_viewpager')
     implementation project(':@react-native-community_slider')
     compile project(':react-native-vector-icons')
     compile project(':react-native-gesture-handler')

--- a/Example/android/app/src/main/java/com/swmansion/gesturehandler/react/example/MainApplication.java
+++ b/Example/android/app/src/main/java/com/swmansion/gesturehandler/react/example/MainApplication.java
@@ -3,6 +3,7 @@ package com.swmansion.gesturehandler.react.example;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.reactnativecommunity.slider.ReactSliderPackage;
 import com.oblador.vectoricons.VectorIconsPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -25,6 +26,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new ReactSliderPackage(),
             new VectorIconsPackage(),
           new RNGestureHandlerPackage()
       );

--- a/Example/android/app/src/main/java/com/swmansion/gesturehandler/react/example/MainApplication.java
+++ b/Example/android/app/src/main/java/com/swmansion/gesturehandler/react/example/MainApplication.java
@@ -3,6 +3,7 @@ package com.swmansion.gesturehandler.react.example;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.reactnativecommunity.viewpager.RNCViewPagerPackage;
 import com.reactnativecommunity.slider.ReactSliderPackage;
 import com.oblador.vectoricons.VectorIconsPackage;
 import com.facebook.react.ReactNativeHost;
@@ -26,6 +27,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new RNCViewPagerPackage(),
             new ReactSliderPackage(),
             new VectorIconsPackage(),
           new RNGestureHandlerPackage()

--- a/Example/android/settings.gradle
+++ b/Example/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'RNGH Example'
+include ':@react-native-community_slider'
+project(':@react-native-community_slider').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/slider/android')
 include ':react-native-vector-icons'
 project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
 

--- a/Example/android/settings.gradle
+++ b/Example/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'RNGH Example'
+include ':@react-native-community_viewpager'
+project(':@react-native-community_viewpager').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/viewpager/android')
 include ':@react-native-community_slider'
 project(':@react-native-community_slider').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/slider/android')
 include ':react-native-vector-icons'

--- a/Example/combo/index.js
+++ b/Example/combo/index.js
@@ -10,12 +10,13 @@ import {
 import {
   NativeViewGestureHandler,
   ScrollView as GHScroll,
-  Slider,
   State,
   TapGestureHandler,
   TextInput,
   RectButton,
+  createNativeWrapper,
 } from 'react-native-gesture-handler';
+import Slider from '@react-native-community/slider';
 
 import { Swipeable, InfoButton } from '../rows';
 import { DraggableBox } from '../draggable';
@@ -25,6 +26,12 @@ import { PressBox } from '../multitap';
 import { LoremIpsum } from '../common';
 
 const CHILD_REF = 'CHILD_REF';
+
+const WrappedSlider = createNativeWrapper(Slider, {
+  shouldCancelWhenOutside: false,
+  shouldActivateOnStart: true,
+  disallowInterruption: true,
+});
 
 class TouchableHighlight extends Component {
   static propTypes = View.propTypes;
@@ -122,7 +129,7 @@ class Combo extends Component {
               <Text>Hello</Text>
             </View>
           </TouchableHighlight>
-          <Slider style={styles.slider} />
+          <WrappedSlider style={styles.slider} />
           <TextInput
             style={styles.textinput}
             placeholder="Type something here!"

--- a/Example/ios/GestureHandler.xcodeproj/project.pbxproj
+++ b/Example/ios/GestureHandler.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		E51555F0E0964905B6A124B5 /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1C1A6DB65E974144834B4CE8 /* Entypo.ttf */; };
 		E9DBD63883AE42BDAEAD6BFB /* Zocial.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9959AF8A7D2B4083BD8A4519 /* Zocial.ttf */; };
 		7397DC1C715543B2AE4A6A1B /* libRNCSlider.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A4FA96EB7D1E4F4E83218D09 /* libRNCSlider.a */; };
+		FCFE66DE97F741B7868E8A4E /* libRNCViewpager.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0960E5C8A1C24EB3B4BED5AF /* libRNCViewpager.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -350,6 +351,8 @@
 		F45F3123B97C4B01A0BBF800 /* libRNGestureHandler.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNGestureHandler.a; sourceTree = "<group>"; };
 		BC26737B71234157978A9B92 /* RNCSlider.xcodeproj */ = {isa = PBXFileReference; name = "RNCSlider.xcodeproj"; path = "../node_modules/@react-native-community/slider/ios/RNCSlider.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
 		A4FA96EB7D1E4F4E83218D09 /* libRNCSlider.a */ = {isa = PBXFileReference; name = "libRNCSlider.a"; path = "libRNCSlider.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		F2134B3208B74A15BEDA8D00 /* RNCViewpager.xcodeproj */ = {isa = PBXFileReference; name = "RNCViewpager.xcodeproj"; path = "../node_modules/@react-native-community/viewpager/ios/RNCViewpager.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		0960E5C8A1C24EB3B4BED5AF /* libRNCViewpager.a */ = {isa = PBXFileReference; name = "libRNCViewpager.a"; path = "libRNCViewpager.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -373,6 +376,7 @@
 				66D932A521BEFC6D00E14346 /* libRNGestureHandler.a in Frameworks */,
 				A43A7B882C8C45BFB74FC777 /* libRNVectorIcons.a in Frameworks */,
 				7397DC1C715543B2AE4A6A1B /* libRNCSlider.a in Frameworks */,
+				FCFE66DE97F741B7868E8A4E /* libRNCViewpager.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -568,6 +572,7 @@
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
 				77571D38DE0E4D398887A4FE /* RNVectorIcons.xcodeproj */,
 				BC26737B71234157978A9B92 /* RNCSlider.xcodeproj */,
+				F2134B3208B74A15BEDA8D00 /* RNCViewpager.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -1057,11 +1062,13 @@
 					"$(SRCROOT)/../node_modules/react-native-gesture-handler/ios",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/@react-native-community/slider/ios/**",
+					"$(SRCROOT)/../node_modules/@react-native-community/viewpager/ios/**",
 				);
 				INFOPLIST_FILE = GestureHandler/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/GestureHandler\"",
 					"\"$(SRCROOT)/GestureHandler\"",
 					"\"$(SRCROOT)/GestureHandler\"",
 					"\"$(SRCROOT)/GestureHandler\"",
@@ -1089,11 +1096,13 @@
 					"$(SRCROOT)/../node_modules/react-native-gesture-handler/ios",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/@react-native-community/slider/ios/**",
+					"$(SRCROOT)/../node_modules/@react-native-community/viewpager/ios/**",
 				);
 				INFOPLIST_FILE = GestureHandler/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/GestureHandler\"",
 					"\"$(SRCROOT)/GestureHandler\"",
 					"\"$(SRCROOT)/GestureHandler\"",
 					"\"$(SRCROOT)/GestureHandler\"",

--- a/Example/ios/GestureHandler.xcodeproj/project.pbxproj
+++ b/Example/ios/GestureHandler.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -38,6 +37,7 @@
 		A818DD53BC194056982B7BF2 /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BB2E03EAE7A94DF18ADA38F7 /* Octicons.ttf */; };
 		E51555F0E0964905B6A124B5 /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1C1A6DB65E974144834B4CE8 /* Entypo.ttf */; };
 		E9DBD63883AE42BDAEAD6BFB /* Zocial.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9959AF8A7D2B4083BD8A4519 /* Zocial.ttf */; };
+		7397DC1C715543B2AE4A6A1B /* libRNCSlider.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A4FA96EB7D1E4F4E83218D09 /* libRNCSlider.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -348,6 +348,8 @@
 		C5DCC010E8A44473AA39F47E /* Foundation.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Foundation.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Foundation.ttf"; sourceTree = "<group>"; };
 		D4363B3FAD994C7CB59220D8 /* SimpleLineIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = SimpleLineIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf"; sourceTree = "<group>"; };
 		F45F3123B97C4B01A0BBF800 /* libRNGestureHandler.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNGestureHandler.a; sourceTree = "<group>"; };
+		BC26737B71234157978A9B92 /* RNCSlider.xcodeproj */ = {isa = PBXFileReference; name = "RNCSlider.xcodeproj"; path = "../node_modules/@react-native-community/slider/ios/RNCSlider.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		A4FA96EB7D1E4F4E83218D09 /* libRNCSlider.a */ = {isa = PBXFileReference; name = "libRNCSlider.a"; path = "libRNCSlider.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -370,6 +372,7 @@
 				566546315B5448F7A7530320 /* libRNGestureHandler.a in Frameworks */,
 				66D932A521BEFC6D00E14346 /* libRNGestureHandler.a in Frameworks */,
 				A43A7B882C8C45BFB74FC777 /* libRNVectorIcons.a in Frameworks */,
+				7397DC1C715543B2AE4A6A1B /* libRNCSlider.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -564,6 +567,7 @@
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
 				77571D38DE0E4D398887A4FE /* RNVectorIcons.xcodeproj */,
+				BC26737B71234157978A9B92 /* RNCSlider.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -1052,11 +1056,13 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-gesture-handler/ios",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/@react-native-community/slider/ios/**",
 				);
 				INFOPLIST_FILE = GestureHandler/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/GestureHandler\"",
 					"\"$(SRCROOT)/GestureHandler\"",
 					"\"$(SRCROOT)/GestureHandler\"",
 				);
@@ -1082,11 +1088,13 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-gesture-handler/ios",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/@react-native-community/slider/ios/**",
 				);
 				INFOPLIST_FILE = GestureHandler/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/GestureHandler\"",
 					"\"$(SRCROOT)/GestureHandler\"",
 					"\"$(SRCROOT)/GestureHandler\"",
 				);

--- a/Example/package.json
+++ b/Example/package.json
@@ -10,6 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
+    "@react-native-community/slider": "^1.0.1",
+    "@react-native-community/viewpager": "^1.1.2",
     "fbjs": "^1.0.0",
     "hoist-non-react-statics": "^3.2.1",
     "invariant": "^2.2.4",

--- a/Example/pagerAndDrawer/index.js
+++ b/Example/pagerAndDrawer/index.js
@@ -2,9 +2,14 @@ import React, { Component } from 'react';
 import { StyleSheet, Text, View, Platform } from 'react-native';
 
 import {
-  ViewPagerAndroid,
   DrawerLayoutAndroid,
+  createNativeWrapper,
 } from 'react-native-gesture-handler';
+import ViewPagerAndroid from '@react-native-community/viewpager';
+
+const WrappedViewPagerAndroid = createNativeWrapper(ViewPagerAndroid, {
+  disallowInterruption: true,
+});
 
 const Page = ({ backgroundColor, text }) =>
   <View style={[styles.page, { backgroundColor }]}>
@@ -28,7 +33,7 @@ export default class Example extends Component {
       </View>
     );
     return (
-      <ViewPagerAndroid style={styles.container}>
+      <WrappedViewPagerAndroid style={styles.container}>
         <View>
           <DrawerLayoutAndroid
             drawerWidth={200}
@@ -47,7 +52,7 @@ export default class Example extends Component {
             <Page backgroundColor="blue" text="Fourth 😎" />
           </DrawerLayoutAndroid>
         </View>
-      </ViewPagerAndroid>
+      </WrappedViewPagerAndroid>
     );
   }
 }

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -916,6 +916,16 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@react-native-community/slider@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-1.0.1.tgz#6f0d83a8006b0e5aff60a4918822bee7a06e36fc"
+  integrity sha512-fLOTvYT2okDR7V85afP4TwOdUKzmrcFXtkoTcSGoQiNxTxshSZrzL19Gisc2fyFBK8qsZ/lxyoTe9VpuaGVoCg==
+
+"@react-native-community/viewpager@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/viewpager/-/viewpager-1.1.2.tgz#cf044478efae6f129bbf6908a574220e723c7852"
+  integrity sha512-qXYqupJTo7q0RgRzVuJvG/Yv7E1CychMjOc+HL4A6KVW6pmsjiurNajIIjTmBydlgKahfbLNUA00UKD5yjvJ0A==
+
 "@react-navigation/core@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-3.0.2.tgz#8631801533a27d034a3b8421dfd0510a9f27dcf3"
@@ -5788,7 +5798,7 @@ merge-stream@^1.0.1:
   dependencies:
     readable-stream "^2.0.1"
 
-merge@1.2.1, merge@^1.2.0:
+merge@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
   integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -613,4 +613,5 @@ export {
   FlatListWithGHScroll as FlatList,
   gestureHandlerRootHOC,
   Directions,
+  createNativeWrapper,
 };

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -2,11 +2,9 @@ import React from 'react';
 import {
   Animated,
   ScrollView,
-  Slider,
   Switch,
   TextInput,
   ToolbarAndroid,
-  ViewPagerAndroid,
   DrawerLayoutAndroid,
   StyleSheet,
   FlatList,
@@ -403,11 +401,6 @@ function createNativeWrapper(Component, config = {}) {
 const WrappedScrollView = createNativeWrapper(ScrollView, {
   disallowInterruption: true,
 });
-const WrappedSlider = createNativeWrapper(Slider, {
-  shouldCancelWhenOutside: false,
-  shouldActivateOnStart: true,
-  disallowInterruption: true,
-});
 const WrappedSwitch = createNativeWrapper(Switch, {
   shouldCancelWhenOutside: false,
   shouldActivateOnStart: true,
@@ -416,9 +409,6 @@ const WrappedSwitch = createNativeWrapper(Switch, {
 const WrappedTextInput = createNativeWrapper(TextInput);
 
 const WrappedToolbarAndroid = createNativeWrapper(ToolbarAndroid);
-const WrappedViewPagerAndroid = createNativeWrapper(ViewPagerAndroid, {
-  disallowInterruption: true,
-});
 const WrappedDrawerLayoutAndroid = createNativeWrapper(DrawerLayoutAndroid, {
   disallowInterruption: true,
 });
@@ -601,11 +591,9 @@ const FlatListWithGHScroll = props => (
 
 export {
   WrappedScrollView as ScrollView,
-  WrappedSlider as Slider,
   WrappedSwitch as Switch,
   WrappedTextInput as TextInput,
   WrappedToolbarAndroid as ToolbarAndroid,
-  WrappedViewPagerAndroid as ViewPagerAndroid,
   WrappedDrawerLayoutAndroid as DrawerLayoutAndroid,
   NativeViewGestureHandler,
   TapGestureHandler,

--- a/docs/about-handlers.md
+++ b/docs/about-handlers.md
@@ -77,11 +77,9 @@ class Multitap extends Component {
 Gesture handler library exposes a set of components normally available in React Native that are wrapped in [`NativeViewGestureHandler`](handler-native.md).
 Here is a list of exposed components:
  - `ScrollView`
- - `Slider`
  - `Switch`
  - `TextInput`
  - `ToolbarAndroid` (**Android only**)
- - `ViewPagerAndroid` (**Android only**)
  - `DrawerLayoutAndroid` (**Android only**)
  
 If you want to use other handlers or [buttons](component-buttons.md) nested in a `ScrollView` or you want to use [`waitFor`](handler-common.md#waitfor) property to define interaction between a handler and `ScrollView`

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -86,3 +86,17 @@ Library exports a `State` object that provides a number of constants used to exp
 
  - `direction`
  - `numberOfPointers`
+
+### `createNativeWrapper`
+
+If you want to create a gesture handler wrapper for your own custom component, you can use this utility function. For example, if you want to use [Slider](https://github.com/react-native-community/react-native-slider) with gesture handler, then you can implement it like this:
+
+```js
+const WrappedSlider = createNativeWrapper(Slider, {
+  shouldCancelWhenOutside: false,
+  shouldActivateOnStart: true,
+  disallowInterruption: true,
+});
+```
+
+The second argument is a config object of type [`NativeViewGestureHandlerProperties`](../react-native-gesture-handler.d.ts#L231) which accepts a list of properties you want to pass to the underlying gesture handler wrapper.

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -16,11 +16,9 @@ Here are a gesture recognizers currently available in the package:
 
 Whenever you use a native component that should handle touch events you can either wrap it with `NativeViewGestureHandler` or import wrapper component exported by the library instead of importing it from `react-native` package. Here is the list of available components:
  - `ScrollView`
- - `Slider`
  - `Switch`
  - `TextInput`
  - `ToolbarAndroid` (**Android only**)
- - `ViewPagerAndroid` (**Android only**)
  - `DrawerLayoutAndroid` (**Android only**)
 
 

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -433,6 +433,11 @@ declare module 'react-native-gesture-handler' {
     Component: React.ComponentType<any>,
     containerStyles?: StyleProp<ViewStyle>
   ): React.ComponentType<any>;
+
+  export function createNativeWrapper(
+    Component: React.ComponentType<any>,
+    config: NativeViewGestureHandlerProperties
+  ): React.ComponentType<any>;
 }
 
 declare module 'react-native-gesture-handler/Swipeable' {

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -7,11 +7,9 @@ declare module 'react-native-gesture-handler' {
     Animated,
     FlatListProperties,
     ScrollViewProperties,
-    SliderProperties,
     SwitchProperties,
     TextInputProperties,
     ToolbarAndroidProperties,
-    ViewPagerAndroidProperties,
     DrawerLayoutAndroidProperties,
     TouchableHighlightProperties,
     TouchableOpacityProperties,
@@ -409,10 +407,6 @@ declare module 'react-native-gesture-handler' {
     NativeViewGestureHandlerProperties & ScrollViewProperties
   > {}
 
-  export class Slider extends React.Component<
-    NativeViewGestureHandlerProperties & SliderProperties
-  > {}
-
   export class Switch extends React.Component<
     NativeViewGestureHandlerProperties & SwitchProperties
   > {}
@@ -423,10 +417,6 @@ declare module 'react-native-gesture-handler' {
 
   export class ToolbarAndroid extends React.Component<
     NativeViewGestureHandlerProperties & ToolbarAndroidProperties
-  > {}
-
-  export class ViewPagerAndroid extends React.Component<
-    NativeViewGestureHandlerProperties & ViewPagerAndroidProperties
   > {}
 
   export class DrawerLayoutAndroid extends React.Component<


### PR DESCRIPTION
Fixes #482 

In RN 0.59 `ViewPager` and `Slider` are going to be dropped and therefore they call for being dropped from RNGH core. However, since there're use cases of these components, decided not to drop support for them at all, but to expose function for creating generic components with pure native ones. 