### PR TITLE
Make simultaneous handlers always symmetric on iOS

### DIFF
--- a/apple/RNGestureHandler.m
+++ b/apple/RNGestureHandler.m
@@ -482,7 +482,9 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
           return YES;
         }
       }
-    } else if (handler->_simultaneousHandlers) {
+    }
+
+    if (handler->_simultaneousHandlers) {
       for (NSNumber *handlerTag in handler->_simultaneousHandlers) {
         if ([self.tag isEqual:handlerTag]) {
           return YES;


### PR DESCRIPTION
## Description

Current behavior only checks `simultaneousHandlers` field of the other handler if there are none set in `simultaneousHandlers` of `this` handler. This effectively makes it so the field is symmetrical only if there are no simultaneous handlers declared on `this` handler.

This PR changes it, so that `simultaneousHandlers` of the other handler are checked always if the checked handler tag is not present in this handler's simultaneous list. This means that only one handler needs to declare being simultaneous with the other one instead of declaring it both ways.
