### PR TITLE
Updated drawer container style type

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -532,7 +532,7 @@ declare module 'react-native-gesture-handler/DrawerLayout' {
     hideStatusBar?: boolean;
     statusBarAnimation?: StatusBarAnimation;
     overlayColor?: string;
-    containerStyle?: StyleProp<ViewStyle>;
+    contentContainerStyle?: StyleProp<ViewStyle>;
   }
 
   interface DrawerMovementOptionType {


### PR DESCRIPTION
Drawer container style typings to not match code [here](https://github.com/kmagiera/react-native-gesture-handler/blob/master/DrawerLayout.js#L51). Since TS Ignore cannot be used within JSX thought I would fix.