### PR TITLE
fix: replaced expo demo app hyperlink

### DIFF
--- a/docs/component-drawer-layout.md
+++ b/docs/component-drawer-layout.md
@@ -55,7 +55,7 @@ function. This attribute is present in the standard implementation already and i
 component or function. Children is a component which is rendered by default and is wrapped by drawer. However, it could be also a render function which takes an Animated value as a parameter that indicates the progress of drawer opening/closing animation (progress value is 0 when closed and 1 when opened) is the same way like `renderNavigationView` prop.
 
 ## Example:
-See the [drawer example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/horizontalDrawer/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
+See the [drawer example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/horizontalDrawer/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
 ```js
 class Drawerable extends Component {
   renderDrawer = () => {

--- a/docs/component-swipeable.md
+++ b/docs/component-swipeable.md
@@ -107,7 +107,7 @@ method that opens component on right side.
 
 ### Example:
 
-See the [swipeable example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/swipeable/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
+See the [swipeable example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/swipeable/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
 ```js
 class AppleStyleSwipeableRow extends Component {
   renderLeftActions = (progress, dragX) => {

--- a/docs/example.md
+++ b/docs/example.md
@@ -12,7 +12,7 @@ Each example is located under a separate folder under [`Example/`](https://githu
 
 ## Running example app on Expo
 
-You can run example app on [Expo](https://expo.io). Follow instructions under [this link](https://exp.host/@osdnk/gesturehandlerexample) to do so. Note that the app published to Expo is not the most up to date version. We publish updates whenever new version of Expo SDK is released. If you wish to try the most up to date version you will have to run example app locally. For that see below 👇
+You can run example app on [Expo](https://expo.io). Follow instructions under [this link](https://expo.io/@sauzy3450/react-native-gesture-handler-demo) to do so. Note that the app published to Expo is not the most up to date version. We publish updates whenever new version of Expo SDK is released. If you wish to try the most up to date version you will have to run example app locally. For that see below 👇
 
 ## Running example app locally
 

--- a/docs/handler-fling.md
+++ b/docs/handler-fling.md
@@ -57,7 +57,7 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ## Example
 
-See the [fling  example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/fling/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
+See the [fling  example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/fling/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
 
 ```js
 const LongPressButton = () => (

--- a/docs/handler-force.md
+++ b/docs/handler-force.md
@@ -46,7 +46,7 @@ You may check if it's possible to use `ForceTouchGestureHandler` with `ForceTouc
 
 ## Example
 
-See the [force touch handler example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/forcetouch/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
+See the [force touch handler example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/forcetouch/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
 
 ```js
 <ForceTouchGestureHandler

--- a/docs/handler-longpress.md
+++ b/docs/handler-longpress.md
@@ -50,7 +50,7 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ## Example
 
-See the [multitap example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/multitap/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
+See the [multitap example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/multitap/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
 
 ```js
 const LongPressButton = () => (

--- a/docs/handler-pan.md
+++ b/docs/handler-pan.md
@@ -174,7 +174,7 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ## Example
 
-See the [draggable example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/draggable/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
+See the [draggable example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/draggable/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
 
 ```js
 const circleRadius = 30;

--- a/docs/handler-pinch.md
+++ b/docs/handler-pinch.md
@@ -40,7 +40,7 @@ Position expressed in points along Y axis of center anchor point of gesture
 
 ## Example
 
-See the [scale and rotation example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/scaleAndRotate/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
+See the [scale and rotation example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/scaleAndRotate/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
 
 ```js
 export class PinchableBox extends React.Component {

--- a/docs/handler-rotation.md
+++ b/docs/handler-rotation.md
@@ -36,7 +36,7 @@ Position expressed in points along Y axis of center anchor point of gesture
 
 ## Example
 
-See the [scale and rotation example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/scaleAndRotate/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
+See the [scale and rotation example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/scaleAndRotate/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
 
 ```js
 class RotableBox extends React.Component {

--- a/docs/handler-tap.md
+++ b/docs/handler-tap.md
@@ -76,7 +76,7 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ## Example
 
-See the [multitap example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/multitap/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
+See the [multitap example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/multitap/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
 
 ```js
 export class PressBox extends Component {

--- a/docs/interactions.md
+++ b/docs/interactions.md
@@ -29,7 +29,7 @@ In this case we would use a [`PinchGestureHandler`](handler-pinch.md), [`Rotatio
 ---
 ### Example
 
-See the ["Scale, rotate & tilt" example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/scaleAndRotate/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
+See the ["Scale, rotate & tilt" example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/scaleAndRotate/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
 
 ```js
 class PinchableBox extends React.Component {
@@ -74,7 +74,7 @@ Otherwise if we try to perform a double tap the single tap handler will fire jus
 ---
 ### Example
 
-See the ["Multitap" example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/multitap/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
+See the ["Multitap" example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/multitap/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
 
 ```js
 const doubleTap = React.createRef();

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -7,7 +7,7 @@ title: Learning Resources
 
 [Gesture Handler Example App](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example) – official gesture handler "showcase" app.
 
-[Gesture Handler Example on Expo](https://exp.host/@osdnk/gesturehandlerexample) – the official app you can install and play with using [Expo](https://expo.io).
+[Gesture Handler Example on Expo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo) – the official app you can install and play with using [Expo](https://expo.io).
 
 ## Talks and workshops
 

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -82,7 +82,7 @@ class HomeSplash extends React.Component {
             <Button href={docUrl('getting-started.html', language)}>
               Read the docs
             </Button>
-            <Button href="https://exp.host/@osdnk/gesturehandlerexample">
+            <Button href="https://expo.io/@sauzy3450/react-native-gesture-handler-demo">
               Try demo app on Expo
             </Button>
           </PromoSection>
@@ -142,7 +142,7 @@ const TryOut = props => (
   <Block id="try">
     {[
       {
-        content: `Check out the [documentation](docs/getting-started.html) and learn how to quickly get up and running with Gesture Handler. Take a look at our API guides to get familiarize with the API. \n\n Try our showcase app or [get it here using Expo](https://exp.host/@osdnk/gesturehandlerexample). Or just [go to this page](docs/example.html) to see how you can run it locally with React Native on both Android and iOS.`,
+        content: `Check out the [documentation](docs/getting-started.html) and learn how to quickly get up and running with Gesture Handler. Take a look at our API guides to get familiarize with the API. \n\n Try our showcase app or [get it here using Expo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo). Or just [go to this page](docs/example.html) to see how you can run it locally with React Native on both Android and iOS.`,
         image: imgUrl('sampleswipeable.gif'),
         imageAlign: 'left',
         title: 'Try it Out',


### PR DESCRIPTION
The current hyperlink is outdated (using Expo 27.x). 