### PR TITLE
chore: fix typos in docs for force touch gesture

### DIFF
--- a/packages/docs-gesture-handler/docs/gestures/force-touch-gesture.md
+++ b/packages/docs-gesture-handler/docs/gestures/force-touch-gesture.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 ---
 
 :::warning
-ForceTouch gesture is depracted and will be removed in the future version of Gesture Handler.
+ForceTouch gesture is deprecated and will be removed in the future version of Gesture Handler.
 :::
 
 import BaseEventData from './\_shared/base-gesture-event-data.md';
@@ -16,7 +16,7 @@ import BaseEventCallbacks from './\_shared/base-gesture-callbacks.md';
 import BaseContinuousEventCallbacks from './\_shared/base-continuous-gesture-callbacks.md';
 
 A continuous gesture that recognizes force of a touch. It allows for tracking pressure of touch on some iOS devices.
-The gesture [activates](/docs/fundamentals/states-events#active) when pressure of touch if greater or equal than `minForce`. It fails if pressure is greater than `maxForce`
+The gesture [activates](/docs/fundamentals/states-events#active) when pressure of touch is greater than or equal to `minForce`. It fails if pressure is greater than `maxForce`.
 Gesture callback can be used for continuous tracking of the touch pressure. It provides information for one finger (the first one).
 
 At the beginning of the gesture, the pressure factor is 0.0. As the pressure increases, the pressure factor increases proportionally. The maximum pressure is 1.0.


### PR DESCRIPTION
## Description

Noticed a couple typos in the docs for Force Touch Gesture, so created a small PR

<img width="965" height="566" alt="image" src="https://github.com/user-attachments/assets/658f0e20-d40f-4320-80b2-caf549b74642" />


<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan
- Not applicable
<!--
Describe how did you test this change here.
-->
