### PR TITLE
Prevent a Android crash from dispatchTouchEvent

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.kt
@@ -21,9 +21,14 @@ class RNGestureHandlerEnabledRootView : ReactRootView {
   }
 
   override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
-    return if (gestureRootHelper?.dispatchTouchEvent(ev) == true) {
-      true
-    } else super.dispatchTouchEvent(ev)
+    return try {
+      if (gestureRootHelper?.dispatchTouchEvent(ev) == true) {
+        true
+      } else super.dispatchTouchEvent(ev)
+    } catch (e: IllegalArgumentException) {
+      e.printStackTrace()
+      false
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

try-catch block around call which intermittently throws an IllegalArgumentException

Resolves Issues:
  -  https://github.com/software-mansion/react-native-gesture-handler/issues/1679
  -  https://github.com/facebook/react-native/issues/30320

## Test plan

  - Installed the dependency
  - Cable load the app which uses the dependency onto a device
  - Try a variety of touch gestures