### PR TITLE
Fix TouchableHighlight initial 'underlayColor' value

### DIFF
--- a/touchables/TouchableHighlight.js
+++ b/touchables/TouchableHighlight.js
@@ -27,9 +27,7 @@ export default class TouchableHighlight extends Component {
     super(props);
     this.state = {
       extraChildStyle: null,
-      extraUnderlayStyle: {
-        backgroundColor: props.underlayColor,
-      },
+      extraUnderlayStyle: null,
     };
   }
 


### PR DESCRIPTION
This PR fixes unexpected initial underlayColor using RNGH `TouchableHighlight`.