### PR TITLE
Remove ViewManagerWithGeneratedInterface from old arch interfaces

### DIFF
--- a/packages/react-native-gesture-handler/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerInterface.java
+++ b/packages/react-native-gesture-handler/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerInterface.java
@@ -11,9 +11,8 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import androidx.annotation.Nullable;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface RNGestureHandlerButtonManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNGestureHandlerButtonManagerInterface<T extends View> {
   void setExclusive(T view, boolean value);
   void setForeground(T view, boolean value);
   void setBorderless(T view, boolean value);

--- a/packages/react-native-gesture-handler/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerRootViewManagerInterface.java
+++ b/packages/react-native-gesture-handler/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerRootViewManagerInterface.java
@@ -10,8 +10,7 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface RNGestureHandlerRootViewManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNGestureHandlerRootViewManagerInterface<T extends View> {
   // No props
 }


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

Fixes #3564

Remove unneeded `ViewManagerWithGeneratedInterface` extend from old arch to preserve backwards compatibility with RN 0.77

## Test plan

<!--
Describe how did you test this change here.
-->

App builds and runs on RN 0.77 with old arch with this patch.