### PR TITLE
Added try/catch for dispatchTouchEvent

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
@@ -37,6 +37,7 @@ public class RNGestureHandlerEnabledRootView extends ReactRootView {
       }
     }catch (IllegalArgumentException e) {
       e.printStackTrace();
+      return false;
     }
     return false;
   }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
@@ -29,8 +29,8 @@ public class RNGestureHandlerEnabledRootView extends ReactRootView {
   @Override
   public boolean dispatchTouchEvent(MotionEvent ev) {
     try {
-      if (mGestureRootHelper != null) {
-        mGestureRootHelper.dispatchTouchEvent(ev)
+      if (mGestureRootHelper != null && mGestureRootHelper.dispatchTouchEvent(ev)) {
+        return true;
       }
       return super.dispatchTouchEvent(ev);
     } catch (IllegalArgumentException e) {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
@@ -28,10 +28,17 @@ public class RNGestureHandlerEnabledRootView extends ReactRootView {
 
   @Override
   public boolean dispatchTouchEvent(MotionEvent ev) {
-    if (mGestureRootHelper != null && mGestureRootHelper.dispatchTouchEvent(ev)) {
-      return true;
+    try {
+      if (mGestureRootHelper != null && mGestureRootHelper.dispatchTouchEvent(ev)) {
+        return true;
+      }
+      if (super.dispatchTouchEvent(ev)) {
+        return true;
+      }
+    }catch (IllegalArgumentException e) {
+      e.printStackTrace();
     }
-    return super.dispatchTouchEvent(ev);
+    return false;
   }
 
   /**

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
@@ -29,17 +29,14 @@ public class RNGestureHandlerEnabledRootView extends ReactRootView {
   @Override
   public boolean dispatchTouchEvent(MotionEvent ev) {
     try {
-      if (mGestureRootHelper != null && mGestureRootHelper.dispatchTouchEvent(ev)) {
-        return true;
+      if (mGestureRootHelper != null) {
+        mGestureRootHelper.dispatchTouchEvent(ev)
       }
-      if (super.dispatchTouchEvent(ev)) {
-        return true;
-      }
+      return super.dispatchTouchEvent(ev);
     } catch (IllegalArgumentException e) {
       e.printStackTrace();
       return false;
     }
-    return false;
   }
 
   /**

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
@@ -35,7 +35,7 @@ public class RNGestureHandlerEnabledRootView extends ReactRootView {
       if (super.dispatchTouchEvent(ev)) {
         return true;
       }
-    }catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException e) {
       e.printStackTrace();
       return false;
     }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
@@ -37,6 +37,8 @@ public class RNGestureHandlerEnabledRootView extends ReactRootView {
       e.printStackTrace();
       return false;
     }
+    return false;
+
   }
 
   /**

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
@@ -37,8 +37,6 @@ public class RNGestureHandlerEnabledRootView extends ReactRootView {
       e.printStackTrace();
       return false;
     }
-    return false;
-
   }
 
   /**


### PR DESCRIPTION
Fix for this issue: https://github.com/kmagiera/react-native-gesture-handler/issues/519 - Crash when using multiple fingers to interact with certain components. 

Fixed by adding try/catch for ```IllegalArgumentException```  when trying to call ```dispatchTouchEvent```.