### PR TITLE
Fix incorrect paths

### DIFF
--- a/apps/basic-example/tsconfig.json
+++ b/apps/basic-example/tsconfig.json
@@ -5,10 +5,13 @@
     "baseUrl": ".",
     "paths": {
       "react-native-gesture-handler": [
-        "../../packages/react-native-gesture-handler/index.ts"
+        "../../packages/react-native-gesture-handler/src"
       ],
       "react-native-gesture-handler/ReanimatedSwipeable": [
         "../../packages/react-native-gesture-handler/src/components/ReanimatedSwipeable.tsx"
+      ],
+      "react-native-gesture-handler/ReanimatedDrawerLayout": [
+        "../../packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx"
       ],
       "react-native-gesture-handler/jest-utils": [
         "../../packages/react-native-gesture-handler/src/jestUtils/index.ts"

--- a/apps/common-app/tsconfig.json
+++ b/apps/common-app/tsconfig.json
@@ -6,10 +6,13 @@
     "paths": {
       "@/*": ["./*"],
       "react-native-gesture-handler": [
-        "../../packages/react-native-gesture-handler/index.ts"
+        "../../packages/react-native-gesture-handler/src"
       ],
       "react-native-gesture-handler/ReanimatedSwipeable": [
         "../../packages/react-native-gesture-handler/src/components/ReanimatedSwipeable.tsx"
+      ],
+      "react-native-gesture-handler/ReanimatedDrawerLayout": [
+        "../../packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx"
       ],
       "react-native-gesture-handler/jest-utils": [
         "../../packages/react-native-gesture-handler/src/jestUtils/index.ts"

--- a/apps/expo-example/tsconfig.json
+++ b/apps/expo-example/tsconfig.json
@@ -11,6 +11,9 @@
       "react-native-gesture-handler/ReanimatedSwipeable": [
         "../../packages/react-native-gesture-handler/src/components/ReanimatedSwipeable.tsx"
       ],
+      "react-native-gesture-handler/ReanimatedDrawerLayout": [
+        "../../packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx"
+      ],
       "react-native-gesture-handler/jest-utils": [
         "../../packages/react-native-gesture-handler/src/jestUtils/index.ts"
       ]

--- a/apps/macos-example/tsconfig.json
+++ b/apps/macos-example/tsconfig.json
@@ -6,10 +6,13 @@
     "paths": {
       "common-app": ["../common-app/index.ts"],
       "react-native-gesture-handler": [
-        "../../packages/react-native-gesture-handler/index.ts"
+        "../../packages/react-native-gesture-handler/src"
       ],
       "react-native-gesture-handler/ReanimatedSwipeable": [
         "../../packages/react-native-gesture-handler/src/components/ReanimatedSwipeable.tsx"
+      ],
+      "react-native-gesture-handler/ReanimatedDrawerLayout": [
+        "../../packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx"
       ],
       "react-native-gesture-handler/jest-utils": [
         "../../packages/react-native-gesture-handler/src/jestUtils/index.ts"


### PR DESCRIPTION
## Description

`tsconfig.json` files had a path that did not exist, therefore imports from Gesture Handler were marked red with message `cannot find module`.

## Test plan

Run `yarn ts-check`