### PR TITLE
Stop calling cancelTouches

### DIFF
--- a/ios/RNGestureHandlerManager.m
+++ b/ios/RNGestureHandlerManager.m
@@ -159,7 +159,9 @@
 
     UIView *parent = rootContentView.superview;
     if ([parent isKindOfClass:[RCTRootView class]]) {
-        [(RCTRootView*)parent cancelTouches];
+      // Previously we were using cancelTouches method from RCTRootView.
+      // Now it's deprecated and we call cancel directly on touchHandler of contentView
+      [(RCTTouchHandler *)[[parent valueForKey:@"contentView"] valueForKey:@"touchHandler"] cancel];
     }
 }
 


### PR DESCRIPTION
`cancelTouches` beneath only calls  `cancel` of `touchHandler` of `contentView`. I just call it directly keeping the same logic.