### PR TITLE
fix: gesture not activating due to outdated handler tag

### DIFF
--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useAnimatedGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useAnimatedGesture.ts
@@ -163,7 +163,10 @@ export function useAnimatedGesture(
           runWorklet(CALLBACK_TYPE.FINALIZE, gesture, event, false);
         }
       } else if (isTouchEvent(event)) {
-        if (!stateControllers[i] || stateControllers[i].handlerTag !== event.handlerTag) {
+        if (
+          !stateControllers[i] ||
+          stateControllers[i].handlerTag !== event.handlerTag
+        ) {
           stateControllers[i] = GestureStateManager.create(event.handlerTag);
         }
 

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureStateManager.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureStateManager.ts
@@ -24,7 +24,7 @@ function create(handlerTag: number): GestureStateManagerType {
   'worklet';
   return {
     handlerTag,
-    
+
     begin: () => {
       'worklet';
       if (REANIMATED_AVAILABLE) {

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureStateManager.web.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureStateManager.web.ts
@@ -5,7 +5,7 @@ export const GestureStateManager = {
   create(handlerTag: number): GestureStateManagerType {
     return {
       handlerTag,
-      
+
       begin: () => {
         NodeManager.getHandler(handlerTag).begin();
       },


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

This fixes an issue where the manual activation of a handler wouldn't work.
I unfortunately didn't had time to make a full reproduction. The scenario roughly looks like this:

```ts
const gesture = useMemo(() -> Gesture.Pan() // Note happens also without useMemo
	.manualActivation(true)
	.onTouchesMove((event, manager) => {
			// Some criteria to met:
			manager.activate()
	})
	.onUpdate(() => {
		// Wouldn't get called on a remount
	})

return <GestureDetector gesture={gesture}> // ...
```

This is being used in a component on a screen. When we navigate from the screen the component gets unmounted and I can see that his logic is being triggered:

https://github.com/software-mansion/react-native-gesture-handler/blob/1e1f4e035ea6d4c38684c4abc43d91dbf5b46dc6/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/index.tsx#L152-L168

```
attachHandler 1
dropHandler 1
```

I think the screen might get frozen instead of unmounted, but not entirely sure, but the cleanup function gets called and the handler gets dropped.
Now, when reopening the screen the handlers will reattach, but have a different handler tag now.

```
attachHandler 1
dropHandler 1
attachHandler 2 
```

When I now run the gesture I can see that the `manager` still has the **previous handler tag**, and thus on the native side it can't find the handler to activate. Its calling `setGestureHandlerState(1 /* previous id */)` here (when I call `manager.activate`):

https://github.com/software-mansion/react-native-gesture-handler/blob/1e1f4e035ea6d4c38684c4abc43d91dbf5b46dc6/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt#L108

I found that attaching the handler tag to the GestureStateMangaer and recreating it if it has changed fixes the issue.
If you need a full reproduction to proceed with this change I can understand, just let me know then I can try to find time to create one 👍 


## Test plan

<!--
Describe how did you test this change here.
-->

Well, shamefully I didn't create a reproduction so I guess the test plan is "trust me bro" 😅  not the best I know - sorry. 
