### PR TITLE
Use default version of Kotlin plugin in apps where Kotlin is not used

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,20 +1,21 @@
 buildscript {
-    ext.default_kotlin_version='1.5.20'
-    ext.safeExtGet = { name, fallback ->
-        return rootProject.ext.has(name) ? rootProject.ext.get(name) : fallback
-    }
+    def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNGH_kotlinVersion']
 
     repositories {
         mavenCentral()
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlin_version', default_kotlin_version)}")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 repositories {
     mavenCentral()
@@ -38,10 +39,12 @@ android {
     }
 }
 
+def kotlin_version = safeExtGet('kotlinVersion', project.properties['RNGH_kotlinVersion'])
+
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "androidx.core:core-ktx:1.6.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${safeExtGet('kotlin_version', default_kotlin_version)}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -16,3 +16,4 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+RNGH_kotlinVersion=1.5.20

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "!**/__fixtures__",
     "!**/__mocks__",
     "android/build.gradle",
+    "android/gradle.properties",
     "android/src/main/AndroidManifest.xml",
     "android/src/main/java/",
     "android/lib/build.gradle",


### PR DESCRIPTION
## Description

Use the default version of the Kotlin plugin when it is not configured in the root project.

## Test plan

Added RNGH to an app without Kotlin configured and built it.
