### PR TITLE
Add missing type imports for DrawerLayout

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -478,7 +478,12 @@ declare module 'react-native-gesture-handler/Swipeable' {
 }
 
 declare module 'react-native-gesture-handler/DrawerLayout' {
-  import { Animated, StatusBarAnimation, StyleProp, ViewStyle } from 'react-native';
+  import {
+    Animated,
+    StatusBarAnimation,
+    StyleProp,
+    ViewStyle
+  } from 'react-native';
 
   interface DrawerLayoutProperties {
     renderNavigationView: (


### PR DESCRIPTION
Fixes the following errors:
```
node_modules/react-native-gesture-handler/react-native-gesture-handler.d.ts:516:22 - error TS2304: Cannot find name 'StyleProp'.
516     containerStyle?: StyleProp<ViewStyle>
                         ~~~~~~~~~

node_modules/react-native-gesture-handler/react-native-gesture-handler.d.ts:516:32 - error TS2304: Cannot find name 'ViewStyle'.
516     containerStyle?: StyleProp<ViewStyle>
```