### PR TITLE
Update instructions for getting started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,9 +18,15 @@ In a nutshell, the library provides:
 
 ## Installation
 
-Since the library uses native support for handling gestures, it requires an extended installation to the norm.
+### Managed [Expo](https://expo.io)
 
-### With [React Native](http://facebook.github.io/react-native/) app (no Expo)
+To use the version of react-native-gesture-handler that is compatible with your managed Expo project, run `expo install react-native-gesture-handler`.
+
+The Expo SDK incorporates the latest version of react-native-gesture-handler available at the time of each SDK release, so managed Expo apps might not always support all our latest features as soon as they are available.
+
+### Bare [React Native](http://facebook.github.io/react-native/)
+
+Since the library uses native support for handling gestures, it requires an extended installation to the norm. If you are starting a new project, you may want to initialize it with [expo-cli](https://docs.expo.io/versions/latest/workflow/expo-cli/) and use a bare template, they come pre-installed with react-native-gesture-handler.
 
 #### Requirements
 
@@ -111,10 +117,6 @@ cd ios && pod install
 ---
 
 Now you're all set. Run your app with `react-native run-android` or `react-native run-ios`.
-
-### With [Expo](https://expo.io)
-
-Gesture Handler is already part of Expo and there is no extra configuration required. However, consider that the Expo SDK team may take some time to include the newest version of the library - so Expo might not always support all our latest features as soon as they are out.
 
 ### With [wix/react-native-navigation](https://github.com/wix/react-native-navigation)
 


### PR DESCRIPTION
- Users need to run `expo install` now.
- Can initialize a bare React Native project with RNGH using expo-cli