### PR TITLE
Clean callbacks when unregistering gesture

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/LogicDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/LogicDetector.tsx
@@ -39,21 +39,13 @@ export function LogicDetector<THandlerData, TConfig>(
       return;
     }
 
-    // Native Detector differentiates Logic Children through a viewTag,
-    // thus if viewTag changes we have to reregister
-    unregister(viewTag);
-  }, [viewTag]);
-
-  useEffect(() => {
-    if (viewTag === -1) {
-      return;
-    }
+    const handlerTags = isComposedGesture(props.gesture)
+      ? props.gesture.tags
+      : [props.gesture.tag];
 
     const logicProps = {
       viewTag,
-      handlerTags: isComposedGesture(props.gesture)
-        ? props.gesture.tags
-        : [props.gesture.tag],
+      handlerTags,
     };
 
     if (Platform.OS === 'web') {
@@ -63,7 +55,7 @@ export function LogicDetector<THandlerData, TConfig>(
     register(logicProps, logicMethods as RefObject<DetectorCallbacks<unknown>>);
 
     return () => {
-      unregister(viewTag);
+      unregister(viewTag, handlerTags);
     };
   }, [viewTag, props.gesture, register, unregister]);
 

--- a/packages/react-native-gesture-handler/src/v3/NativeDetector/NativeDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/NativeDetector/NativeDetector.tsx
@@ -59,7 +59,11 @@ export function NativeDetector<THandlerData, TConfig>({
     []
   );
 
-  const unregister = useCallback((childTag: number) => {
+  const unregister = useCallback((childTag: number, handlerTags: number[]) => {
+    handlerTags.forEach((tag) => {
+      logicMethods.current.delete(tag);
+    });
+
     setLogicChildren((prev) => prev.filter((c) => c.viewTag !== childTag));
   }, []);
 

--- a/packages/react-native-gesture-handler/src/v3/NativeDetector/useDetectorContext.ts
+++ b/packages/react-native-gesture-handler/src/v3/NativeDetector/useDetectorContext.ts
@@ -1,4 +1,4 @@
-import { createContext, RefObject, useContext } from 'react';
+import { createContext, RefObject, use } from 'react';
 import { DetectorCallbacks, LogicChildren } from '../types';
 
 type DetectorContextType = {
@@ -6,13 +6,13 @@ type DetectorContextType = {
     child: LogicChildren,
     methods: RefObject<DetectorCallbacks<unknown>>
   ) => void;
-  unregister: (child: number) => void;
+  unregister: (child: number, handlerTags: number[]) => void;
 };
 
 export const DetectorContext = createContext<DetectorContextType | null>(null);
 
 export function useDetectorContext() {
-  const ctx = useContext(DetectorContext);
+  const ctx = use(DetectorContext);
   if (!ctx) {
     throw new Error('Logic detector must be a descendant of a Native Detector');
   }


### PR DESCRIPTION
## Description

When using LogicDetector, NativeDetector never cleared the ref to the methods defined there, firing every version of the callback that was ever created for a given view. This PR should fix it.

It also removes the redundant `useEffect` with only `viewTag` in its dependency array - the other one also includes `viewTag` and unregisters in the `cleanup`.

## Test plan

Uncomment/comment the `onBegin` part of the code and inspect the `logicMethods` ref in the `NativeDetector`. Before this PR it was never cleared, after this PR, it should be cleared.

```jsx
  const tapAll = useTap({
    // onBegin: () => {
    //   'worklet';
    // },
    onStart: () => {
      'worklet';
      console.log('Tapped anywhere!');
    },
  });

  const tapFirstPart = useTap({
    onStart: () => {
      'worklet';
      console.log('Tapped on first part!');
    },
  });

  return (
    <View style={styles.container}>
      <NativeDetector gesture={tapAll}>
        <Text style={{ fontSize: 18, textAlign: 'center' }}>
          Some text example running with RNGH
          <LogicDetector gesture={tapFirstPart}>
            <Text style={{ fontSize: 24, color: COLORS.NAVY }}>
              {' '}
              try tapping on this part
            </Text>
          </LogicDetector>
        </Text>
      </NativeDetector>
    </View>
  );
```
