### PR TITLE
 Split layout props in GenericTouchable instead of using containerStyle

### DIFF
--- a/src/components/touchables/GenericTouchable.tsx
+++ b/src/components/touchables/GenericTouchable.tsx
@@ -3,8 +3,6 @@ import { Component } from 'react';
 import {
   Animated,
   Platform,
-  StyleProp,
-  ViewStyle,
   TouchableWithoutFeedbackProps,
 } from 'react-native';
 
@@ -17,6 +15,8 @@ import {
 } from '../../handlers/gestureHandlerCommon';
 import { NativeViewGestureHandlerPayload } from '../../handlers/NativeViewGestureHandler';
 import { TouchableNativeFeedbackExtraProps } from './TouchableNativeFeedback.android';
+
+const AnimatedBaseButton = Animated.createAnimatedComponent(BaseButton);
 
 /**
  * Each touchable is a states' machine which preforms transitions.
@@ -46,8 +46,6 @@ export interface GenericTouchableProps extends TouchableWithoutFeedbackProps {
   nativeID?: string;
   shouldActivateOnStart?: boolean;
   disallowInterruption?: boolean;
-
-  containerStyle?: StyleProp<ViewStyle>;
 }
 
 interface InternalProps {
@@ -263,8 +261,8 @@ export default class GenericTouchable extends Component<
     };
 
     return (
-      <BaseButton
-        style={this.props.containerStyle}
+      <AnimatedBaseButton
+        style={this.props.style}
         onHandlerStateChange={
           // TODO: not sure if it can be undefined instead of null
           this.props.disabled ? undefined : this.onHandlerStateChange
@@ -274,11 +272,10 @@ export default class GenericTouchable extends Component<
         shouldActivateOnStart={this.props.shouldActivateOnStart}
         disallowInterruption={this.props.disallowInterruption}
         testID={this.props.testID}
+        {...coreProps}
         {...this.props.extraButtonProps}>
-        <Animated.View {...coreProps} style={this.props.style}>
-          {this.props.children}
-        </Animated.View>
-      </BaseButton>
+        {this.props.children}
+      </AnimatedBaseButton>
     );
   }
 }

--- a/src/components/touchables/GenericTouchable.tsx
+++ b/src/components/touchables/GenericTouchable.tsx
@@ -4,6 +4,7 @@ import {
   Animated,
   Platform,
   TouchableWithoutFeedbackProps,
+  StyleSheet,
 } from 'react-native';
 
 import { State } from '../../State';
@@ -15,8 +16,7 @@ import {
 } from '../../handlers/gestureHandlerCommon';
 import { NativeViewGestureHandlerPayload } from '../../handlers/NativeViewGestureHandler';
 import { TouchableNativeFeedbackExtraProps } from './TouchableNativeFeedback.android';
-
-const AnimatedBaseButton = Animated.createAnimatedComponent(BaseButton);
+import splitStyleProp from './splitStyleProp';
 
 /**
  * Each touchable is a states' machine which preforms transitions.
@@ -259,10 +259,11 @@ export default class GenericTouchable extends Component<
       onLayout: this.props.onLayout,
       hitSlop: this.props.hitSlop,
     };
+    const { outer, inner } = splitStyleProp(this.props.style);
 
     return (
-      <AnimatedBaseButton
-        style={this.props.style}
+      <BaseButton
+        style={outer}
         onHandlerStateChange={
           // TODO: not sure if it can be undefined instead of null
           this.props.disabled ? undefined : this.onHandlerStateChange
@@ -272,10 +273,17 @@ export default class GenericTouchable extends Component<
         shouldActivateOnStart={this.props.shouldActivateOnStart}
         disallowInterruption={this.props.disallowInterruption}
         testID={this.props.testID}
-        {...coreProps}
         {...this.props.extraButtonProps}>
-        {this.props.children}
-      </AnimatedBaseButton>
+        <Animated.View {...coreProps} style={[styles.innerView, inner]}>
+          {this.props.children}
+        </Animated.View>
+      </BaseButton>
     );
   }
 }
+
+const styles = StyleSheet.create({
+  innerView: {
+    flexGrow: 1,
+  },
+});

--- a/src/components/touchables/splitStyleProp.ts
+++ b/src/components/touchables/splitStyleProp.ts
@@ -1,0 +1,61 @@
+import { FlexStyle, StyleProp, StyleSheet } from 'react-native';
+
+const OUTER_PROPS: { [key in keyof FlexStyle]?: true } = {
+  alignSelf: true,
+  bottom: true,
+  display: true,
+  end: true,
+  flex: true,
+  flexBasis: true,
+  flexGrow: true,
+  flexShrink: true,
+  height: true,
+  left: true,
+  margin: true,
+  marginBottom: true,
+  marginEnd: true,
+  marginHorizontal: true,
+  marginLeft: true,
+  marginRight: true,
+  marginStart: true,
+  marginTop: true,
+  marginVertical: true,
+  maxHeight: true,
+  maxWidth: true,
+  minHeight: true,
+  minWidth: true,
+  position: true,
+  right: true,
+  start: true,
+  top: true,
+  width: true,
+  zIndex: true,
+};
+
+/**
+ * Split a style prop between an "outer" and "inner" views in a way that makes it behave
+ * as if it was a single view.
+ *
+ * @example
+ * const { outer, inner } = splitStyleProp(style);
+ * return (
+ *   <View style={outer}>
+ *     <View style={[{ flexGrow: 1 }, inner]} />
+ *   </View>
+ * );
+ */
+export default function splitStyleProp<T extends FlexStyle>(
+  style?: StyleProp<T>
+): { outer: T; inner: T } {
+  const resolvedStyle = StyleSheet.flatten(style);
+  const inner: Record<string, unknown> = {};
+  const outer: Record<string, unknown> = {};
+  Object.entries(resolvedStyle).forEach(([key, value]) => {
+    if ((OUTER_PROPS as { [key: string]: true | undefined })[key] === true) {
+      outer[key] = value;
+    } else {
+      inner[key] = value;
+    }
+  });
+  return { outer: outer as T, inner: inner as T };
+}


### PR DESCRIPTION
## Description

Touchable components do not layout as expected since they are wrapped in an extra view. To workaround this they have an extra `containerStyle` prop, but this is confusing and different from the ones in `react-native`.

This removes the `containerStyle` props and instead split the style prop passed between styles that should apply to the inner and outer view. This makes it seemlessly behave as if it was a single view.

## Test plan

Using something like:

```ts
<View style={{ flexDirection: "row" }}>
  <TouchableOpacity
    style={{
      flex: 1,
      width: 50,
      height: 50,
      backgroundColor: "red",
      marginRight: 16,
      borderColor: "blue",
      borderWidth: 4,
      borderRadius: 6,
    }}
  />
  <TouchableOpacity
    feedback="opacity"
    sx={{
      flex: 1,
      width: 50,
      height: 50,
      backgroundColor: "red",
      marginRight: 16,
    }}
  />
  <TouchableOpacity
    feedback="opacity"
    sx={{
      flex: 1,
      width: 50,
      height: 50,
      backgroundColor: "red",
      marginRight: 16,
    }}
  />
</View>
```

Before:

![image](https://user-images.githubusercontent.com/2677334/131723397-a1f81c98-2025-46d0-9f38-e1fe2362810f.png)

After: 

![image](https://user-images.githubusercontent.com/2677334/131723417-3a1f0522-a82e-4ced-b533-bd7c5df58e08.png)
