### PR TITLE
Add option to style touchable container

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -403,21 +403,25 @@ declare module 'react-native-gesture-handler' {
     BorderlessButtonProperties
   > {}
 
+  export interface ContainedTouchableProperties {
+    containerStyle?: StyleProp<ViewStyle>
+  }
+
   export class TouchableHighlight extends React.Component<
-    TouchableHighlightProperties
-  > {}
+    TouchableHighlightProperties | ContainedTouchableProperties
+    > {}
 
   export class TouchableNativeFeedback extends React.Component<
-    TouchableNativeFeedbackProperties
-  > {}
+    TouchableNativeFeedbackProperties | ContainedTouchableProperties
+    > {}
 
   export class TouchableOpacity extends React.Component<
-    TouchableOpacityProperties
-  > {}
+    TouchableOpacityProperties | ContainedTouchableProperties
+    > {}
 
   export class TouchableWithoutFeedback extends React.Component<
-    TouchableWithoutFeedbackProperties
-  > {}
+    TouchableWithoutFeedbackProperties | ContainedTouchableProperties
+    > {}
 
   /* GESTURE HANDLER WRAPPED CLASSES */
 

--- a/touchables/GenericTouchable.js
+++ b/touchables/GenericTouchable.js
@@ -256,6 +256,7 @@ export default class GenericTouchable extends Component {
 
     return (
       <BaseButton
+        style={this.props.containerStyle}
         onHandlerStateChange={
           this.props.disabled ? null : this.onHandlerStateChange
         }


### PR DESCRIPTION
RNGH Touchable components usually have a child view that is wrapped with BaseButton. Styles supplied to the Touchables are applied directly to the child view and in some circumstances a need arises to be able to style the container as well as the child. In my specific use case I'm running into the same issue as #607. That issue proposes removing the child view entirely which is probably preferable however this patch enables a fairly simple workaround by allowing additional styling on the container.

Regarding the type information, I wasn't aware of a way to only have this apply when the view is actually being wrapped, however I believe that the additional styling will just be ignored in those cases so I don't see any issues with this.