### PR TITLE
Disable the background accessibility when the drawer opens and overlaps (Android)

### DIFF
--- a/DrawerLayout.js
+++ b/DrawerLayout.js
@@ -450,7 +450,8 @@ export default class DrawerLayout extends Component<PropType, StateType> {
               : styles.containerInFront,
             containerStyles,
             contentContainerStyle,
-          ]}>
+          ]}
+          importantForAccessibility={this._drawerShown ? "no-hide-descendants" : "yes"}>
           {typeof this.props.children === 'function'
             ? this.props.children(this._openValue)
             : this.props.children}


### PR DESCRIPTION
Previously, the screen / components behind the drawer are still focusable because we didn't add the "importantForAccessibility" (only Android) to disable the accessibility service depending if the drawer opens 