### PR TITLE
feat: add RNGestureHandlerEnabledRootView constructor with attrs

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
@@ -2,6 +2,7 @@ package com.swmansion.gesturehandler.react;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.util.AttributeSet;
 import android.view.MotionEvent;
 
 import com.facebook.react.ReactInstanceManager;
@@ -16,6 +17,10 @@ public class RNGestureHandlerEnabledRootView extends ReactRootView {
 
   public RNGestureHandlerEnabledRootView(Context context) {
     super(context);
+  }
+
+  public RNGestureHandlerEnabledRootView(Context context, AttributeSet attrs) {
+    super(context, attrs);
   }
 
   @Override


### PR DESCRIPTION
In this way, we can use a gesture handler view as part of an xml layout like follows (for example):

```xml
<?xml version="1.0" encoding="utf-8"?>
<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
    android:orientation="vertical" 
    android:layout_width="match_parent"
    android:layout_height="match_parent">

    <com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView
        android:id="@+id/your_react_root_view_id"
        android:layout_width="match_parent"
        android:layout_height="match_parent"/>
</LinearLayout>
```