### PR TITLE
Fix composed types

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/relations/useComposedGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/relations/useComposedGesture.ts
@@ -4,7 +4,7 @@ import {
   TouchEvent,
   ComposedGesture,
   ComposedGestureName,
-  Gesture,
+  AnyGesture,
 } from '../../types';
 import { tagMessage } from '../../../utils';
 import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
@@ -13,7 +13,7 @@ import { containsDuplicates, isComposedGesture } from '../utils/relationUtils';
 // TODO: Simplify repeated relations (Simultaneous with Simultaneous, Exclusive with Exclusive, etc.)
 export function useComposedGesture(
   type: ComposedGestureName,
-  ...gestures: Gesture[]
+  ...gestures: AnyGesture[]
 ): ComposedGesture {
   const tags = gestures.flatMap((gesture) =>
     isComposedGesture(gesture) ? gesture.tags : gesture.tag

--- a/packages/react-native-gesture-handler/src/v3/hooks/relations/useExclusive.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/relations/useExclusive.ts
@@ -1,7 +1,7 @@
-import { ComposedGestureName, Gesture } from '../../types';
+import { AnyGesture, ComposedGestureName } from '../../types';
 import { useComposedGesture } from './useComposedGesture';
 
-export function useExclusive(...gestures: Gesture[]) {
+export function useExclusive(...gestures: AnyGesture[]) {
   const composedGesture = useComposedGesture(
     ComposedGestureName.Exclusive,
     ...gestures

--- a/packages/react-native-gesture-handler/src/v3/hooks/relations/useRace.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/relations/useRace.ts
@@ -1,6 +1,6 @@
-import { ComposedGestureName, Gesture } from '../../types';
+import { AnyGesture, ComposedGestureName } from '../../types';
 import { useComposedGesture } from './useComposedGesture';
 
-export function useRace(...gestures: Gesture[]) {
+export function useRace(...gestures: AnyGesture[]) {
   return useComposedGesture(ComposedGestureName.Race, ...gestures);
 }

--- a/packages/react-native-gesture-handler/src/v3/hooks/relations/useSimultaneous.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/relations/useSimultaneous.ts
@@ -1,7 +1,7 @@
-import { ComposedGestureName, Gesture } from '../../types';
+import { AnyGesture, ComposedGestureName } from '../../types';
 import { useComposedGesture } from './useComposedGesture';
 
-export function useSimultaneous(...gestures: Gesture[]) {
+export function useSimultaneous(...gestures: AnyGesture[]) {
   const composedGesture = useComposedGesture(
     ComposedGestureName.Simultaneous,
     ...gestures

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/relationUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/relationUtils.ts
@@ -6,7 +6,7 @@ import {
 } from '../../types';
 
 export function isComposedGesture<THandlerData, TConfig>(
-  gesture: Gesture<THandlerData, TConfig>
+  gesture: Gesture<THandlerData, TConfig> | ComposedGesture
 ): gesture is ComposedGesture {
   return 'tags' in gesture;
 }

--- a/packages/react-native-gesture-handler/src/v3/types.ts
+++ b/packages/react-native-gesture-handler/src/v3/types.ts
@@ -142,6 +142,9 @@ export type Gesture<THandlerData = unknown, TConfig = unknown> =
   | SingleGesture<THandlerData, TConfig>
   | ComposedGesture;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyGesture = Gesture<any, unknown>;
+
 interface ExternalRelations {
   simultaneousWithExternalGesture?: Gesture | Gesture[];
   requireExternalGestureToFail?: Gesture | Gesture[];


### PR DESCRIPTION
## Description

I've noticed that typescript throws error when using composed gestures. This PR fixes this problem.

> [!NOTE]
> We decided that it is not worth to spend much time on changing those types, as the only thing that composition does is merging gestures into one object.

## Test plan

<details>
<summary>Tested on the following example:</summary>

```tsx
import * as React from 'react';
import { SafeAreaView, Platform, View } from 'react-native';
import {
  GestureHandlerRootView,
  usePan,
  useSimultaneous,
  useTap,
  NativeDetector,
} from 'react-native-gesture-handler';

export default function App() {
  const pan = usePan({
    onUpdate: (_e) => {
      console.log('pan');
    },
  });

  const tap = useTap({});

  const g = useSimultaneous(pan, tap);

  return (
    <GestureHandlerRootView style={{ flex: 1 }}>
      <SafeAreaView
        style={[{ flex: 1 }, Platform.OS === 'android' && { paddingTop: 50 }]}>
        <NativeDetector gesture={g}>
          <View />
        </NativeDetector>
      </SafeAreaView>
    </GestureHandlerRootView>
  );
}
```

</details>