### PR TITLE
[Web] fixed texinput submition when inside pressable

### DIFF
--- a/packages/react-native-gesture-handler/src/web/tools/KeyboardEventManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/KeyboardEventManager.ts
@@ -82,7 +82,8 @@ export default class KeyboardEventManager extends EventManager<HTMLElement> {
       KeyboardEventManager.registeredStaticListeners = true;
       document.addEventListener(
         'keyup',
-        KeyboardEventManager.keyUpStaticCallback
+        KeyboardEventManager.keyUpStaticCallback,
+        { capture: true }
       );
     }
   }
@@ -95,7 +96,8 @@ export default class KeyboardEventManager extends EventManager<HTMLElement> {
     if (KeyboardEventManager.instances.size === 0) {
       document.removeEventListener(
         'keyup',
-        KeyboardEventManager.keyUpStaticCallback
+        KeyboardEventManager.keyUpStaticCallback,
+        { capture: true }
       );
       KeyboardEventManager.registeredStaticListeners = false;
     }


### PR DESCRIPTION
## Description

Fixes issue #3622. On web, when we submitted `TextInput` using enter, which was inside `Pressable`, then Gesture Handler didn't recognize any subsqeuent taps or gestures. Tap gesture was kept in active state, and caused all other gestures to fail.

## Test plan
```ts
import React from 'react';
import { useState } from 'react';
import { View } from 'react-native';
import { Pressable, TextInput } from 'react-native-gesture-handler';
export default function EmptyExample() {
  const [shown, setShown] = useState(true)
  return (
    <View>
      <Pressable key="2" style={{ backgroundColor: 'red', width: 100, height: 60 }} testID="bad-pressable" onPress={() => { console.log("pressed") }}>
        {shown ? <TextInput
          style={{ backgroundColor: 'green', width: 100, height: 60 }}
          onSubmitEditing={() => { console.log("submit"); setShown(false); }}
        /> : <View ></View>}
      </Pressable >
    </View >
  )
};
```
