### PR TITLE
Don't cancel long press after activation on Android

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.java
@@ -57,12 +57,8 @@ public class LongPressGestureHandler extends GestureHandler<LongPressGestureHand
       float deltaX = event.getRawX() - mStartX;
       float deltaY = event.getRawY() - mStartY;
       float distSq = deltaX * deltaX + deltaY * deltaY;
-      if (distSq > mMaxDistSq) {
-        if (getState() == STATE_ACTIVE) {
-          cancel();
-        } else {
-          fail();
-        }
+      if (distSq > mMaxDistSq && getState() != STATE_ACTIVE) {
+        fail();
       }
     }
   }


### PR DESCRIPTION
Makes long presses more consistent with iOS, which doesn’t cancel the gesture due to maxDist if it’s already in the `ACTIVE` state. This is also more consistent with TapGestureHandler, whose docs specifically say that maxDist fails if the “handler hasn't yet activated”.