### PR TITLE
Migrate Android Support Libraries To AndroidX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,10 @@ matrix:
       components:
       - tools
       - platform-tools
-      - build-tools-27.0.3
+      - build-tools-28.0.3
 
     install:
-    - yes | sdkmanager "platforms;android-26"
+    - yes | sdkmanager "platforms;android-28"
     - nvm install $NODE_VERSION
     - nvm use $NODE_VERSION
     - nvm alias default $NODE_VERSION

--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -126,13 +126,13 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation project(':@react-native-community_viewpager')
     implementation project(':@react-native-community_slider')
-    compile project(':react-native-vector-icons')
-    compile project(':react-native-gesture-handler')
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:24.0.0"
-    compile "com.facebook.react:react-native:+"  // From node_modules
+    implementation project(':react-native-vector-icons')
+    implementation project(':react-native-gesture-handler')
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 }
 
 // Run this once to be able to run the application with BUCK

--- a/Example/android/app/src/main/AndroidManifest.xml
+++ b/Example/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
 
     <uses-sdk
         android:minSdkVersion="16"
-        android:targetSdkVersion="22" />
+        android:targetSdkVersion="28" />
 
     <application
       android:name=".MainApplication"

--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
         minSdkVersion = 16
         compileSdkVersion = 28
         targetSdkVersion = 28
-        supportLibVersion = "1.0.2"
     }
     repositories {
         google()

--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -2,18 +2,18 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "27.0.3"
+        buildToolsVersion = "28.0.3"
         minSdkVersion = 16
         compileSdkVersion = 28
-        targetSdkVersion = 26
-        supportLibVersion = "27.1.1"
+        targetSdkVersion = 28
+        supportLibVersion = "1.0.2"
     }
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
@@ -31,6 +31,6 @@ allprojects {
 
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.4'
+    gradleVersion = '4.6'
     distributionUrl = distributionUrl.replace("bin", "all")
 }

--- a/Example/android/gradle.properties
+++ b/Example/android/gradle.properties
@@ -17,4 +17,5 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-android.useDeprecatedNdk=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/Example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/Example/package.json
+++ b/Example/package.json
@@ -10,8 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@react-native-community/slider": "git+https://git@github.com:aarongrider/react-native-slider",
-    "@react-native-community/viewpager": "git+https://git@github.com:aarongrider/react-native-viewpager",
+    "@react-native-community/slider": "github:aarongrider/react-native-slider",
+    "@react-native-community/viewpager": "github:aarongrider/react-native-viewpager",
     "fbjs": "^1.0.0",
     "hoist-non-react-statics": "^3.2.1",
     "invariant": "^2.2.4",

--- a/Example/package.json
+++ b/Example/package.json
@@ -10,8 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@react-native-community/slider": "^1.0.3",
-    "@react-native-community/viewpager": "^1.1.2",
+    "@react-native-community/slider": "git+ssh://git@github.com:aarongrider/react-native-slider",
+    "@react-native-community/viewpager": "git+ssh://git@github.com:aarongrider/react-native-viewpager",
     "fbjs": "^1.0.0",
     "hoist-non-react-statics": "^3.2.1",
     "invariant": "^2.2.4",

--- a/Example/package.json
+++ b/Example/package.json
@@ -10,8 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@react-native-community/slider": "git+ssh://git@github.com:aarongrider/react-native-slider",
-    "@react-native-community/viewpager": "git+ssh://git@github.com:aarongrider/react-native-viewpager",
+    "@react-native-community/slider": "git+https://git@github.com:aarongrider/react-native-slider",
+    "@react-native-community/viewpager": "git+https://git@github.com:aarongrider/react-native-viewpager",
     "fbjs": "^1.0.0",
     "hoist-non-react-statics": "^3.2.1",
     "invariant": "^2.2.4",

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -916,15 +916,13 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@react-native-community/slider@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-1.0.3.tgz#a49027519d56f4408356ebf04a7b226ce4001cda"
-  integrity sha512-IEg7AdayIAb9ZA8KMilTwINMNgSwhF5BXNqwvJ2XsRd+JF12/r5ho+t+GONu8m2rWcCehiiM/h4pds1B9FzMlQ==
+"@react-native-community/slider@git+ssh://git@github.com:aarongrider/react-native-slider":
+  version "1.0.4"
+  resolved "git+ssh://git@github.com:aarongrider/react-native-slider#dfbff1e54b8218e161e03761a796bc295a4da792"
 
