### PR TITLE
Remove remaining `any` in gesture config type

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/relationUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/relationUtils.ts
@@ -1,4 +1,9 @@
-import { ComposedGesture, Gesture, GestureRelations } from '../../types';
+import {
+  BaseGestureConfig,
+  ComposedGesture,
+  Gesture,
+  GestureRelations,
+} from '../../types';
 
 export function isComposedGesture(
   gesture: Gesture
@@ -53,8 +58,8 @@ function makeSimultaneousWithExternalGestureSymmetric(
   }
 }
 
-export function prepareRelations(
-  config: any,
+export function prepareRelations<THandlerData, TConfig>(
+  config: BaseGestureConfig<THandlerData, TConfig>,
   handlerTag: number
 ): GestureRelations {
   makeSimultaneousWithExternalGestureSymmetric(


### PR DESCRIPTION
## Description

Seems like I've missed one place where `config` was typed as `any` 🙊 

## Test plan

`yarn ts-check`
