### PR TITLE
Update android package name

### DIFF
--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -91,7 +91,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.swmansion.gesturehandler.react.example"
+        applicationId "com.swmansion.gesturehandler.example"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/Example/android/app/src/main/AndroidManifest.xml
+++ b/Example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.swmansion.gesturehandler.react.example"
+    package="com.swmansion.gesturehandler.example"
     android:versionCode="1"
     android:versionName="1.0">
 

--- a/Example/android/app/src/main/java/com/swmansion/gesturehandler/react/example/MainActivity.java
+++ b/Example/android/app/src/main/java/com/swmansion/gesturehandler/react/example/MainActivity.java
@@ -1,9 +1,9 @@
-package com.swmansion.gesturehandler.react.example;
+package com.swmansion.gesturehandler.example;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
-import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
+import com.swmansion.gesturehandler.RNGestureHandlerEnabledRootView;
 
 public class MainActivity extends ReactActivity {
 

--- a/Example/android/app/src/main/java/com/swmansion/gesturehandler/react/example/MainApplication.java
+++ b/Example/android/app/src/main/java/com/swmansion/gesturehandler/react/example/MainApplication.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react.example;
+package com.swmansion.gesturehandler.example;
 
 import android.app.Application;
 
@@ -10,7 +10,7 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
-import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
+import com.swmansion.gesturehandler.RNGestureHandlerPackage;
 
 import java.util.Arrays;
 import java.util.List;

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,12 +5,12 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 25)
-    buildToolsVersion safeExtGet("buildToolsVersion", '25.0.2')
+    compileSdkVersion safeExtGet("compileSdkVersion", 28)
+    buildToolsVersion safeExtGet("buildToolsVersion", '28.0.2')
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 25)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
         ndk {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,4 +17,6 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-android.useDeprecatedNdk=true
+# android.useDeprecatedNdk=true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.swmansion.gesturehandler.react">
+    package="com.swmansion.gesturehandler">
 </manifest>

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import android.annotation.TargetApi;
 import android.content.Context;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import android.content.Context;
 import android.os.Bundle;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.java
@@ -1,6 +1,6 @@
 package com.swmansion.gesturehandler.react;
 
-import android.support.v4.util.Pools;
+import androidx.core.util.Pools;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import androidx.core.util.Pools;
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEventDataExtractor.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEventDataExtractor.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import com.facebook.react.bridge.WritableMap;
 import com.swmansion.gesturehandler.GestureHandler;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import android.util.SparseArray;
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import android.content.Context;
 import android.view.MotionEvent;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerPackage.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerPackage.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import android.util.SparseArray;
 import android.view.View;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import android.os.SystemClock;
 import android.util.Log;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootInterface.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootInterface.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import javax.annotation.Nullable;
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import android.content.Context;
 import android.view.MotionEvent;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootViewManager.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootViewManager.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.java
@@ -1,6 +1,6 @@
 package com.swmansion.gesturehandler.react;
 
-import android.support.v4.util.Pools;
+import androidx.core.util.Pools;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import androidx.core.util.Pools;
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNViewConfigurationHelper.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNViewConfigurationHelper.java
@@ -1,4 +1,4 @@
-package com.swmansion.gesturehandler.react;
+package com.swmansion.gesturehandler;
 
 import android.os.Build;
 import android.view.View;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,12 +54,12 @@ If you use one of the *native navigation libraries* (e.g. [wix/react-native-navi
 
 Update your `MainActivity.java` file (or wherever you create an instance of `ReactActivityDelegate`), so that it overrides the method responsible for creating `ReactRootView` instance and then use the root view wrapper provided by this library. Do not forget to import `ReactActivityDelegate`, `ReactRootView`, and `RNGestureHandlerEnabledRootView`:
 ```diff
-package com.swmansion.gesturehandler.react.example;
+package com.swmansion.gesturehandler.example;
 
 import com.facebook.react.ReactActivity;
 + import com.facebook.react.ReactActivityDelegate;
 + import com.facebook.react.ReactRootView;
-+ import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
++ import com.swmansion.gesturehandler.RNGestureHandlerEnabledRootView;
 
 public class MainActivity extends ReactActivity {
 

--- a/e2e/android/app/BUCK
+++ b/e2e/android/app/BUCK
@@ -35,12 +35,12 @@ android_library(
 
 android_build_config(
     name = "build_config",
-    package = "com.swmansion.gesturehandler.react.example",
+    package = "com.swmansion.gesturehandler.example",
 )
 
 android_resource(
     name = "res",
-    package = "com.swmansion.gesturehandler.react.example",
+    package = "com.swmansion.gesturehandler.example",
     res = "src/main/res",
 )
 

--- a/e2e/android/app/build.gradle
+++ b/e2e/android/app/build.gradle
@@ -102,7 +102,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.swmansion.gesturehandler.react.example"
+        applicationId "com.swmansion.gesturehandler.example"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/e2e/android/app/src/main/AndroidManifest.xml
+++ b/e2e/android/app/src/main/AndroidManifest.xml
@@ -1,17 +1,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.swmansion.gesturehandler.react.example">
+  package="com.swmansion.gesturehandler.example">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-      android:name="com.swmansion.gesturehandler.react.example.MainApplication"
+      android:name="com.swmansion.gesturehandler.example.MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme">
       <activity
-        android:name="com.swmansion.gesturehandler.react.example.MainActivity"
+        android:name="com.swmansion.gesturehandler.example.MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:windowSoftInputMode="adjustResize">

--- a/e2e/android/app/src/main/java/com/swmansion/gesturehandler/react/example/MainActivity.java
+++ b/e2e/android/app/src/main/java/com/swmansion/gesturehandler/react/example/MainActivity.java
@@ -1,9 +1,9 @@
-package com.swmansion.gesturehandler.react.example;
+package com.swmansion.gesturehandler.example;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
-import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
+import com.swmansion.gesturehandler.RNGestureHandlerEnabledRootView;
 
 public class MainActivity extends ReactActivity {
 

--- a/e2e/android/app/src/main/java/com/swmansion/gesturehandler/react/example/MainApplication.java
+++ b/e2e/android/app/src/main/java/com/swmansion/gesturehandler/react/example/MainApplication.java
@@ -1,14 +1,14 @@
-package com.swmansion.gesturehandler.react.example;
+package com.swmansion.gesturehandler.example;
 
 import android.app.Application;
 
-import com.swmansion.gesturehandler.react.example.BuildConfig;
+import com.swmansion.gesturehandler.example.BuildConfig;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
-import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
+import com.swmansion.gesturehandler.RNGestureHandlerPackage;
 
 import java.util.Arrays;
 import java.util.List;

--- a/e2e/ios/ExampleE2E.xcodeproj/project.pbxproj
+++ b/e2e/ios/ExampleE2E.xcodeproj/project.pbxproj
@@ -1018,7 +1018,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.gesturehandler.react.example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.gesturehandler.example;
 				PRODUCT_NAME = ExampleE2E;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -1036,7 +1036,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.gesturehandler.react.example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.gesturehandler.example;
 				PRODUCT_NAME = ExampleE2E;
 				VERSIONING_SYSTEM = "apple-generic";
 			};


### PR DESCRIPTION
This `PR` is improvement from #650.

In `React Native 0.60`, `packageList` is generated automatically during build and it fails to generate `in-depth` package name. See below example.
```
> Task :app:compileReleaseJavaWithJavac FAILED
/home/circleci/dooboo/android/app/build/generated/rncli/src/main/java/com/facebook/react/PackageList.java:16: error: cannot find symbol
import com.swmansion.gesturehandler.RNGestureHandlerPackage;;
                                   ^
  symbol:   class RNGestureHandlerPackage
  location: package com.swmansion.gesturehandler
/home/circleci/dooboo/android/app/build/generated/rncli/src/main/java/com/facebook/react/PackageList.java:45: error: cannot find symbol
      new RNGestureHandlerPackage(),new ReactNativeLocalizationPackage()
          ^
  symbol:   class RNGestureHandlerPackage
  location: class PackageList
...
```

We can manage to change `import com.swmansion.gesturehandler.RNGestureHandlerPackage;` to `import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;` in `PackageList.java` locally to pass the build which is not recommended.

However, the problem is when you are using `ci`. Even if you can build it without error, `ci` will also generate error and build won't pass.

If package manager doesn't want `package` name to be changed, it's ok. However, I am using this `PR` for my build and hope it can also help others.
