### PR TITLE
Fix #320: Unsupported event crash.

### DIFF
--- a/createHandler.js
+++ b/createHandler.js
@@ -31,12 +31,20 @@ UIManager.genericDirectEventTypes = {
   ...UIManager.genericDirectEventTypes,
   ...customGHEventsConfig,
 };
+// In newer versions of RN the `genericDirectEventTypes` is located in the object
+// returned by UIManager.getConstants(), we need to add it there as well to make
+// it compatible with RN 61+
+if (UIManager.getConstants) {
+  UIManager.getConstants().genericDirectEventTypes = {
+    ...UIManager.getConstants().genericDirectEventTypes,
+    ...customGHEventsConfig,
+  };
+}
 
 // Wrap JS responder calls and notify gesture handler manager
 const {
   setJSResponder: oldSetJSResponder = () => {},
   clearJSResponder: oldClearJSResponder = () => {},
-  getConstants: oldGetConstants = () => ({}),
 } = UIManager;
 UIManager.setJSResponder = (tag, blockNativeResponder) => {
   RNGestureHandlerModule.handleSetJSResponder(tag, blockNativeResponder);
@@ -45,18 +53,6 @@ UIManager.setJSResponder = (tag, blockNativeResponder) => {
 UIManager.clearJSResponder = () => {
   RNGestureHandlerModule.handleClearJSResponder();
   oldClearJSResponder();
-};
-// We also add GH specific events to the constants object returned by
-// UIManager.getConstants to make it work with the newest version of RN
-UIManager.getConstants = () => {
-  const constants = oldGetConstants();
-  return {
-    ...constants,
-    genericDirectEventTypes: {
-      ...constants.genericDirectEventTypes,
-      ...customGHEventsConfig,
-    },
-  };
 };
 
 let handlerTag = 1;


### PR DESCRIPTION
After recent changes in RN core we started seeing the well known "Unsupported event" crash.

The crash is due to the fact that gesture handler requires for all view types to accept geature-handler events, namely, onGestureHandlerEvent and onGestureHandlerStateChange. This is necessary for us to be able to deliver those events to RN Views and other components that need to respond to gestures. As RN core does not expose a method that'd allow us to register custom events for RCTView, we've been relying on a few workarounds that unfortunately only worked on some version of RN. The latest workaround was to override `genericDirectEventTypes` object from `UIManager` configuration. This object is then used during view registration to populate event config maps. We've been extending `UIManager.genericDirectEventTypes` at first until it got moved to `UImanager.getConstants().genericDirectEventTypes` -- after that change we started overriding `getConstants` method to return the extended object. For a reason I haven't had time to figure out this stopped working in RN 62 and the current workaround is to just extend the object returned from `getConstants()` relying on the assumption that this method always returns a reference to the same method.

As it was the case for the previous workaround this one still requires that we load gesture-handler module before *any* view registration is done. Once the views are registered it is no longer possible to update their event maps for their view configuration.

It is important to note that the crash has been happening on iOS in release mode only. It does not occur in other configuration as of this monkey patch that adds static JS configuration https://github.com/facebook/react-native/commit/942de5718236ddbd1a112a2ce7adf20591949672. However this patch does not work in release mode due to the fact that the static JS config is only loaded via `registerGeneratedViewConfig` method which is only used in __DEV__ mode, while `requireNativeComponent` is used in release – see the relevant commit: https://github.com/facebook/react-native/commit/42cf8a92416a49584e8eedda798c371eb83ec932