### PR TITLE
Fix excessive state changes in Pan's touchesBegan

### DIFF
--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -73,7 +73,9 @@
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-  [_gestureHandler reset];
+  if ([self numberOfTouches] == 0) {
+    [_gestureHandler reset];
+  }
 #if !TARGET_OS_TV
   if (_hasCustomActivationCriteria) {
     // We use "minimumNumberOfTouches" property to prevent pan handler from recognizing
@@ -286,4 +288,3 @@
 }
 
 @end
-


### PR DESCRIPTION
## Description

Fix the issue when adding additional fingers fired UNDETERMINED -> ACTIVE state. This should be fired only once when transitioning from no touch to the first touch.

## Test plan

Tested on own app.
