### PR TITLE
Fix link to the example app in the documentation

### DIFF
--- a/packages/docs-gesture-handler/docs/fundamentals/introduction.md
+++ b/packages/docs-gesture-handler/docs/fundamentals/introduction.md
@@ -25,7 +25,7 @@ We recommended to use Reanimated to implement gesture-driven animations with Ges
 
 ### Apps
 
-[Gesture Handler Example App](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example) – official gesture handler "showcase" app.
+[Gesture Handler Example App](https://github.com/software-mansion/react-native-gesture-handler/tree/main/apps/expo-example) – official gesture handler "showcase" app.
 
 ### Talks and workshops
 


### PR DESCRIPTION
## Description

The example app link was broken due to monorepo migration.

## Test plan

Click the new link
