### PR TITLE
Make `dev client` default when starting `expo-example`

### DIFF
--- a/apps/expo-example/package.json
+++ b/apps/expo-example/package.json
@@ -4,7 +4,7 @@
   "main": "index.ts",
   "scripts": {
     "postinstall": "npx expo prebuild",
-    "start": "expo start",
+    "start": "expo start --dev-client",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",


### PR DESCRIPTION
## Description

Currently when we start `expo-example` it uses expo go by default. This PR changes it do use `dev client` instead

## Test plan

Run `expo-example`