### PR TITLE
[General] Make `InterceptingGestureDetector` throw when not rendered under GHRootView

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/detectors/GestureDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/GestureDetector.tsx
@@ -6,21 +6,12 @@ import {
   GestureDetectorProps as LegacyGestureDetectorProps,
   GestureDetector as LegacyGestureDetector,
 } from '../../handlers/gestures/GestureDetector';
-import { use } from 'react';
-import { isTestEnv } from '../../utils';
-import { Platform } from 'react-native';
-import GestureHandlerRootViewContext from '../../GestureHandlerRootViewContext';
+import { useEnsureGestureHandlerRootView } from './useEnsureGestureHandlerRootView';
 
 export function GestureDetector<THandlerData, TConfig>(
   props: NativeDetectorProps<THandlerData, TConfig> | LegacyGestureDetectorProps
 ) {
-  const rootViewContext = use(GestureHandlerRootViewContext);
-
-  if (__DEV__ && !rootViewContext && !isTestEnv() && Platform.OS !== 'web') {
-    throw new Error(
-      'GestureDetector must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized. See https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation for more details.'
-    );
-  }
+  useEnsureGestureHandlerRootView();
 
   if (
     props.gesture instanceof ComposedGesture ||

--- a/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/InterceptingGestureDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/InterceptingGestureDetector.tsx
@@ -20,6 +20,7 @@ import {
   ReanimatedNativeDetector,
 } from '../common';
 import { tagMessage } from '../../../utils';
+import { useEnsureGestureHandlerRootView } from '../useEnsureGestureHandlerRootView';
 
 interface VirtualChildrenForNative {
   viewTag: number;
@@ -31,6 +32,8 @@ export function InterceptingGestureDetector<THandlerData, TConfig>({
   gesture,
   children,
 }: InterceptingGestureDetectorProps<THandlerData, TConfig>) {
+  useEnsureGestureHandlerRootView();
+
   const [virtualChildren, setVirtualChildren] = useState<Set<VirtualChild>>(
     () => new Set()
   );

--- a/packages/react-native-gesture-handler/src/v3/detectors/useEnsureGestureHandlerRootView.ts
+++ b/packages/react-native-gesture-handler/src/v3/detectors/useEnsureGestureHandlerRootView.ts
@@ -1,0 +1,14 @@
+import { use } from 'react';
+import { isTestEnv } from '../../utils';
+import { Platform } from 'react-native';
+import GestureHandlerRootViewContext from '../../GestureHandlerRootViewContext';
+
+export function useEnsureGestureHandlerRootView() {
+  const rootViewContext = use(GestureHandlerRootViewContext);
+
+  if (__DEV__ && !rootViewContext && !isTestEnv() && Platform.OS !== 'web') {
+    throw new Error(
+      'GestureDetector must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized. See https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation for more details.'
+    );
+  }
+}


### PR DESCRIPTION
## Description

Makes `InterceptingGestureDetector` throw when not rendered underneath `GestureHandlerRootView`, the same as the normal `GestureDetector` does.

## Test plan

Render `InterceptingGestureDetector` without root view
