### PR TITLE
[General] Rename `onStart`/`onEnd` to `onActivate`/`onDeactivate`

### DIFF
--- a/packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx
@@ -501,7 +501,7 @@ const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
 
     const overlayDismissGesture = useTapGesture({
       maxDistance: 25,
-      onEnd: () => {
+      onDeactivate: () => {
         'worklet';
         if (
           isDrawerOpen.value &&
@@ -535,7 +535,7 @@ const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
         (drawerOpened
           ? drawerLockMode !== DrawerLockMode.LOCKED_OPEN
           : drawerLockMode !== DrawerLockMode.LOCKED_CLOSED),
-      onStart: () => {
+      onActivate: () => {
         'worklet';
         emitStateChanged(DrawerState.DRAGGING, false);
         runOnJS(setDrawerState)(DrawerState.DRAGGING);
@@ -577,7 +577,7 @@ const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
           Extrapolation.CLAMP
         );
       },
-      onEnd: handleRelease,
+      onDeactivate: handleRelease,
     });
 
     // When using RTL, row and row-reverse flex directions are flipped.

--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
@@ -460,7 +460,7 @@ const Swipeable = (props: SwipeableProps) => {
     simultaneousWith: simultaneousWithExternalGesture,
     requireToFail: requireExternalGestureToFail,
     block: blocksExternalGesture,
-    onStart: () => {
+    onActivate: () => {
       'worklet';
       if (rowState.value !== 0) {
         close();
@@ -476,7 +476,7 @@ const Swipeable = (props: SwipeableProps) => {
     requireToFail: requireExternalGestureToFail,
     block: blocksExternalGesture,
     hitSlop: hitSlop,
-    onStart: updateElementWidths,
+    onActivate: updateElementWidths,
     onUpdate: (event: PanGestureUpdateEvent) => {
       'worklet';
       userDrag.value = event.translationX;
@@ -501,7 +501,7 @@ const Swipeable = (props: SwipeableProps) => {
 
       updateAnimatedEvent();
     },
-    onEnd: (event: PanGestureStateChangeEvent) => {
+    onDeactivate: (event: PanGestureStateChangeEvent) => {
       'worklet';
       handleRelease(event);
     },

--- a/packages/react-native-gesture-handler/src/v3/hooks/callbacks/js/useGestureStateChangeEvent.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/callbacks/js/useGestureStateChangeEvent.ts
@@ -12,16 +12,16 @@ export function useGestureStateChangeEvent<THandlerData, TConfig>(
   return useMemo(() => {
     const handlers = prepareStateChangeHandlers({
       onBegin: config.onBegin,
-      onStart: config.onStart,
-      onEnd: config.onEnd,
+      onActivate: config.onActivate,
+      onDeactivate: config.onDeactivate,
       onFinalize: config.onFinalize,
     });
     return getStateChangeHandler(handlerTag, handlers, context);
   }, [
     handlerTag,
     config.onBegin,
-    config.onStart,
-    config.onEnd,
+    config.onActivate,
+    config.onDeactivate,
     config.onFinalize,
     context,
   ]);

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/eventHandlersUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/eventHandlersUtils.ts
@@ -10,12 +10,12 @@ export function prepareStateChangeHandlers<THandlerData>(
   callbacks: GestureCallbacks<THandlerData>
 ): GestureCallbacks<THandlerData> {
   'worklet';
-  const { onBegin, onStart, onEnd, onFinalize } = callbacks;
+  const { onBegin, onActivate, onDeactivate, onFinalize } = callbacks;
 
   const handlers: GestureCallbacks<THandlerData> = {
     ...(onBegin ? { onBegin } : {}),
-    ...(onStart ? { onStart } : {}),
-    ...(onEnd ? { onEnd } : {}),
+    ...(onActivate ? { onActivate } : {}),
+    ...(onDeactivate ? { onDeactivate } : {}),
     ...(onFinalize ? { onFinalize } : {}),
   };
 
@@ -66,11 +66,11 @@ export function getHandler<THandlerData>(
     case CALLBACK_TYPE.BEGAN:
       return callbacks.onBegin;
     case CALLBACK_TYPE.START:
-      return callbacks.onStart;
+      return callbacks.onActivate;
     case CALLBACK_TYPE.UPDATE:
       return callbacks.onUpdate;
     case CALLBACK_TYPE.END:
-      return callbacks.onEnd;
+      return callbacks.onDeactivate;
     case CALLBACK_TYPE.FINALIZE:
       return callbacks.onFinalize;
     case CALLBACK_TYPE.TOUCHES_DOWN:

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
@@ -36,9 +36,9 @@ export const HandlerCallbacks = new Set<
   keyof Required<GestureCallbacks<unknown>>
 >([
   'onBegin',
-  'onStart',
+  'onActivate',
   'onUpdate',
-  'onEnd',
+  'onDeactivate',
   'onFinalize',
   'onTouchesDown',
   'onTouchesMove',

--- a/packages/react-native-gesture-handler/src/v3/types/ConfigTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/ConfigTypes.ts
@@ -16,8 +16,8 @@ import { WithSharedValue } from './ReanimatedTypes';
 
 export type GestureCallbacks<THandlerData> = {
   onBegin?: (event: GestureStateChangeEvent<THandlerData>) => void;
-  onStart?: (event: GestureStateChangeEvent<THandlerData>) => void;
-  onEnd?: (
+  onActivate?: (event: GestureStateChangeEvent<THandlerData>) => void;
+  onDeactivate?: (
     event: GestureStateChangeEvent<THandlerData>,
     didSucceed: boolean
   ) => void;


### PR DESCRIPTION
## Description

It's easy to confuse `onBegin` with `onStart`, `onEnd` with `onFinalize`, maybe less so, but it can still be confusing. We wanted to rename `onStart` and the replacement was `onActivate`. To show that `onEnd` is complementary to that, this PR also changes it to `onDeactivate`.

Let me know what you think.

## Test plan

Static checks
