### PR TITLE
Reattach gestures when the Detector moves back to the window on iOS

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
@@ -62,6 +62,13 @@
       }
     }
     _attachedLogicHandlers.clear();
+    _attachedHandlers = [NSMutableSet set];
+  } else {
+    const auto &props = *std::static_pointer_cast<const RNGestureHandlerDetectorProps>(_props);
+    [self attachHandlers:props.handlerTags
+              actionType:RNGestureHandlerActionTypeNativeDetector
+                 viewTag:-1
+        attachedHandlers:_attachedHandlers];
   }
 }
 


### PR DESCRIPTION
## Description

Currently, inside `willMoveToWindow`, all handlers are detached from the detector view when it moves out of the window, but then they are never reattached when it moves back. This PR adds the second case and reattaches gestures.

## Test plan

Test the native detector on the basic example app
