### PR TITLE
Emit changes to pointersInside

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -363,6 +363,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     x = adaptedTransformedEvent.x
     y = adaptedTransformedEvent.y
     numberOfPointers = adaptedTransformedEvent.pointerCount
+    val wasWithinBounds = isWithinBounds
     isWithinBounds = isWithinBounds(view, x, y)
     if (shouldCancelWhenOutside && !isWithinBounds) {
       if (state == STATE_ACTIVE) {
@@ -386,6 +387,8 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
       sourceEvent.action == MotionEvent.ACTION_HOVER_EXIT
     ) {
       onHandleHover(adaptedTransformedEvent, adaptedSourceEvent)
+    } else if (sourceEvent.action == MotionEvent.ACTION_MOVE && state == STATE_ACTIVE && wasWithinBounds != isWithinBounds) {
+      orchestrator!!.onHandlerStateChange(this, state, state)
     } else {
       onHandle(adaptedTransformedEvent, adaptedSourceEvent)
     }

--- a/apple/RNGestureHandler.mm
+++ b/apple/RNGestureHandler.mm
@@ -273,7 +273,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
            forViewWithTag:(nonnull NSNumber *)reactTag
             withExtraData:(RNGestureHandlerEventExtraData *)extraData
 {
-  if (state != _lastState) {
+  if (state != _lastState || state == RNGestureHandlerStateActive) {
     // don't send change events from END to FAILED or CANCELLED, this may happen when gesture is ended in `onTouchesUp`
     // callback
     if (_lastState == RNGestureHandlerStateEnd &&


### PR DESCRIPTION
## Description

Currently `onHandlerStateChange` will only send events whenever the handler state changes. However for the use case where one wants to resign highlight from the button whenever the user moves their pointer away from it, the only way is to use the `onGestureEvent`. This handler is however exceptionally noisy especially on Android, to the extent where I get UI thread frame drops when using worklets.

This MR emits additional events for the quite rare case where `pointersInside` prop changes for active gesture handlers to support this use case in a performant way.

## Test plan

<!--
Describe how did you test this change here.
-->
