### PR TITLE
[Android][iOS] Don't handle events on the detector surface

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorViewManager.kt
@@ -2,6 +2,7 @@ package com.swmansion.gesturehandler.react
 
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.PointerEvents.Companion.parsePointerEvents
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.ViewManagerDelegate
@@ -44,5 +45,9 @@ class RNGestureHandlerDetectorViewManager :
   override fun onDropViewInstance(view: RNGestureHandlerDetectorView) {
     view.onViewDrop()
     super.onDropViewInstance(view)
+  }
+
+  override fun setPointerEvents(view: RNGestureHandlerDetectorView, pointerEventsStr: String?) {
+    view.pointerEvents = parsePointerEvents(pointerEventsStr)
   }
 }

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerDetectorNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerDetectorNativeComponent.ts
@@ -4,6 +4,7 @@ import type {
   DirectEventHandler,
   UnsafeMixed,
   Double,
+  WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
 import type { ViewProps } from 'react-native';
 
@@ -47,6 +48,8 @@ export interface VirtualChildrenProps {
   viewTag: Int32;
 }
 
+// @ts-expect-error WithDefault adds `| null` to the type, which doesn't align with ViewProps.pointerEvents
+// Using Exclude to remove null from the type makes the error go away, but breaks codegen.
 export interface NativeProps extends ViewProps {
   onGestureHandlerEvent?: DirectEventHandler<GestureHandlerEvent>;
   onGestureHandlerStateChange?: DirectEventHandler<GestureHandlerStateChangeEvent>;
@@ -59,6 +62,11 @@ export interface NativeProps extends ViewProps {
   handlerTags: Int32[];
   moduleId: Int32;
   virtualChildren: VirtualChildrenProps[];
+
+  pointerEvents?: WithDefault<
+    'box-none' | 'none' | 'box-only' | 'auto',
+    'auto'
+  >;
 }
 
 export default codegenNativeComponent<NativeProps>('RNGestureHandlerDetector', {

--- a/packages/react-native-gesture-handler/src/v3/detectors/NativeDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/NativeDetector.tsx
@@ -28,6 +28,7 @@ export function NativeDetector<THandlerData, TConfig>({
 
   return (
     <NativeDetectorComponent
+      pointerEvents={'box-none'}
       // @ts-ignore This is a type mismatch between RNGH types and RN Codegen types
       onGestureHandlerStateChange={
         gesture.detectorCallbacks.onGestureHandlerStateChange

--- a/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/InterceptingGestureDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/InterceptingGestureDetector.tsx
@@ -207,6 +207,7 @@ export function InterceptingGestureDetector<THandlerData, TConfig>({
   return (
     <InterceptingDetectorContext value={contextValue}>
       <NativeDetectorComponent
+        pointerEvents={'box-none'}
         // @ts-ignore This is a type mismatch between RNGH types and RN Codegen types
         onGestureHandlerStateChange={useMemo(
           () => createGestureEventHandler('onGestureHandlerStateChange'),


### PR DESCRIPTION
## Description

Prevents `NativeDetector` from reacting to events that happen on its surface but not on any of its children. This should match the behavior from the V2 API, and feels more like an "expected" result.

This doesn't affect the web since `display: contents` there isn't subject to our hacks and the detector doesn't create a box. The behavior after this PR should be consistent across the platforms.

Since codegen is not perfect, to put it lightly, I had to redeclare `pointerEvents` in the spec and handle the setter on Android. The only base class that does it automatically is `ReactViewManager`, but we need to create a `ViewGroup` to accept children.

## Test plan

|-|Android|iOS|
|-|-|-|
|Before|<video src='https://github.com/user-attachments/assets/d936d480-ab94-4d6c-803a-1ea06c7b3fa0' />|<video src='https://github.com/user-attachments/assets/e7bf9560-1a6e-4c66-8528-523108655ea4' />|
|After|<video src='https://github.com/user-attachments/assets/cfa6aa95-2392-4d1c-a0c5-75d3c751b2b7' />|<video src='https://github.com/user-attachments/assets/4f45bc6d-3699-4293-8ad1-c8b8426d28a5' />|








