### PR TITLE
Extract handlers when child view is handling touch with `pointerEvents='box-none'`

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -475,7 +475,12 @@ class GestureHandlerOrchestrator(
       PointerEventsConfig.BOX_NONE -> {
         // This view can't be the target, but its children might
         if (view is ViewGroup) {
-          extractGestureHandlers(view, coords, pointerId)
+          extractGestureHandlers(view, coords, pointerId).also { found ->
+            // A child view is handling touch, also extract handlers attached to this view
+            if (found) {
+              recordViewHandlersForPointer(view, coords, pointerId)
+            }
+          }
         } else false
       }
       PointerEventsConfig.AUTO -> {


### PR DESCRIPTION
## Description

As described in the [docs](https://reactnative.dev/docs/view#pointerevents), when a view has `pointerEvents` prop set to `box-none` then it will never be a touch target but its children might be. Current implementation ignores gestures attached to the view with `pointerEvents='box-none'` entirely, even if its child is handling events, contrary to how it works on iOS where the gestures attached to parent will also work on the child view (but not on the parent).

This PR changes implementation of the view traversing algorithm to also extract gestures from a view with `pointerEvents='box-none'` when the target of a touch is its descendant.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1575. Supersedes https://github.com/software-mansion/react-native-gesture-handler/pull/1710.

## Test plan

Tested on the Example app.
