### PR TITLE
Add working directory to publish workflow

### DIFF
--- a/.github/workflows/npm-gesture-handler-publish.yml
+++ b/.github/workflows/npm-gesture-handler-publish.yml
@@ -51,4 +51,5 @@ jobs:
           path: './packages/react-native-gesture-handler/${{ env.PACKAGE_NAME }}'
 
       - name: Publish npm package
+        working-directory: packages/react-native-gesture-handler
         run: npm publish $PACKAGE_NAME --provenance


### PR DESCRIPTION
## Description

Seems like workflow for publishing package lacks `working-directory`

## Test plan

🚀🚀🚀