### PR TITLE
[General] Fix `DiagonalDirections` type

### DIFF
--- a/packages/react-native-gesture-handler/src/Directions.ts
+++ b/packages/react-native-gesture-handler/src/Directions.ts
@@ -12,10 +12,10 @@ const DOWN_LEFT = 10; // DOWN | LEFT
 
 // Public interface
 export const Directions = {
-  RIGHT: RIGHT,
-  LEFT: LEFT,
-  UP: UP,
-  DOWN: DOWN,
+  RIGHT,
+  LEFT,
+  UP,
+  DOWN,
 } as const;
 
 // Internal interface


### PR DESCRIPTION
## Description

It seems like TypeScript isn't treating an expression where every node is `const` as `const`:

```ts
const a = 1; // a: 1
const b = 2; // b: 2
const c = a + b; // c: number
```

This caused `DiagonalDirections` type to be a number instead of a union of consts.

## Test plan

Check the inferred type of `DiagonalDirections`
