### PR TITLE
Remove overlay 70% opacity to allow more flexibility

### DIFF
--- a/DrawerLayout.js
+++ b/DrawerLayout.js
@@ -78,7 +78,7 @@ export default class DrawerLayout extends Component<PropType, StateType> {
     drawerType: 'front',
     edgeWidth: 20,
     minSwipeDistance: 3,
-    overlayColor: 'black',
+    overlayColor: 'rgba(0, 0, 0, 0.7)',
     drawerLockMode: 'unlocked',
   };
 

--- a/DrawerLayout.js
+++ b/DrawerLayout.js
@@ -369,7 +369,7 @@ export default class DrawerLayout extends Component<PropType, StateType> {
     invariant(this._openValue, 'should be set');
     const overlayOpacity = this._openValue.interpolate({
       inputRange: [0, 1],
-      outputRange: [0, 0.7],
+      outputRange: [0, 1],
       extrapolate: 'clamp',
     });
     const dynamicOverlayStyles = {


### PR DESCRIPTION
## Purpose

Remove the forced 70% opacity overlay to allow more flexibility - for instance if you want 90% instead.

## Use

When declaring overlay background, you could feed it `rgba(255, 255, 255, 0.9)` to achieve a white overlay that is only slightly transparent.