### PR TITLE
Add `hitSlop` into `childProps` in `createNativeWrapper`

### DIFF
--- a/src/handlers/createNativeWrapper.tsx
+++ b/src/handlers/createNativeWrapper.tsx
@@ -44,7 +44,11 @@ export default function createNativeWrapper<P>(
       },
       {
         gestureHandlerProps: { ...config }, // Watch out not to modify config
-        childProps: { enabled: props.enabled, hitSlop: props.hitSlop } as P,
+        childProps: {
+          enabled: props.enabled,
+          hitSlop: props.hitSlop,
+          testID: props.testID,
+        } as P,
       }
     );
     const _ref = useRef<React.ComponentType<P>>();


### PR DESCRIPTION
## Description

Starting from #3343 we no longer pass Gesture Handler props into native views. I've managed to catch that mentioned PR lacked `enabled` prop in  `childProps`, but it turns out that `hitSlop` should also be passed, as without it `hitSlops` don't work on `iOS` (as reported [here](https://bsky.app/profile/vova.codes/post/3lhrnbcxgu224)).

Fixes #3398 

## Test plan

<details>
<summary>Tested on the following code:</summary>

```jsx
import React from 'react';
import { StyleSheet, View } from 'react-native';
import { TouchableOpacity } from 'react-native-gesture-handler';

export default function Example() {
  return (
    <View style={styles.container}>
      <TouchableOpacity
        style={{
          width: 50,
          height: 50,
          backgroundColor: 'red',
        }}
        hitSlop={20}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
});
```

</details>