### PR TITLE
[Docs] Add FlatList to the list of native components

### DIFF
--- a/docs/about-handlers.md
+++ b/docs/about-handlers.md
@@ -77,6 +77,7 @@ class Multitap extends Component {
 Gesture handler library exposes a set of components normally available in React Native that are wrapped in [`NativeViewGestureHandler`](handler-native.md).
 Here is a list of exposed components:
  - `ScrollView`
+ - `FlatList`
  - `Switch`
  - `TextInput`
  - `ToolbarAndroid` (**Android only**)


### PR DESCRIPTION
This is just a small documentation change so I didn't create a new issue.  

Should `FlatList` be included on the list of native components exposed by RN Gesture Handler?

https://github.com/kmagiera/react-native-gesture-handler/blob/5f428532ea26b0c055b640d9110a69eb1698e8ec/GestureHandler.js#L613