### PR TITLE
Added mocks for pan and scroll gesture components

### DIFF
--- a/__mocks__/RNGestureHandlerModule.js
+++ b/__mocks__/RNGestureHandlerModule.js
@@ -1,4 +1,8 @@
+import { View } from 'react-native'
+
 export default {
+  ScrollVew: View,
+  PanGestureHandler: View,
   attachGestureHandler: () => {},
   createGestureHandler: () => {},
   dropGestureHandler: () => {},

--- a/__mocks__/RNGestureHandlerModule.js
+++ b/__mocks__/RNGestureHandlerModule.js
@@ -1,7 +1,7 @@
-import { View } from 'react-native'
+import { View, ScrollView } from 'react-native'
 
 export default {
-  ScrollVew: View,
+  ScrollView,
   PanGestureHandler: View,
   attachGestureHandler: () => {},
   createGestureHandler: () => {},


### PR DESCRIPTION
Basically `react-native-tab-view` uses this components and without them testing is not possible