### PR TITLE
fix: allow to override gesture handler props in Swipable

### DIFF
--- a/Swipeable.js
+++ b/Swipeable.js
@@ -311,8 +311,8 @@ export default class Swipeable extends Component<PropType, StateType> {
 
     return (
       <PanGestureHandler
+        activeOffsetX={[-10, 10]}
         {...this.props}
-        minDeltaX={10}
         onGestureEvent={this._onGestureEvent}
         onHandlerStateChange={this._onHandlerStateChange}>
         <Animated.View

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -464,8 +464,8 @@ declare module 'react-native-gesture-handler' {
 
 declare module 'react-native-gesture-handler/Swipeable' {
   import { Animated, StyleProp, ViewStyle } from 'react-native';
-
-  interface SwipeableProperties {
+  import { PanGestureHandlerProperties } from 'react-native-gesture-handler'
+  interface SwipeableProperties extends Omit<PanGestureHandlerProperties, 'onGestureEvent' | 'onHandlerStateChange'> {
     friction?: number;
     leftThreshold?: number;
     rightThreshold?: number;


### PR DESCRIPTION
Hi, I was playing a bit with the Swipeable component. I tried to put it inside `react-native-tab-view`.
I had a common case, where there is a list of swipable elements  on one of the tabs. I turned out I cannot swipe tab view because of the underlying `<PanGestureHandler/>`. 

In my case overriding `minDeltaX` or `activeOffsetX` on `<PanGestureHandler/>` fixes the issue due to a specific placement of swipeable elements on the last tab on the right. I had to patch a package to be able to override `minDeltaX` since props have been spread in first line of the file. 

I decided to open a PR with that fix.
It replaces legacy `minDeltaX` with `activeOffsetX`, spread props below `activeOffsetX` and also improve TypeScript types for this component, so now it inherits props from `<PanGestureHandler/>`.
