### PR TITLE
NativeWrappers use displayName from wrapped component

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -352,6 +352,8 @@ function createNativeWrapper(Component, config = {}) {
     static propTypes = {
       ...Component.propTypes,
     };
+  
+    static displayName = Component.displayName || "ComponentWrapper";
 
     _refHandler = node => {
       // bind native component's methods


### PR DESCRIPTION
Closes #517 

When creating a native wrapper component (using `createNativeWrapper`), copy the input Component's `displayName` property, if it exists.