### PR TITLE
Fix TouchableNativeFeedback background propTypes

### DIFF
--- a/touchables/TouchableNativeFeedback.android.js
+++ b/touchables/TouchableNativeFeedback.android.js
@@ -34,7 +34,7 @@ export default class TouchableNativeFeedback extends Component {
   static propTypes = {
     ...GenericTouchable.publicPropTypes,
     useForeground: PropTypes.bool,
-    background: PropTypes.string,
+    background: PropTypes.object,
     style: PropTypes.any,
   };
 


### PR DESCRIPTION
Currently the propType for background is `string`. It should be `object`.