### PR TITLE
[Web] Add `name` property to handlers

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/FlingGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/FlingGestureHandler.ts
@@ -1,12 +1,13 @@
 import { State } from '../../State';
 import { DiagonalDirections, Directions } from '../../Directions';
-import { AdaptedEvent, Config, GestureHandlerName } from '../interfaces';
+import { AdaptedEvent, Config } from '../interfaces';
 
 import GestureHandler from './GestureHandler';
 import Vector from '../tools/Vector';
 import { coneToDeviation } from '../utils';
 import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 import IGestureHandler from './IGestureHandler';
+import { SingleGestureName } from '../../v3/types';
 
 const DEFAULT_MAX_DURATION_MS = 800;
 const DEFAULT_MIN_VELOCITY = 700;
@@ -33,7 +34,7 @@ export default class FlingGestureHandler extends GestureHandler {
   ) {
     super(delegate);
 
-    this.name = GestureHandlerName.Fling;
+    this.name = SingleGestureName.Fling;
   }
 
   public override updateGestureConfig(config: Config): void {

--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -9,7 +9,6 @@ import {
   EventTypes,
   HitSlop,
   GestureHandlerNativeEvent,
-  GestureHandlerName,
 } from '../interfaces';
 import EventManager from '../tools/EventManager';
 import GestureHandlerOrchestrator from '../tools/GestureHandlerOrchestrator';
@@ -27,11 +26,15 @@ import { PointerType } from '../../PointerType';
 import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 import { ActionType } from '../../ActionType';
 import { tagMessage } from '../../utils';
-import { GestureStateChangeEvent, GestureUpdateEvent } from '../../v3/types';
+import {
+  GestureStateChangeEvent,
+  GestureUpdateEvent,
+  SingleGestureName,
+} from '../../v3/types';
 import { TouchEventType } from '../../TouchEventType';
 
 export default abstract class GestureHandler implements IGestureHandler {
-  private _name!: GestureHandlerName;
+  private _name!: SingleGestureName;
   private lastSentState: State | null = null;
 
   private _state: State = State.UNDETERMINED;
@@ -1019,7 +1022,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     return this._name;
   }
 
-  protected set name(value: GestureHandlerName) {
+  protected set name(value: SingleGestureName) {
     this._name = value;
   }
 

--- a/packages/react-native-gesture-handler/src/web/handlers/HoverGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/HoverGestureHandler.ts
@@ -1,10 +1,11 @@
 import { State } from '../../State';
-import { AdaptedEvent, GestureHandlerName } from '../interfaces';
+import { AdaptedEvent } from '../interfaces';
 import GestureHandlerOrchestrator from '../tools/GestureHandlerOrchestrator';
 import GestureHandler from './GestureHandler';
 import { StylusData } from '../../handlers/gestureHandlerCommon';
 import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 import IGestureHandler from './IGestureHandler';
+import { SingleGestureName } from '../../v3/types';
 
 export default class HoverGestureHandler extends GestureHandler {
   private stylusData: StylusData | undefined;
@@ -13,7 +14,7 @@ export default class HoverGestureHandler extends GestureHandler {
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>
   ) {
     super(delegate);
-    this.name = GestureHandlerName.Hover;
+    this.name = SingleGestureName.Hover;
   }
 
   protected override transformNativeEvent(): Record<string, unknown> {

--- a/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
@@ -6,10 +6,11 @@ import type {
   UserSelect,
 } from '../../handlers/gestureHandlerCommon';
 import type { State } from '../../State';
-import type { Config, GestureHandlerName } from '../interfaces';
+import type { Config } from '../interfaces';
 import type EventManager from '../tools/EventManager';
 import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 import type PointerTracker from '../tools/PointerTracker';
+import { SingleGestureName } from '../../v3/types';
 
 export default interface IGestureHandler {
   active: boolean;
@@ -18,7 +19,7 @@ export default interface IGestureHandler {
   handlerTag: number;
   readonly delegate: GestureHandlerDelegate<unknown, this>;
   readonly tracker: PointerTracker;
-  readonly name: GestureHandlerName;
+  readonly name: SingleGestureName;
   state: State;
   shouldCancelWhenOutside: boolean;
   shouldResetProgress: boolean;

--- a/packages/react-native-gesture-handler/src/web/handlers/LongPressGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/LongPressGestureHandler.ts
@@ -1,11 +1,7 @@
 import { ActionType } from '../../ActionType';
 import { State } from '../../State';
-import {
-  AdaptedEvent,
-  Config,
-  GestureHandlerName,
-  PropsRef,
-} from '../interfaces';
+import { SingleGestureName } from '../../v3/types';
+import { AdaptedEvent, Config, PropsRef } from '../interfaces';
 import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 
 import GestureHandler from './GestureHandler';
@@ -34,7 +30,7 @@ export default class LongPressGestureHandler extends GestureHandler {
   ) {
     super(delegate);
 
-    this.name = GestureHandlerName.LongPress;
+    this.name = SingleGestureName.LongPress;
   }
 
   public override init(

--- a/packages/react-native-gesture-handler/src/web/handlers/ManualGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/ManualGestureHandler.ts
@@ -1,4 +1,5 @@
-import { AdaptedEvent, GestureHandlerName } from '../interfaces';
+import { SingleGestureName } from '../../v3/types';
+import { AdaptedEvent } from '../interfaces';
 import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 import GestureHandler from './GestureHandler';
 import IGestureHandler from './IGestureHandler';
@@ -8,7 +9,7 @@ export default class ManualGestureHandler extends GestureHandler {
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>
   ) {
     super(delegate);
-    this.name = GestureHandlerName.Manual;
+    this.name = SingleGestureName.Manual;
   }
 
   protected override onPointerDown(event: AdaptedEvent): void {

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -1,17 +1,13 @@
 import { Platform } from 'react-native';
 import { State } from '../../State';
 import { DEFAULT_TOUCH_SLOP } from '../constants';
-import {
-  AdaptedEvent,
-  Config,
-  GestureHandlerName,
-  PropsRef,
-} from '../interfaces';
+import { AdaptedEvent, Config, PropsRef } from '../interfaces';
 
 import GestureHandler from './GestureHandler';
 import { ActionType } from '../../ActionType';
 import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 import IGestureHandler from './IGestureHandler';
+import { SingleGestureName } from '../../v3/types';
 export default class NativeViewGestureHandler extends GestureHandler {
   private buttonRole!: boolean;
 
@@ -28,7 +24,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>
   ) {
     super(delegate);
-    this.name = GestureHandlerName.NativeView;
+    this.name = SingleGestureName.Native;
   }
 
   public override init(

--- a/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
@@ -1,16 +1,12 @@
 import { State } from '../../State';
 import { DEFAULT_TOUCH_SLOP } from '../constants';
-import {
-  AdaptedEvent,
-  Config,
-  GestureHandlerName,
-  WheelDevice,
-} from '../interfaces';
+import { AdaptedEvent, Config, WheelDevice } from '../interfaces';
 import { StylusData } from '../../handlers/gestureHandlerCommon';
 
 import GestureHandler from './GestureHandler';
 import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 import IGestureHandler from './IGestureHandler';
+import { SingleGestureName } from '../../v3/types';
 
 const DEFAULT_MIN_POINTERS = 1;
 const DEFAULT_MAX_POINTERS = 10;
@@ -62,7 +58,7 @@ export default class PanGestureHandler extends GestureHandler {
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>
   ) {
     super(delegate);
-    this.name = GestureHandlerName.Pan;
+    this.name = SingleGestureName.Pan;
   }
 
   public override updateGestureConfig(config: Config): void {

--- a/packages/react-native-gesture-handler/src/web/handlers/PinchGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PinchGestureHandler.ts
@@ -1,6 +1,6 @@
 import { State } from '../../State';
 import { DEFAULT_TOUCH_SLOP } from '../constants';
-import { AdaptedEvent, GestureHandlerName, PropsRef } from '../interfaces';
+import { AdaptedEvent, PropsRef } from '../interfaces';
 
 import GestureHandler from './GestureHandler';
 import ScaleGestureDetector, {
@@ -9,6 +9,7 @@ import ScaleGestureDetector, {
 import { ActionType } from '../../ActionType';
 import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 import IGestureHandler from './IGestureHandler';
+import { SingleGestureName } from '../../v3/types';
 
 export default class PinchGestureHandler extends GestureHandler {
   private scale = 1;
@@ -55,7 +56,7 @@ export default class PinchGestureHandler extends GestureHandler {
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>
   ) {
     super(delegate);
-    this.name = GestureHandlerName.Pinch;
+    this.name = SingleGestureName.Pinch;
   }
 
   public override init(

--- a/packages/react-native-gesture-handler/src/web/handlers/RotationGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/RotationGestureHandler.ts
@@ -1,5 +1,5 @@
 import { State } from '../../State';
-import { AdaptedEvent, GestureHandlerName, PropsRef } from '../interfaces';
+import { AdaptedEvent, PropsRef } from '../interfaces';
 
 import GestureHandler from './GestureHandler';
 import RotationGestureDetector, {
@@ -8,6 +8,7 @@ import RotationGestureDetector, {
 import { ActionType } from '../../ActionType';
 import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 import IGestureHandler from './IGestureHandler';
+import { SingleGestureName } from '../../v3/types';
 
 const ROTATION_RECOGNITION_THRESHOLD = Math.PI / 36;
 
@@ -51,7 +52,7 @@ export default class RotationGestureHandler extends GestureHandler {
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>
   ) {
     super(delegate);
-    this.name = GestureHandlerName.Rotation;
+    this.name = SingleGestureName.Rotation;
   }
 
   public override init(

--- a/packages/react-native-gesture-handler/src/web/handlers/TapGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/TapGestureHandler.ts
@@ -1,10 +1,6 @@
 import { State } from '../../State';
-import {
-  AdaptedEvent,
-  Config,
-  EventTypes,
-  GestureHandlerName,
-} from '../interfaces';
+import { SingleGestureName } from '../../v3/types';
+import { AdaptedEvent, Config, EventTypes } from '../interfaces';
 import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 
 import GestureHandler from './GestureHandler';
@@ -42,7 +38,7 @@ export default class TapGestureHandler extends GestureHandler {
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>
   ) {
     super(delegate);
-    this.name = GestureHandlerName.Tap;
+    this.name = SingleGestureName.Tap;
   }
 
   public override updateGestureConfig(config: Config): void {

--- a/packages/react-native-gesture-handler/src/web/interfaces.ts
+++ b/packages/react-native-gesture-handler/src/web/interfaces.ts
@@ -172,16 +172,3 @@ export type GestureHandlerRef = {
 export type SVGRef = {
   elementRef: { current: SVGElement };
 };
-
-export enum GestureHandlerName {
-  Tap = 'TapGestureHandler',
-  Pan = 'PanGestureHandler',
-  LongPress = 'LongPressGestureHandler',
-  Pinch = 'PinchGestureHandler',
-  Rotation = 'RotationGestureHandler',
-  Fling = 'FlingGestureHandler',
-  NativeView = 'NativeViewGestureHandler',
-  ForceTouch = 'ForceTouchGestureHandler',
-  Manual = 'ManualGestureHandler',
-  Hover = 'HoverGestureHandler',
-}

--- a/packages/react-native-gesture-handler/src/web/tools/InteractionManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/InteractionManager.ts
@@ -1,6 +1,6 @@
-import { GestureRelations } from '../../v3/types';
+import { GestureRelations, SingleGestureName } from '../../v3/types';
 import type IGestureHandler from '../handlers/IGestureHandler';
-import { Config, GestureHandlerName, Handler } from '../interfaces';
+import { Config, Handler } from '../interfaces';
 
 export default class InteractionManager {
   private static _instance: InteractionManager;
@@ -107,7 +107,7 @@ export default class InteractionManager {
     otherHandler: IGestureHandler
   ): boolean {
     // We check constructor name instead of using `instanceof` in order do avoid circular dependencies
-    const isNativeHandler = otherHandler.name === GestureHandlerName.NativeView;
+    const isNativeHandler = otherHandler.name === SingleGestureName.Native;
     const isActive = otherHandler.active;
     const isButton = otherHandler.isButton?.() === true;
 


### PR DESCRIPTION
## Description

This PR adds `name` property to handlers on web, so that we can avoid checks like in `InteractionsManager`:

```js
   const isNativeHandler =
      otherHandler.constructor.name === 'NativeViewGestureHandler';
```

## Test plan

Tested on **Swipeable** example on mobile version in chrome. 