### PR TITLE
Do not use `handleGestureEvent` for `Animated.Event`

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/NativeDetector/NativeDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/NativeDetector/NativeDetector.tsx
@@ -135,9 +135,9 @@ export function NativeDetector<THandlerData, TConfig>({
         // @ts-ignore This is a type mismatch between RNGH types and RN Codegen types
         onGestureHandlerEvent={handleGestureEvent('onGestureHandlerEvent')}
         // @ts-ignore This is a type mismatch between RNGH types and RN Codegen types
-        onGestureHandlerAnimatedEvent={handleGestureEvent(
-          'onGestureHandlerAnimatedEvent'
-        )}
+        onGestureHandlerAnimatedEvent={
+          gesture.gestureEvents.onGestureHandlerAnimatedEvent
+        }
         // @ts-ignore This is a type mismatch between RNGH types and RN Codegen types
         onGestureHandlerTouchEvent={handleGestureEvent(
           'onGestureHandlerTouchEvent'


### PR DESCRIPTION
## Description

This PR removes `handleGestureEvent` from `onGestureHandlerAnimatedEvent`. This function was trying to call `Animated.Event`, which is not possible since it is an object. This takes out part of `LogicDetector` logic, however it didn't work anyway and at least standard `NativeDetector` works as it should.

> [!NOTE]
> It was previously a part of #3745

## Test plan

Tested on current `basic-example`