### PR TITLE
[Web] Fixed `Accessing element.ref was removed in React 19` error

### DIFF
--- a/packages/react-native-gesture-handler/src/web/utils.ts
+++ b/packages/react-native-gesture-handler/src/web/utils.ts
@@ -282,7 +282,7 @@ export function isRNSVGElement(viewRef: SVGRef | GestureHandlerRef) {
 export function isRNSVGNode(node: any) {
   // If `ref` has `rngh` field, it means that component comes from Gesture Handler. This is a special case for
   // `Text` component, which is present in `RNSVGElements` set, yet we don't want to treat it as SVG.
-  if (node.ref?.rngh) {
+  if (node.props.ref?.rngh) {
     return false;
   }
 


### PR DESCRIPTION
## Description

Since version 19, React doesn't allow direct access to ref from an element. 
This error occurs when using React Native Gesture Handler on web.

## Test plan

Tested my fix in my web project and error in console disappears.
