### PR TITLE
[Pinch] Only update focal point when multiple fingers present

### DIFF
--- a/ios/Handlers/RNPinchHandler.m
+++ b/ios/Handlers/RNPinchHandler.m
@@ -8,7 +8,9 @@
 
 #import "RNPinchHandler.h"
 
-@implementation RNPinchGestureHandler
+@implementation RNPinchGestureHandler {
+  CGPoint _focalPoint;
+}
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
@@ -23,9 +25,12 @@
 #if !TARGET_OS_TV
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIPinchGestureRecognizer *)recognizer
 {
+    if (recognizer.numberOfTouches > 1) {
+      _focalPoint = [recognizer locationInView:recognizer.view];
+    }
     return [RNGestureHandlerEventExtraData
             forPinch:recognizer.scale
-            withFocalPoint:[recognizer locationInView:recognizer.view]
+            withFocalPoint:_focalPoint
             withVelocity:recognizer.velocity
             withNumberOfTouches:recognizer.numberOfTouches];
 }


### PR DESCRIPTION
Fixes #546. Android's [ScaleGestureDetector](https://developer.android.com/reference/android/view/ScaleGestureDetector.html#getFocusX()) says "the focal point is between each of the pointers forming the gesture". However, that means that at the end of the gesture, when the first finger is removed from the screen, the focal point will suddenly be redefined as the location of the second finger, rather than being between the two fingers.

This PR prevents the focal point from being updated when only one finger is present.