### PR TITLE
Reset velocity when beginning pan gesture

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
@@ -213,6 +213,8 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
       startY = lastY
       offsetX = 0f
       offsetY = 0f
+      velocityX = 0f
+      velocityY = 0f
       velocityTracker = VelocityTracker.obtain()
       addVelocityMovement(velocityTracker, event)
       begin()


### PR DESCRIPTION
## Description

PanGestureHandler didn't reset its velocity on Android. Because of that the first dispatched event to the handler would contain the same velocity as the last event in the previous gesture.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1693.

## Test plan

Tested on the Example app.
