### PR TITLE
Adding accessibilityLabel to NativeViewGestureHandlerProperties

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -372,6 +372,7 @@ declare module 'react-native-gesture-handler' {
     extends NativeViewGestureHandlerProperties {
     exclusive?: boolean;
     testID?: string;
+    accessibilityLabel?: string;
   }
 
   export interface BaseButtonProperties extends RawButtonProperties {


### PR DESCRIPTION
Adding "accessibilityLabel" to buttons so that so they can be picked up by test automation frameworks such as WebdriverIO and Appium. More specifically, updating the RawButtonProperties interface to include the "accessibilityLabel" property:

export interface RawButtonProperties
extends NativeViewGestureHandlerProperties {
exclusive?: boolean;
testID?: string;
accessibilityLabel?: string;
}

This provides a fix to the issue: https://github.com/kmagiera/react-native-gesture-handler/issues/865