### PR TITLE
Add imports to example

### DIFF
--- a/docs/component-swipeable.md
+++ b/docs/component-swipeable.md
@@ -107,8 +107,13 @@ method that opens component on right side.
 
 ### Example:
 
-See the [swipeable example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/swipeable/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample).
+See the [swipeable example](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/swipeable/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://exp.host/@osdnk/gesturehandlerexample). Swipeable works only with the built in Animated library.
 ```js
+import React, { Component } from "react";
+import { Animated, StyleSheet, View } from "react-native";
+import { RectButton } from "react-native-gesture-handler";
+import Swipeable from "react-native-gesture-handler/Swipeable";
+
 class AppleStyleSwipeableRow extends Component {
   renderLeftActions = (progress, dragX) => {
     const trans = dragX.interpolate({


### PR DESCRIPTION
This makes it clear to use the animated rather than reanimated library in swipeable