### PR TITLE
FIX hitSlop right and left properties not being respected on android

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.java
@@ -400,9 +400,9 @@ public class GestureHandler<T extends GestureHandler> {
       float height= mHitSlop[HIT_SLOP_HEIGHT_IDX];
       if (hitSlopSet(width)) {
         if (!hitSlopSet(padLeft)) {
-          left = padRight - width;
+          left = right - width;
         } else if (!hitSlopSet(padRight)) {
-          right = padLeft + width;
+          right = left + width;
         }
       }
       if (hitSlopSet(height)) {


### PR DESCRIPTION
Relates to #569 

Incorrect values were taken into consideration in function which determines whether the pointer is within bounds. We were using hitSlop padding values set through props instead of calculated absolute bounds (left, right, bottom, top).