### PR TITLE
ReanimatedDrawerLayout: fix buttons not receiving onPress

### DIFF
--- a/packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx
@@ -500,6 +500,7 @@ const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
     const overlayDismissGesture = useMemo(
       () =>
         Gesture.Tap()
+          .enabled(drawerOpened)
           .maxDistance(25)
           .onEnd(() => {
             if (
@@ -509,7 +510,7 @@ const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
               closeDrawer();
             }
           }),
-      [closeDrawer, isDrawerOpen, drawerLockMode]
+      [closeDrawer, isDrawerOpen, drawerLockMode, drawerOpened]
     );
 
     const overlayAnimatedStyle = useAnimatedStyle(() => ({


### PR DESCRIPTION
## Description

When using ReanimatedDrawerLayout, none of the react-native-gesture-handler buttons respond to taps because of the `overlayDismissGesture`. The gesture is activated even when the Drawer is closed. 

By passing in `drawerOpened`, a state variable already enabled into `overlayDismissGesture` the problem is fixed and the drawer continues working as-is.

## Test plan

In my own app, I added `drawerOpened` into `overlayDismissGesture` and was able to successfully fix the problem. 