### PR TITLE
Bump `node` on CI

### DIFF
--- a/.github/workflows/android-build-paper.yml
+++ b/.github/workflows/android-build-paper.yml
@@ -31,10 +31,10 @@ jobs:
           distribution: oracle
           java-version: 17
 
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: yarn
 
       - name: Install node dependencies

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -33,10 +33,10 @@ jobs:
           distribution: oracle
           java-version: 17
 
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: yarn
 
       - name: Install node dependencies

--- a/.github/workflows/check-archs-consistency.yml
+++ b/.github/workflows/check-archs-consistency.yml
@@ -27,10 +27,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: yarn
 
       - name: Install node dependencies

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -21,10 +21,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: yarn
 
       - name: Install node dependencies

--- a/.github/workflows/ios-build-paper.yml
+++ b/.github/workflows/ios-build-paper.yml
@@ -31,10 +31,10 @@ jobs:
         with:
           xcode-version: '16.1'
 
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: yarn
 
       - name: Install node dependencies

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           xcode-version: '16.1'
 
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: yarn
 
       - name: Install node dependencies

--- a/.github/workflows/kotlin-lint.yml
+++ b/.github/workflows/kotlin-lint.yml
@@ -30,10 +30,10 @@ jobs:
           distribution: oracle
           java-version: 17
 
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: yarn
 
       - uses: actions/cache@v4

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: yarn

--- a/.github/workflows/static-example-apps-checks.yml
+++ b/.github/workflows/static-example-apps-checks.yml
@@ -26,10 +26,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: yarn
 
       - name: Install node dependencies

--- a/.github/workflows/static-root-checks.yml
+++ b/.github/workflows/static-root-checks.yml
@@ -23,10 +23,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: yarn
 
       - name: Install node dependencies

--- a/.github/workflows/yarn-validation.yml
+++ b/.github/workflows/yarn-validation.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
 
       - name: Install root dependencies
         run: yarn install


### PR DESCRIPTION
## Description

`node` versions in our workflows were quite outdated, this PR bumps them from `18` to `24`

## Test plan

Check CIs