### PR TITLE
Export PureNativeButton

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -624,5 +624,6 @@ export {
   /* Other */
   FlatListWithGHScroll as FlatList,
   gestureHandlerRootHOC,
+  GestureHandlerButton as PureNativeButton,
   Directions,
 };

--- a/docs/component-buttons.md
+++ b/docs/component-buttons.md
@@ -109,7 +109,7 @@ It should be used if you wish to handle non-crucial actions and supportive behav
 
 ### `PureNativeButton`
 
-Use `PureNativeButton` for accessing native Component used for build more complex buttons listed above.
+Use a `PureNativeButton` for accessing the native Component used for build more complex buttons listed above.
 It's normally is not recommended to use, but it might be useful if we want to wrap it using Animated or Reanimated.
 
 ```javascript

--- a/docs/component-buttons.md
+++ b/docs/component-buttons.md
@@ -105,3 +105,41 @@ It should be used if you wish to handle non-crucial actions and supportive behav
 
 
 <img src="assets/iosmail.gif" width="280" />
+
+
+### `PureNativeButton`
+
+Use `PureNativeButton` for accessing native Component used for build more complex buttons listed above.
+It's normally is not recommended to use, but it might be useful if we want to wrap it using Animated or Reanimated.
+
+```javascript
+import { createNativeWrapper, PureNativeButton } from 'react-native-gesture-handler';
+import Animated from 'react-native-reanimated';
+const { event, Value, createAnimatedComponent } = Animated;
+
+const AnimatedRawButton = createNativeWrapper(
+  createAnimatedComponent(PureNativeButton),
+  {
+    shouldCancelWhenOutside: false,
+    shouldActivateOnStart: false,
+  }
+);
+
+export default class App extends React.Component {
+  constructor(props) {
+    super(props);
+    const state = new Value();
+    this._onGestureEvent = event([
+      {
+        nativeEvent: { state },
+      },
+    ]);
+  }
+
+  render() {
+    return (
+      <AnimatedRawButton onHandlerStateChange={this._onGestureEvent}/>
+    );
+  }
+}
+```


### PR DESCRIPTION
## Motivation
@ckknight 
I'd like to use `Animated.event` with the handlers of the Buttons, without having to rely on using `TapGestureHandler` or similar.

Given the following code:

```jsx
<RawButton onGestureEvent={Animated.event([{ nativeEvent: { state: new Animated.Value(-1) } }])}>
  <View style={{width: 50, height: 50, backgroundColor: 'red'}} />
<RawButton>
```

This error occurs when tapping:

Expected `onGestureHandlerStateChange` listener to be a function, instead got a value of `object` type.

This is the case whether using `react-native`'s `Animated` or using `react-native-reanimated`.

## Changes
Exporting PuteNativeButton allows to preparing Animated component on users' own. `createNativeWrapper` makes a wrapper for this component and only if it's an animated component, we could use the code above. 

So now it will be possible to do it like:

```jsx
import { createNativeWrapper, PureNativeButton } from 'react-native-gesture-handler';
import Animated from 'react-native-reanimated';
const { event, Value, createAnimatedComponent } = Animated;
const AnimatedRawButton = createNativeWrapper(
  createAnimatedComponent(PureNativeButton),
  {
    shouldCancelWhenOutside: false,
    shouldActivateOnStart: false,
  }
);
export default class App extends React.Component {
  constructor(props) {
    super(props);
    const state = new Value();
    this._onGestureEvent = event([
      {
        nativeEvent: { state },
      },
    ]);
  }
  render() {
    return (
      <AnimatedRawButton onHandlerStateChange={this._onGestureEvent}/>
    );
  }
}
```