### PR TITLE
[Android] `build.gradle` cleanup

### DIFF
--- a/packages/react-native-gesture-handler/android/build.gradle
+++ b/packages/react-native-gesture-handler/android/build.gradle
@@ -214,7 +214,7 @@ android {
     }
 
     if (isGHExampleApp()) {
-        tasks.withType(ExternalNativeBuildJsonTask) {
+        tasks.withType(ExternalNativeBuildJsonTask).configureEach {
             compileTask ->
                 compileTask.doLast {
                     def rootDir = new File("${project.projectDir}/..")


### PR DESCRIPTION
> [!NOTE]
> Supersede #3335 

# Description

This PR contains cherry picked commits from #3335 as merging changes after migrating into monorepo became quite painful 😞 

1. `appProject` seems to be left unused after #3091 
2. adding `configureEach` allows for [lazy task initialization](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:old_vs_new_configuration_api_overview)

# Original description

## Description

This PR optimises pre-build time of Gesture Handler android, taking it down from ~7s to ~0.6s, a 11x improvement.

- baseline:
  - time 6.776s ([link](https://gradle.com/s/h5iselfgzhafi))
  - time 7.391s ([link](https://scans.gradle.com/s/6sz4ssuepvema))
- optimised:
  - time 0.687s ([link](https://gradle.com/s/zwiujfjblp64s))
  - time 0.560s ([link](https://gradle.com/s/i5xqega7pazja))
  - time 0.596s ([link](https://gradle.com/s/ohcnspquhmau4))

fixes: #2865

Optimisation of the `example` app pre-build time will be done in a separate PR, 
so far i took it down from 13s to 0.1s (caching & on-demand building).

## Test plan

- Run `./gradlew help --scan` to see pre-build performance
- Build app to see everything still works
