### PR TITLE
[Typescript] Adds rippleColor to RectButtonProperties

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -362,6 +362,7 @@ declare module 'react-native-gesture-handler' {
     onPress?: (pointerInside: boolean) => void;
     onActiveStateChange?: (active: boolean) => void;
     style?: StyleProp<ViewStyle>;
+    rippleColor?: string;
   }
 
   export interface RectButtonProperties extends BaseButtonProperties {


### PR DESCRIPTION
This fixes the following TS error:

```
Type '{ children: Element; style: any; underlayColor: string; rippleColor: string; onPress: () => void; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RectButton> & Readonly<{ children?: ReactNode; }> & Readonly<RectButtonProperties>'.
  Property 'rippleColor' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RectButton> & Readonly<{ children?: ReactNode; }> & Readonly<RectButtonProperties>'.ts(2322)
```