### PR TITLE
Add workflow for releases

### DIFF
--- a/.github/workflows/npm-gesture-handler-publish.yml
+++ b/.github/workflows/npm-gesture-handler-publish.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Assert PACKAGE_NAME
         if: ${{ env.PACKAGE_NAME == 'PLACEHOLDER' }}
-        run: exit 1 # This should never happen.
+        run: exit 1 # If we end up here, it means that package was not generated.
 
       - name: Upload npm package to GitHub
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

This PR adds workflow that will publish new versions of **Gesture Handler**  to `npm`. This is similar to [react-native-screens CI](https://github.com/software-mansion/react-native-screens/blob/15f83cf00b2d46c17c8e0f4c157c76f10bb57d53/.github/workflows/npm-screens-publish-nightly.yml), but this one will publish stable releases. 

> [!NOTE]
> We will dive deeper and check how to make this CI publish both, nightly and stable releases. For now we need this for stable release, so we want to make sure it works without any problems.

## Test plan

Downloaded artifact from CI.