### PR TITLE
Don't call deprecated `[RCTRootView cancelTouches]`

### DIFF
--- a/ios/RNGestureHandlerManager.m
+++ b/ios/RNGestureHandlerManager.m
@@ -144,23 +144,7 @@
 - (void)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
     didActivateInRootView:(UIView *)rootContentView
 {
-    // Cancel touches in RN's root view in order to cancel all in-js recognizers
 
-    // As scroll events are special-cased in RN responder implementation and sending them would
-    // trigger JS responder change, we don't cancel touches if the handler that got activated is
-    // a scroll recognizer. This way root view will keep sending touchMove and touchEnd events
-    // and therefore allow JS responder to properly release the responder at the end of the touch
-    // stream.
-    // NOTE: this is not a proper fix and solving this problem requires upstream fixes to RN. In
-    // particular if we have one PanHandler and ScrollView that can work simultaniously then when
-    // the Pan handler activates it would still tigger cancel events.
-    // Once the upstream fix lands the line below along with this comment can be removed
-    if ([gestureRecognizer.view isKindOfClass:[UIScrollView class]]) return;
-
-    UIView *parent = rootContentView.superview;
-    if ([parent isKindOfClass:[RCTRootView class]]) {
-        [(RCTRootView*)parent cancelTouches];
-    }
 }
 
 - (void)dealloc


### PR DESCRIPTION
According to the message in the commit it should not be needed anymore https://github.com/facebook/react-native/commit/36307d87e1974aff1abac598da2fd11c4e8e23c1. Not sure if we have a good test case for this to make sure it doesn't break but I've used it in my app for a while and everything seems fine (although I don't really mix RN and RNGH gesture components).

I kept `didActivateInRootView` empty since it is needed by the protocol but it might be possible to remove it from the protocol also.