### PR TITLE
[Web] Fix press out

### DIFF
--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -307,8 +307,8 @@ const Pressable = (props: PressableProps) => {
         })
         .onFinalize((_event, success) => {
           if (Platform.OS !== 'web') {
-            // On Web we use Tap().onFinalize() instead of Native().onFinalize(),
-            // as Native cancels on mouse move, and Tap does not.
+            // On Web we use LongPress().onFinalize() instead of Native().onFinalize(),
+            // as Native cancels on mouse move, and LongPress does not.
             if (success) {
               stateMachine.handleEvent(StateMachineEvent.FINALIZE);
             } else {


### PR DESCRIPTION
## Description

After https://github.com/software-mansion/react-native-gesture-handler/pull/3678/ pressables `onPressOut` did not work on web. This PR fixes the issue. That PR added a check whether gesture has succeded or not. Because on web, native gestures fail on mouse move, the finalise was handled by LongPress.finalize, but the LongPress has minDuration set to INT_32 max so it never ends succesfully. This creates new tap gesture that which handles finalise on web.

## Test plan

Tested on the following example
```tsx
import { View } from 'react-native'
import { GestureHandlerRootView, Pressable, ScrollView } from 'react-native-gesture-handler'

export default function Test() {
  return (
    <GestureHandlerRootView >
      <ScrollView style={{ flexGrow: 1, backgroundColor: 'white' }}>
        <View style={{ paddingTop: 200, height: 2000 }}>
          <Pressable
            style={{ width: 30, height: 30, backgroundColor: 'pink' }}
            onPress={() => console.log("pressed")}
          />
        </View>
      </ScrollView>
    </GestureHandlerRootView >
  )
}
```
