### PR TITLE
[General] Rename `useMultipleGestures` to `useCompetingGestures`

### DIFF
--- a/packages/react-native-gesture-handler/src/__tests__/RelationsTraversal.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/RelationsTraversal.test.tsx
@@ -1,7 +1,7 @@
 import { tagMessage } from '../utils';
 import {
   useExclusiveGestures,
-  useMultipleGestures,
+  useCompetingGestures,
   useSimultaneousGestures,
 } from '../v3/hooks/composition';
 import { useGesture } from '../v3/hooks/useGesture';
@@ -39,7 +39,7 @@ describe('Ensure only one leaf node', () => {
   });
 
   test('useRace', () => {
-    expect(() => useMultipleGestures(pan1, pan1)).toThrow(errorMessage);
+    expect(() => useCompetingGestures(pan1, pan1)).toThrow(errorMessage);
   });
 
   test('Complex composition', () => {
@@ -93,7 +93,7 @@ describe('Simple relations', () => {
   });
 
   test('useRace', () => {
-    const composedGesture = renderHook(() => useMultipleGestures(pan1, pan2))
+    const composedGesture = renderHook(() => useCompetingGestures(pan1, pan2))
       .result.current;
 
     configureRelations(composedGesture);

--- a/packages/react-native-gesture-handler/src/v3/hooks/composition/index.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/composition/index.ts
@@ -1,3 +1,3 @@
 export { useSimultaneousGestures } from './useSimultaneousGestures';
 export { useExclusiveGestures } from './useExclusiveGestures';
-export { useMultipleGestures } from './useMultipleGestures';
+export { useCompetingGestures } from './useCompetingGestures';

--- a/packages/react-native-gesture-handler/src/v3/hooks/composition/useCompetingGestures.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/composition/useCompetingGestures.ts
@@ -1,6 +1,6 @@
 import { AnyGesture, ComposedGestureName } from '../../types';
 import { useComposedGesture } from './useComposedGesture';
 
-export function useMultipleGestures(...gestures: AnyGesture[]) {
+export function useCompetingGestures(...gestures: AnyGesture[]) {
   return useComposedGesture(ComposedGestureName.Race, ...gestures);
 }


### PR DESCRIPTION
## Description

Following the internal discussion, renames `useMultipleGestures` to `useCompetingGestures`.

## Test plan

Static checks
