### PR TITLE
Add `null` to `GestureRef` type

### DIFF
--- a/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
@@ -367,7 +367,9 @@ export abstract class BaseGesture<
    */
   requireExternalGestureToFail(...gestures: Exclude<GestureRef, number>[]) {
     for (const gesture of gestures) {
-      this.addDependency('requireToFail', gesture);
+      if (gesture) {
+        this.addDependency('requireToFail', gesture);
+      }
     }
     return this;
   }
@@ -379,7 +381,9 @@ export abstract class BaseGesture<
    */
   blocksExternalGesture(...gestures: Exclude<GestureRef, number>[]) {
     for (const gesture of gestures) {
-      this.addDependency('blocksHandlers', gesture);
+      if (gesture) {
+        this.addDependency('blocksHandlers', gesture);
+      }
     }
     return this;
   }


### PR DESCRIPTION
## Description

Since React 19, `useRef` requires initial value. In that case `null` is common value, but unfortunately our types do not handle that case. This PR fixes this problem.

## Test plan

`yarn ts-check`

<details>
<summary>Also tested on the following code:</summary>

```tsx
import React, { useRef } from 'react';
import {
  View,
  Text,
  StyleSheet,
  // ScrollView as RNScrollView,
} from 'react-native';
import {
  Gesture,
  GestureDetector,
  GestureHandlerRootView,
  ScrollView as GHScrollView,
} from 'react-native-gesture-handler';

const App = () => {
  const scrollRef = useRef<GHScrollView>(null);

  const swipe = Gesture.Pan()
    .simultaneousWithExternalGesture(scrollRef)
    .onUpdate((e) => {
      console.log(e);
    })
    .onFinalize((e, s) => {
      console.log(e, s);
    })
    .onEnd(() => {});

  return (
    <GestureHandlerRootView style={{ flex: 1 }}>
      <GestureDetector gesture={swipe}>
        <View style={styles.container}>
          <GHScrollView
            horizontal
            ref={scrollRef}
            style={{ marginTop: 24, maxHeight: 60 }}
            contentContainerStyle={{
              alignItems: 'center',
              paddingHorizontal: 16,
            }}
            showsHorizontalScrollIndicator={false}>
            {Array.from({ length: 10 }).map((_, idx) => (
              <View
                key={idx}
                style={{
                  width: 80,
                  height: 40,
                  backgroundColor: '#e0e0e0',
                  borderRadius: 8,
                  justifyContent: 'center',
                  alignItems: 'center',
                  marginRight: 12,
                }}>
                <Text>Item {idx + 1}</Text>
              </View>
            ))}
          </GHScrollView>
        </View>
      </GestureDetector>
    </GestureHandlerRootView>
  );
};

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#fff',
  },
  text: {
    fontSize: 18,
    color: '#333',
  },
});

export default App;
```

</details>
