### PR TITLE
Don't call `needs-repro` CI on comments

### DIFF
--- a/.github/workflows/needs-repro.yml
+++ b/.github/workflows/needs-repro.yml
@@ -3,8 +3,6 @@ name: Check for reproduction
 on:
   issues:
     types: [opened, edited]
-  issue_comment:
-    types: [created, edited, deleted]
 
 jobs:
   main:


### PR DESCRIPTION
## Description

This PR disables `needs-repro` watching changes on the comments.

Resolves the issue visible [here](https://github.com/software-mansion/react-native-gesture-handler/issues/3476#issuecomment-2984441560).

## Test plan

<!--
Describe how did you test this change here.
-->
