### PR TITLE
Fix `hasWorkletEventHandlers`

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/reanimatedUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/reanimatedUtils.ts
@@ -1,6 +1,11 @@
 import RNGestureHandlerModule from '../../../RNGestureHandlerModule';
 import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
-import { BaseGestureConfig, SharedValue, SharedValueOrT } from '../../types';
+import {
+  BaseGestureConfig,
+  GestureCallbacks,
+  SharedValue,
+  SharedValueOrT,
+} from '../../types';
 import { HandlerCallbacks } from './propsWhiteList';
 
 // Variant of djb2 hash function.
@@ -88,9 +93,8 @@ export function hasWorkletEventHandlers<THandlerData, TConfig>(
   config: BaseGestureConfig<THandlerData, TConfig>
 ) {
   return Object.entries(config).some(
-    (key, value) =>
-      (key as keyof BaseGestureConfig<THandlerData, TConfig>) in
-        HandlerCallbacks &&
+    ([key, value]) =>
+      HandlerCallbacks.has(key as keyof GestureCallbacks<unknown>) &&
       typeof value === 'function' &&
       '__workletHash' in value
   );


### PR DESCRIPTION
## Description

This PR fixes incorrect implementation of `hasWorkletEventHandlers` function. Namely:

1. Changes `in` to `has`, as `in` cannot be used to check if `Set` contains given element;
2. Correctly wraps `some` parameter into `[]` - earlier `value` was actually an index.

This problems resulted in callbacks being run on `JS`, even when they should be run on `UI`.

## Test plan

<details>
<summary>Tested on the following code:</summary>

```tsx
import * as React from 'react';
import { Animated, Button } from 'react-native';
import {
  GestureHandlerRootView,
  NativeDetector,
  usePan,
} from 'react-native-gesture-handler';
import { getRuntimeKind } from 'react-native-worklets';

export default function App() {
  const [visible, setVisible] = React.useState(true);

  const gesture = usePan({
    onUpdate: () => {
      'worklet';
      console.log(getRuntimeKind());
    },
  });

  return (
    <GestureHandlerRootView
      style={{ flex: 1, backgroundColor: 'white', paddingTop: 8 }}>
      <Button
        title="Toggle visibility"
        onPress={() => {
          setVisible(!visible);
        }}
      />

      {visible && (
        <NativeDetector gesture={gesture}>
          <Animated.View
            style={[
              {
                width: 150,
                height: 150,
                backgroundColor: 'blue',
                opacity: 0.5,
                borderWidth: 10,
                borderColor: 'green',
                marginTop: 20,
                marginLeft: 40,
              },
            ]}
          />
        </NativeDetector>
      )}
    </GestureHandlerRootView>
  );
}
```

</details>
