### PR TITLE
fixed reanimated handlers

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/reanimatedUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/reanimatedUtils.ts
@@ -1,6 +1,11 @@
 import RNGestureHandlerModule from '../../../RNGestureHandlerModule';
 import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
-import { BaseGestureConfig, SharedValue, SharedValueOrT } from '../../types';
+import {
+  BaseGestureConfig,
+  GestureCallbacks,
+  SharedValue,
+  SharedValueOrT,
+} from '../../types';
 import { HandlerCallbacks } from './propsWhiteList';
 
 // Variant of djb2 hash function.
@@ -87,13 +92,13 @@ export function unbindSharedValues<THandlerData, TConfig>(
 export function hasWorkletEventHandlers<THandlerData, TConfig>(
   config: BaseGestureConfig<THandlerData, TConfig>
 ) {
-  return Object.entries(config).some(
-    (key, value) =>
-      (key as keyof BaseGestureConfig<THandlerData, TConfig>) in
-        HandlerCallbacks &&
+  return Object.entries(config).some(([key, value]) => {
+    return (
+      HandlerCallbacks.has(key as keyof GestureCallbacks<unknown>) &&
       typeof value === 'function' &&
       '__workletHash' in value
-  );
+    );
+  });
 }
 
 export function maybeUnpackValue<T>(v: SharedValueOrT<T>) {


### PR DESCRIPTION
## Description

After recent changes `hasWorkletEventHandlers` function was broken, it alwasy returned false, as `HandlerCallbacks` is a set so we have to check with `.has` not `is` operator.

Without this `LogicDetector` will throw weird errors as  `gesture.config.shouldUseReanimatedDetector` is always false.

_Note: I still have to check whether this change did not break anything else
## Test plan

Check whether `NativeDetector` with a reanimated `LogicDetector` underneath loads on iOS.
