### PR TITLE
Swipeable flow type errors fix

### DIFF
--- a/Swipeable.js
+++ b/Swipeable.js
@@ -25,7 +25,7 @@ export type PropType = {
   rightThreshold?: number,
   overshootLeft?: boolean,
   overshootRight?: boolean,
-  overshootFriction?: number,
+  overshootFriction: number,
   onSwipeableLeftOpen?: Function,
   onSwipeableRightOpen?: Function,
   onSwipeableOpen?: Function,


### PR DESCRIPTION
There are some flow type errors in Swipeable.js about overshootFriction:
```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/react-native-gesture-handler/Swipeable.js:124:45

Cannot perform arithmetic operation because undefined [1] is not a number.

 [1]  28│   overshootFriction?: number,
        :
     121│       })
     122│     ).interpolate({
     123│       inputRange: [
     124│         -rightWidth - (overshootRight ? 1 : overshootFriction),
     125│         -rightWidth,
     126│         leftWidth,
     127│         leftWidth + (overshootLeft ? 1 : overshootFriction),


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/react-native-gesture-handler/Swipeable.js:130:42

Cannot compare undefined [1] to number [2].

 [1]  28│   overshootFriction?: number,
        :
     127│         leftWidth + (overshootLeft ? 1 : overshootFriction),
     128│       ],
     129│       outputRange: [
 [2] 130│         -rightWidth - (overshootRight || overshootFriction > 1 ? 1 : 0),
     131│         -rightWidth,
     132│         leftWidth,
     133│         leftWidth + (overshootLeft || overshootFriction > 1 ? 1 : 0),

Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/react-native-gesture-handler/Swipeable.js:133:39

Cannot compare undefined [1] to number [2].

 [1]  28│   overshootFriction?: number,
        :
     130│         -rightWidth - (overshootRight || overshootFriction > 1 ? 1 : 0),
     131│         -rightWidth,
     132│         leftWidth,
 [2] 133│         leftWidth + (overshootLeft || overshootFriction > 1 ? 1 : 0),
     134│       ],
     135│     });
     136│     this._transX = transX;
```


So, we can make `overshootFriction` not nullable: https://flow.org/en/docs/react/components/#toc-using-default-props