### PR TITLE
fix: android - onstart on pinch gesture handler

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -40,6 +40,9 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
 
     override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
       startingSpan = detector.currentSpan
+      if (state == STATE_UNDETERMINED) {
+        begin()
+      }
       return true
     }
 
@@ -57,7 +60,6 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
       scaleGestureDetector = ScaleGestureDetector(context, gestureListener)
       val configuration = ViewConfiguration.get(context)
       spanSlop = configuration.scaledTouchSlop.toFloat()
-      begin()
     }
     scaleGestureDetector?.onTouchEvent(event)
     var activePointers = event.pointerCount


### PR DESCRIPTION
## Description
This PR attempts to fix `onStart` callback on android with `PinchGestureHandler` and resolve the below inconsistency on android and iOS. Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/553
 
### On iOS
- onStart callback gets called during a Pinch (with two finger) gesture. 

### On Android
- onStart callback gets called even when a single finger is tapped and `focalX` and `focalY` are always 0 during onStart.


This PR can cause a breaking change for someone who's depending upon using `onStart` for single-finger gestures on Android (doesn't seem very likely with PinchGestureHandler, but I am not sure!)

<!--
Description and motivation for this PR.

Inlude 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan
- Use `useAnimatedGestureHandler` as shown below and print values of `focalX` and `focalY` or `numberOfPointers` in `onStart` callback. 
- Verify the consistency of `onStart` on Android and iOS.
- `onStart` should be called with 2 finger pinch (similar to iOS). 
- `focalX` and `focalY` should not be 0.

```jsx
const handler = useAnimatedGestureHandler<PinchGestureHandlerGestureEvent>({
    onStart(e, ctx: any) {
      console.log(e.focalX, e.focalY)
    },
});


// Attach the handler to PinchGestureHandler
<PinchGestureHandler onGestureEvent={handler}>
      <Animated.View
        style={{ height: 300, width: 300, backgroundColor: "pink" }}
      />
</PinchGestureHandler>
```

<!--
Describe how did you test this change here.
-->
