### PR TITLE
Change style prop-type to any

### DIFF
--- a/touchables/TouchableHighlight.js
+++ b/touchables/TouchableHighlight.js
@@ -18,7 +18,7 @@ export default class TouchableHighlight extends Component {
     ...GenericTouchable.publicPropTypes,
     activeOpacity: PropTypes.number,
     underlayColor: PropTypes.string,
-    style: PropTypes.object,
+    style: PropTypes.any,
     onShowUnderlay: PropTypes.func,
     onHideUnderlay: PropTypes.func,
   };

--- a/touchables/TouchableNativeFeedback.android.js
+++ b/touchables/TouchableNativeFeedback.android.js
@@ -35,7 +35,7 @@ export default class TouchableNativeFeedback extends Component {
     ...GenericTouchable.publicPropTypes,
     useForeground: PropTypes.bool,
     background: PropTypes.string,
-    style: PropTypes.object,
+    style: PropTypes.any,
   };
 
   getExtraButtonProps = () => {

--- a/touchables/TouchableOpacity.js
+++ b/touchables/TouchableOpacity.js
@@ -14,7 +14,7 @@ export default class TouchableOpacity extends Component {
 
   static propTypes = {
     ...GenericTouchable.publicPropTypes,
-    style: PropTypes.object,
+    style: PropTypes.any,
     activeOpacity: PropTypes.number,
   };
 


### PR DESCRIPTION
The style prop can actually be pretty much anything: an object, a number, a falsey value, or an array containing any mix of the preceding types. We could write up a complex type check for that, but it seems overkill. And prop-types are being removed from react-native core, so I'm not sure we even need these prop checks. 

If you feel strongly about a complex type check, let me know and I'll see what I can do. 