### PR TITLE
Exports interceptTouchOutside property

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.java
@@ -12,6 +12,7 @@ import androidx.annotation.Nullable;
 public class RNGestureHandlerRootView extends ReactViewGroup {
 
   private @Nullable RNGestureHandlerRootHelper mRootHelper;
+  private Boolean interceptTouchOutside = false;
 
   public RNGestureHandlerRootView(Context context) {
     super(context);
@@ -23,6 +24,15 @@ public class RNGestureHandlerRootView extends ReactViewGroup {
     if (mRootHelper == null) {
       mRootHelper = new RNGestureHandlerRootHelper((ReactContext) getContext(), this);
     }
+  }
+
+  @Override
+  public boolean onTouchEvent(MotionEvent ev) {
+    return interceptTouchOutside;
+  }
+
+  public void setInterceptTouchOutside(Boolean interceptTouchOutside) {
+    this.interceptTouchOutside = interceptTouchOutside;
   }
 
   public void tearDown() {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootViewManager.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootViewManager.java
@@ -4,6 +4,7 @@ import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
 
 import java.util.Map;
 
@@ -32,6 +33,11 @@ public class RNGestureHandlerRootViewManager extends ViewGroupManager<RNGestureH
   @Override
   public void onDropViewInstance(RNGestureHandlerRootView view) {
     view.tearDown();
+  }
+
+  @ReactProp(name = "interceptTouchOutside", defaultBoolean = false)
+  public void setInterceptTouchOutside(RNGestureHandlerRootView view, @Nullable Boolean interceptTouchOutside) {
+    view.setInterceptTouchOutside(interceptTouchOutside);
   }
 
   /**

--- a/gestureHandlerRootHOC.android.js
+++ b/gestureHandlerRootHOC.android.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from "prop-types";
 import {
   requireNativeComponent,
   StyleSheet,
@@ -9,6 +10,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 const iface = {
   name: 'GestureHandlerRootView',
   propTypes: {
+    interceptTouchOutside: PropTypes.bool,
     ...ViewPropTypes,
   },
 };
@@ -20,12 +22,18 @@ const GestureHandlerRootView = requireNativeComponent(
 
 export default function gestureHandlerRootHOC(
   Component,
-  containerStyles = undefined
+  {
+    containerStyles = undefined,
+    interceptTouchOutside = false
+  }
 ) {
   class Wrapper extends React.Component {
     render() {
       return (
-        <GestureHandlerRootView style={[styles.container, containerStyles]}>
+        <GestureHandlerRootView
+          style={[styles.container, containerStyles]}
+          interceptTouchOutside={interceptTouchOutside}
+        >
           <Component {...this.props} />
         </GestureHandlerRootView>
       );

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -449,7 +449,10 @@ declare module 'react-native-gesture-handler' {
 
   export function gestureHandlerRootHOC(
     Component: React.ComponentType<any>,
-    containerStyles?: StyleProp<ViewStyle>
+    config: {
+      containerStyles?: StyleProp<ViewStyle>,
+      interceptTouchOutside?: boolean
+    }
   ): React.ComponentType<any>;
 
   export function createNativeWrapper(


### PR DESCRIPTION
fix react-native-navigation overlays intercept all touch events when wrapped with gestureHandlerRootHOC #514