### PR TITLE
Remove Math.sign polyfill

### DIFF
--- a/Swipeable.js
+++ b/Swipeable.js
@@ -11,13 +11,6 @@ import { PanGestureHandler, TapGestureHandler, State } from './GestureHandler';
 
 const DRAG_TOSS = 0.05;
 
-// Math.sign polyfill for iOS 8.x
-if (!Math.sign) {
-  Math.sign = function(x) {
-    return Number(x > 0) - Number(x < 0) || +x;
-  };
-}
-
 export type PropType = {
   children: any,
   friction: number,


### PR DESCRIPTION
RN only supports iOS 9+ now so we can remove this according to the comment.