### PR TITLE
Use UNSAFE_componentWillUpdate in Swipable.js

### DIFF
--- a/Swipeable.js
+++ b/Swipeable.js
@@ -88,7 +88,7 @@ export default class Swipeable extends Component<PropType, StateType> {
     );
   }
 
-  componentWillUpdate(props: PropType, state: StateType) {
+  UNSAFE_componentWillUpdate(props: PropType, state: StateType) {
     if (
       this.props.friction !== props.friction ||
       this.props.overshootLeft !== props.overshootLeft ||


### PR DESCRIPTION
To silence the react warning, ideally we'd migrate to new React apis.