### PR TITLE
Remove react/react-native peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,10 +67,6 @@
     "invariant": "^2.2.2",
     "prop-types": "^15.5.10"
   },
-  "peerDependencies": {
-    "react": ">= 16.3.2",
-    "react-native": ">= 0.58.2"
-  },
   "jest": {
     "preset": "jest-react-native"
   },


### PR DESCRIPTION
Same as https://github.com/kmagiera/react-native-reanimated/pull/298

Although we have kept them up to date pretty well, a `>=` matcher isn't exactly the most useful as a future version of either lib could easily break support. These sorts of warnings aren't the most useful in the ecosystem right now, perhaps when it stabilizes more.