### PR TITLE
Cancel failed buttons in reset

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -770,6 +770,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     }
   }
   fun reset() {
+    onReset()
     view = null
     orchestrator = null
     Arrays.fill(trackedPointerIDs, -1)
@@ -777,7 +778,6 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     trackedPointersCount = 0
     trackedPointers.fill(null)
     touchEventType = RNGestureHandlerTouchEvent.EVENT_UNDETERMINED
-    onReset()
   }
 
   fun withMarkedAsInBounds(closure: () -> Unit) {

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -161,6 +161,9 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
   }
 
   override fun onReset() {
+    if (state == STATE_FAILED && view != null) {
+      onCancel()
+    }
     this.hook = defaultHook
   }
 


### PR DESCRIPTION
## Description

This PR is an attempt at fixing bug reported in https://github.com/software-mansion/react-native-gesture-handler/issues/2160. 

Essentially when having a button with `shouldCancelWhenOutside={true}` in a `ScrollView` and scrolling quickly, especially when at the bottom where the scrollview exhibit rubber band effect, all buttons becomes unresponsive. This is because `touchResponder` is never freed after it goes into `FAILED` state, which typically otherwise happens when `ACTION_UP` is emitted – something that never happens. 

I'm not sure of the ideal solution, but I'd figured I share my half-baked workaround to emit `CANCEL` in `onReset` if the button is stuck in `FAILED`. Curious to hear suggestions on how to improve this.

## Test plan

<!--
Describe how did you test this change here.
-->
