### PR TITLE
Fix memoizeWrap when displayName is null

### DIFF
--- a/GestureComponents.js
+++ b/GestureComponents.js
@@ -3,17 +3,21 @@ import ReactNative from 'react-native';
 
 import createNativeWrapper from './createNativeWrapper';
 
-const MEMOIZED = {};
+const MEMOIZED = new WeakMap();
 
 function memoizeWrap(Component, config) {
-  const memoized = MEMOIZED[Component.displayName];
-  if (memoized) {
-    return memoized;
+  if (Component == null) {
+    return null;
   }
-  return (MEMOIZED[Component.displayName] = createNativeWrapper(
-    Component,
-    config
-  ));
+  let memoized = MEMOIZED.get(Component);
+  if (!memoized) {
+    memoized = createNativeWrapper(
+      Component,
+      config
+    );
+    MEMOIZED.set(Component, memoized);
+  }
+  return memoized;
 }
 
 module.exports = {


### PR DESCRIPTION
`Component.displayName` can be undefined for release builds which means a bunch of components will fight for the undefined key. In my app it results in the `Switch` component rendering nothing (or probably just another component like `ScrollView`).

To fix this I use the component class as the key in a `WeakMap` instead. I also added a null check since some components are being removed from RN core like ToolbarAndroid so it makes `memoizeWrap` safe in those cases.