### PR TITLE
fix: warn only once on web

### DIFF
--- a/createHandler.web.js
+++ b/createHandler.web.js
@@ -181,6 +181,12 @@ export default function createHandler(handlerName, propTypes = {}) {
 
     static propTypes = propTypes;
 
+    componentDidMount() {
+      if (!handlers[handlerName]) {
+        console.warn(`${handlerName} is not yet supported on web.`);
+      }
+    }
+
     _refHandler = node => {
       this._viewNode = node;
     };
@@ -190,11 +196,7 @@ export default function createHandler(handlerName, propTypes = {}) {
     };
 
     render() {
-      let Handler = handlers[handlerName];
-      if (!Handler) {
-        console.warn(`${handlerName} is not yet supported on web.`);
-        Handler = UnimplementedGestureHandler;
-      }
+      const Handler = handlers[handlerName] || UnimplementedGestureHandler;
 
       return <Handler ref={this._refHandler} {...this.props} />;
     }


### PR DESCRIPTION
Currently, everytime the handler rerenders a warning is printed to the console. This PR reduces it to only once, i.e. when it's mounted.