### PR TITLE
Remove incorrectly passed `gestureEvents`

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/detectors/NativeDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/NativeDetector.tsx
@@ -29,7 +29,7 @@ export function NativeDetector<THandlerData, TConfig>({
         gesture.detectorCallbacks.onGestureHandlerStateChange
       }
       // @ts-ignore This is a type mismatch between RNGH types and RN Codegen types
-      onGestureHandlerEvent={gesture.gestureEvents.onGestureHandlerEvent}
+      onGestureHandlerEvent={gesture.detectorCallbacks.onGestureHandlerEvent}
       // @ts-ignore This is a type mismatch between RNGH types and RN Codegen types
       onGestureHandlerTouchEvent={
         gesture.detectorCallbacks.onGestureHandlerTouchEvent


### PR DESCRIPTION
## Description

After #3732 using new API results in a crash, as there's no longer `gestureEvents` field defined on `Gesture` type.

<img width="689" height="41" alt="image" src="https://github.com/user-attachments/assets/b7e5bc87-f783-41c9-be91-61dd235384d8" />

This PR fixes this behavior.

## Test plan

<details>
<summary>Tested on the following example:</summary>

```tsx
import React from 'react';
import { StyleSheet, View } from 'react-native';
import {
  GestureDetector,
  GestureHandlerRootView,
  usePan,
} from 'react-native-gesture-handler';

export default function EmptyExample() {
  const pan = usePan({});

  return (
    <GestureHandlerRootView style={styles.container}>
      <GestureDetector gesture={pan}>
        <View style={{ width: 300, height: 300, backgroundColor: 'green' }} />
      </GestureDetector>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
});
```

</details>