-"@react-native-community/viewpager@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/viewpager/-/viewpager-1.1.2.tgz#cf044478efae6f129bbf6908a574220e723c7852"
-  integrity sha512-qXYqupJTo7q0RgRzVuJvG/Yv7E1CychMjOc+HL4A6KVW6pmsjiurNajIIjTmBydlgKahfbLNUA00UKD5yjvJ0A==
+"@react-native-community/viewpager@git+ssh://git@github.com:aarongrider/react-native-viewpager":
+  version "1.1.6"
+  resolved "git+ssh://git@github.com:aarongrider/react-native-viewpager#24f31ff76573e455d548ac0189a58ad0e85fdf67"
 
 "@react-navigation/core@3.0.2":
   version "3.0.2"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,16 +1,27 @@
-apply plugin: 'com.android.library'
+buildscript {
+  repositories {
+    google()
+    jcenter()
+  }
+
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.2.1'
+  }
+}
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+apply plugin: 'com.android.library'
+
 android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 25)
-    buildToolsVersion safeExtGet("buildToolsVersion", '25.0.2')
+    compileSdkVersion safeExtGet("compileSdkVersion", 28)
+    buildToolsVersion safeExtGet("buildToolsVersion", '28.0.3')
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 25)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
         ndk {
@@ -24,6 +35,12 @@ android {
     sourceSets {
         main.java.srcDirs += 'lib/src/main/java'
     }
+}
+
+repositories {
+    google()
+    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,4 +17,5 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-android.useDeprecatedNdk=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -1,16 +1,17 @@
 apply plugin: 'com.android.library'
 
 repositories {
-    maven { url 'http://repo1.maven.org/maven2' }
+    google()
+    jcenter()
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -23,6 +24,6 @@ android {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    testImplementation 'junit:junit:4.12'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
 }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 public class GestureHandlerOrchestrator {
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
@@ -7,7 +7,7 @@ import android.view.MotionEvent;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactRootView;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 public class RNGestureHandlerEnabledRootView extends ReactRootView {
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.java
@@ -1,6 +1,6 @@
 package com.swmansion.gesturehandler.react;
 
-import android.support.v4.util.Pools;
+import androidx.core.util.Pools;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
@@ -8,7 +8,7 @@ import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.swmansion.gesturehandler.GestureHandler;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 public class RNGestureHandlerEvent extends Event<RNGestureHandlerEvent> {
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -33,7 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import static com.swmansion.gesturehandler.GestureHandler.HIT_SLOP_NONE;
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerPackage.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerPackage.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 public class RNGestureHandlerPackage implements ReactPackage {
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.java
@@ -8,7 +8,7 @@ import com.swmansion.gesturehandler.GestureHandlerRegistry;
 
 import java.util.ArrayList;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 public class RNGestureHandlerRegistry implements GestureHandlerRegistry {
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootInterface.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootInterface.java
@@ -1,6 +1,6 @@
 package com.swmansion.gesturehandler.react;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 public interface RNGestureHandlerRootInterface {
   @Nullable RNGestureHandlerRootHelper getRootHelper();

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.java
@@ -7,7 +7,7 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.views.view.ReactViewGroup;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 public class RNGestureHandlerRootView extends ReactViewGroup {
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootViewManager.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootViewManager.java
@@ -7,7 +7,7 @@ import com.facebook.react.uimanager.ViewGroupManager;
 
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * React native's view manager used for creating instances of {@link }RNGestureHandlerRootView}. It

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.java
@@ -1,6 +1,6 @@
 package com.swmansion.gesturehandler.react;
 
-import android.support.v4.util.Pools;
+import androidx.core.util.Pools;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
@@ -8,7 +8,7 @@ import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.swmansion.gesturehandler.GestureHandler;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 public class RNGestureHandlerStateChangeEvent extends Event<RNGestureHandlerStateChangeEvent>{
 


### PR DESCRIPTION
This is a new PR following: https://github.com/kmagiera/react-native-gesture-handler/pull/579

Currently I am using 2 forked dependencies to get the Android tests to pass. We will probably want to wait till our dependencies take the AndroidX upgrade and install directly from npm before merging this branch.

https://github.com/react-native-community/react-native-slider/pull/56
https://github.com/react-native-community/react-native-viewpager/pull/22