### PR TITLE
Remove `sync-architectures` script from commit hook

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -6,6 +6,5 @@
     "yarn format:android"
   ],
   "packages/react-native-gesture-handler/apple/**/*.{h,m,mm,cpp}": "yarn format:apple",
-  "packages/react-native-gesture-handler/{shared,android/src}/**/*.{h,cpp}": "yarn format:cpp",
-  "packages/react-native-gesture-handler/src/specs/*.ts": "yarn workspace react-native-gesture-handler sync-architectures"
+  "packages/react-native-gesture-handler/{shared,android/src}/**/*.{h,cpp}": "yarn format:cpp"
 }


### PR DESCRIPTION
## Description

#3639 removed support for React Native old architecture. While it removed script for architectures sync, it is still called on commit hook, thus trying to add commit with updated spec fails.

## Test plan

Run `git commit`
