### PR TITLE
Restore dropping handler or unmounting

### DIFF
--- a/createHandler.js
+++ b/createHandler.js
@@ -183,11 +183,8 @@ export default function createHandler(
       RNGestureHandlerModule.updateGestureHandler(this._handlerTag, newConfig);
     };
 
-    _dropGestureHandler = () => {
-      RNGestureHandlerModule.dropGestureHandler(this._handlerTag);
-    };
-
     componentWillUnmount() {
+      RNGestureHandlerModule.dropGestureHandler(this._handlerTag);
       if (this._updateEnqueued) {
         clearImmediate(this._updateEnqueued);
       }


### PR DESCRIPTION
https://github.com/kmagiera/react-native-gesture-handler/pull/406/files#diff-88fa64c878efe14d137f130ddbe000a5R185 
From unknown reason, it has been changed here.

Probably it's just a mistake, but it was leading to memory leaks. 