### PR TITLE
Replace propType dependency with string literals

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -21,6 +21,7 @@ import Directions from './Directions';
 import State from './State';
 import PlatformConstants from './PlatformConstants';
 
+// If changed, add changes to NATIVE_WRAPPER_PROPS_FILTER as well
 const GestureHandlerPropTypes = {
   id: PropTypes.string,
   minPointers: PropTypes.number,
@@ -64,6 +65,8 @@ const GestureHandlerPropTypes = {
 
 const NativeViewGestureHandler = createHandler('NativeViewGestureHandler', {
   ...GestureHandlerPropTypes,
+
+  // If changed, add changes to NATIVE_WRAPPER_PROPS_FILTER as well
   shouldActivateOnStart: PropTypes.bool,
   disallowInterruption: PropTypes.bool,
 });
@@ -339,13 +342,34 @@ const RotationGestureHandler = createHandler(
 );
 
 const NATIVE_WRAPPER_BIND_BLACKLIST = new Set(['replaceState', 'isMounted']);
-const NATIVE_WRAPPER_PROPS_FILTER = {
-  // accept all gesture handler prop types plus native wrapper specific ones
-  ...NativeViewGestureHandler.propTypes,
-  // we want to pass gesture event handlers if registered
-  onGestureHandlerEvent: PropTypes.func,
-  onGestureHandlerStateChange: PropTypes.func,
-};
+
+/*
+ * This array should consist of:
+ *   - All keys in propTypes from NativeGestureHandler
+ *     (and all keys in GestureHandlerPropTypes)
+ *   - 'onGestureHandlerEvent'
+ *   - 'onGestureHandlerStateChange'
+ */
+const NATIVE_WRAPPER_PROPS_FILTER = [
+  'id',
+  'minPointers',
+  'enabled',
+  'waitFor',
+  'simultaneousHandlers',
+  'shouldCancelWhenOutside',
+  'hitSlop',
+  'onGestureEvent',
+  'onHandlerStateChange',
+  'onBegan',
+  'onFailed',
+  'onCancelled',
+  'onActivated',
+  'onEnded',
+  'shouldActivateOnStart',
+  'disallowInterruption',
+  'onGestureHandlerEvent',
+  'onGestureHandlerStateChange',
+];
 
 function createNativeWrapper(Component, config = {}) {
   class ComponentWrapper extends React.Component {
@@ -353,7 +377,7 @@ function createNativeWrapper(Component, config = {}) {
       ...Component.propTypes,
     };
 
-    static displayName = Component.displayName || "ComponentWrapper";
+    static displayName = Component.displayName || 'ComponentWrapper';
 
     _refHandler = node => {
       // bind native component's methods
@@ -383,7 +407,7 @@ function createNativeWrapper(Component, config = {}) {
       // filter out props that should be passed to gesture handler wrapper
       const gestureHandlerProps = Object.keys(this.props).reduce(
         (props, key) => {
-          if (key in NATIVE_WRAPPER_PROPS_FILTER) {
+          if (~NATIVE_WRAPPER_PROPS_FILTER.indexOf(key)) {
             props[key] = this.props[key];
           }
           return props;
@@ -588,7 +612,9 @@ const FlatListWithGHScroll = React.forwardRef((props, ref) => (
   <FlatList
     ref={ref}
     {...props}
-    renderScrollComponent={scrollProps => <WrappedScrollView {...scrollProps} />}
+    renderScrollComponent={scrollProps => (
+      <WrappedScrollView {...scrollProps} />
+    )}
   />
 ));
 

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -407,7 +407,7 @@ function createNativeWrapper(Component, config = {}) {
       // filter out props that should be passed to gesture handler wrapper
       const gestureHandlerProps = Object.keys(this.props).reduce(
         (props, key) => {
-          if (~NATIVE_WRAPPER_PROPS_FILTER.indexOf(key)) {
+          if (NATIVE_WRAPPER_PROPS_FILTER.indexOf(key) !== -1) {
             props[key] = this.props[key];
           }
           return props;


### PR DESCRIPTION
I looked through the files and tried to replace what propType dependencies I could find with string literals. I also tried out the Example app with `babel-plugin-transform-react-remove-prop-types` and it seemed to me like it was working (also verified that the propTypes actually was removed by printing them to the console and making sure they were `undefined`).

However, if someone with more experience with the code base could take a gander at the changes and verify that it is working that would be great, I'd if I missed anything and it accidentally got merged. Since I have limited experience with all the components I might have missed some regressions but I hope not.

Thanks in advance 🙂

This should fix #548.