### PR TITLE
Hide incorrectly exposed `ReanimatedSwipeable` props.

### DIFF
--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
@@ -501,6 +501,7 @@ const Swipeable = (props: SwipeableProps) => {
   const panGesture = useMemo(() => {
     const pan = Gesture.Pan()
       .enabled(enabled !== false)
+      .hitSlop(hitSlop)
       .enableTrackpadTwoFingerGesture(enableTrackpadTwoFingerGesture)
       .activeOffsetX([-dragOffsetFromRightEdge, dragOffsetFromLeftEdge])
       .onStart(updateElementWidths)
@@ -547,6 +548,7 @@ const Swipeable = (props: SwipeableProps) => {
     return pan;
   }, [
     enabled,
+    hitSlop,
     enableTrackpadTwoFingerGesture,
     dragOffsetFromRightEdge,
     dragOffsetFromLeftEdge,
@@ -576,7 +578,6 @@ const Swipeable = (props: SwipeableProps) => {
       <Animated.View
         {...remainingProps}
         onLayout={onRowLayout}
-        hitSlop={hitSlop ?? undefined}
         style={[styles.container, containerStyle]}>
         {leftElement()}
         {rightElement()}

--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeableProps.ts
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeableProps.ts
@@ -16,22 +16,22 @@ export interface SwipeableProps {
   ref?: React.RefObject<SwipeableMethods | null>;
 
   /**
-   *
+   * Sets a `testID` property, allowing for querying `ReanimatedSwipeable` for it in tests.
    */
   testID?: string;
 
-  /**
-   *
-   */
   children?: React.ReactNode;
 
   /**
-   *
+   * Indicates whether `ReanimatedSwipeable` should be analyzing stream of touch events or not.
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture#enabledvalue-boolean
    */
   enabled?: boolean;
 
   /**
-   *
+   * This parameter enables control over what part of the connected view area can be used to begin recognizing the gesture.
+   * When a negative number is provided the bounds of the view will reduce the area by the given number of points in each of the sides evenly.
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture#hitslopsettings
    */
   hitSlop?: HitSlop;
 


### PR DESCRIPTION
## Description

As stated in [this comment](https://github.com/software-mansion/react-native-gesture-handler/issues/3670#issuecomment-3179955589), some of the `ReanimatedSwipeable` props were incorrectly exposed. Most of them came from `BaseGestureHandlerProps`, but were not actually used in the implementation. 

I've updated `SwipeableProps` type to include only those that were actually used.

I've also moved `hitSlop` from `Animated.View` to `Pan` gesture - it seems that it worked on `iOS`, but not on `android`.

Closes #3670 

## Test plan

Tested on the **"Swipeable reanimation"** example with `hitSlop={-20}` added.