### PR TITLE
fix: android - Pinch gesture handler when one finger is lifted

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -61,15 +61,11 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
       spanSlop = configuration.scaledTouchSlop.toFloat()
       begin()
     }
-
-    activePointers = event.pointerCount;
-
     scaleGestureDetector?.onTouchEvent(event)
-
+    activePointers = event.pointerCount;
     if (event.actionMasked == MotionEvent.ACTION_POINTER_UP) {
       activePointers -= 1
     }
-
     if (state == STATE_ACTIVE && event.actionMasked == MotionEvent.ACTION_UP) {
       end()
     } else if (event.actionMasked == MotionEvent.ACTION_UP) {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -62,7 +62,7 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
       begin()
     }
     scaleGestureDetector?.onTouchEvent(event)
-    activePointers = event.pointerCount;
+    activePointers = event.pointerCount
     if (event.actionMasked == MotionEvent.ACTION_POINTER_UP) {
       activePointers -= 1
     }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -13,6 +13,8 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
     private set
   val focalPointX: Float
     get() = scaleGestureDetector?.focusX ?: Float.NaN
+  var activePointers = 0
+    private set
   val focalPointY: Float
     get() = scaleGestureDetector?.focusY ?: Float.NaN
 
@@ -59,9 +61,13 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
       spanSlop = configuration.scaledTouchSlop.toFloat()
       begin()
     }
-  
-  if(event.actionMasked != MotionEvent.ACTION_POINTER_UP){
-      scaleGestureDetector?.onTouchEvent(event)
+
+    activePointers = event.pointerCount;
+
+    scaleGestureDetector?.onTouchEvent(event)
+
+    if (event.actionMasked == MotionEvent.ACTION_POINTER_UP) {
+      activePointers -= 1
     }
 
     if (state == STATE_ACTIVE && event.actionMasked == MotionEvent.ACTION_UP) {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -57,14 +57,13 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
       scaleGestureDetector = ScaleGestureDetector(context, gestureListener)
       val configuration = ViewConfiguration.get(context)
       spanSlop = configuration.scaledTouchSlop.toFloat()
-      begin()
     }
-    scaleGestureDetector?.onTouchEvent(event)
-    var activePointers = event.pointerCount
-    if (event.actionMasked == MotionEvent.ACTION_POINTER_UP) {
-      activePointers -= 1
+    
+    if(event.actionMasked != MotionEvent.ACTION_POINTER_UP){
+      scaleGestureDetector?.onTouchEvent(event)
     }
-    if (state == STATE_ACTIVE && activePointers < 2) {
+
+    if (state == STATE_ACTIVE && event.actionMasked == MotionEvent.ACTION_UP) {
       end()
     } else if (event.actionMasked == MotionEvent.ACTION_UP) {
       fail()

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -57,9 +57,10 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
       scaleGestureDetector = ScaleGestureDetector(context, gestureListener)
       val configuration = ViewConfiguration.get(context)
       spanSlop = configuration.scaledTouchSlop.toFloat()
+      begin()
     }
-    
-    if(event.actionMasked != MotionEvent.ACTION_POINTER_UP){
+  
+  if(event.actionMasked != MotionEvent.ACTION_POINTER_UP){
       scaleGestureDetector?.onTouchEvent(event)
     }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -248,6 +248,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
         putDouble("focalX", PixelUtil.toDIPFromPixel(handler.focalPointX).toDouble())
         putDouble("focalY", PixelUtil.toDIPFromPixel(handler.focalPointY).toDouble())
         putDouble("velocity", handler.velocity)
+        putDouble("numberOfPointers", handler.activePointers.toDouble())
       }
     }
   }


### PR DESCRIPTION
## Description
- This PR attempts to make android PinchGestureHandler consistent with iOS's implementation. i.e. Do not move PinchHandler to `end` state when a finger is lifted.
- This issue is discussed in detail over here https://github.com/software-mansion/react-native-gesture-handler/issues/1214

I agree with the notion of preserving the platform behaviour on iOS but in case of android there's no native pinch handler and some custom logic is already there in place, so I am not sure what behavior is correct.

## Approach
- End the gesture on ACTION_UP. i.e. both fingers are lifted.
- Added a property in PinchGestureHandler to control the `numberOfPointer` during `ACTION_POINTER_UP`
<!--
Description and motivation for this PR.

Inlude 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

- We can test it with the below snippet. Pinch handler will only move to end state when both the fingers are lifted.
- [This gist](https://gist.github.com/intergalacticspacehighway/9e931614199915cb4694209f12bf6f11) can also be tested. With the changes in this PR, the gist code will run same in both the platforms.

```jsx
const handler = useAnimatedGestureHandler<PinchGestureHandlerGestureEvent>({
    onActive(e) {
      console.log("Active")
    },
    onEnd(e) {
      console.log("Ended")
    }
});


// Attach the handler to PinchGestureHandler
<PinchGestureHandler onGestureEvent={handler}>
      <Animated.View
        style={{ height: 300, width: 300, backgroundColor: "pink" }}
      />
</PinchGestureHandler>
```

<!--
Describe how did you test this change here.
-->

