### PR TITLE
[Web] Use correct config field for Reanimated flag

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -746,8 +746,8 @@ export default abstract class GestureHandler implements IGestureHandler {
       this.forAnimated = config.dispatchesAnimatedEvents;
     }
 
-    if (config.shouldUseReanimated !== undefined) {
-      this.forReanimated = config.shouldUseReanimated;
+    if (config.dispatchesReanimatedEvents !== undefined) {
+      this.forReanimated = config.dispatchesReanimatedEvents;
     }
 
     if (config.manualActivation !== undefined) {

--- a/packages/react-native-gesture-handler/src/web/interfaces.ts
+++ b/packages/react-native-gesture-handler/src/web/interfaces.ts
@@ -52,7 +52,7 @@ export interface Config extends Record<string, ConfigArgs> {
   touchAction?: TouchAction;
   manualActivation?: boolean;
   dispatchesAnimatedEvents?: false;
-  shouldUseReanimated?: boolean;
+  dispatchesReanimatedEvents?: boolean;
   needsPointerData?: false;
 
   activateAfterLongPress?: number;


### PR DESCRIPTION
## Description

Changes the config field mapped to `forReanimated` on web GestureHandler. `shouldUseReanimated` doesn't exist anymore, and `shouldUseReanimatedDetector` is filtered out from the config.

## Test plan

Verify that `forReanimated` is set correctly
