### PR TITLE
[iOS] Fix pan not triggering `onFinalize` when blocked

### DIFF
--- a/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
@@ -259,6 +259,7 @@
 
 - (void)reset
 {
+  [self triggerAction];
   [_gestureHandler.pointerTracker reset];
   [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(activateAfterLongPress) object:nil];
   self.enabled = YES;


### PR DESCRIPTION
## Description

I noticed that https://github.com/software-mansion/react-native-gesture-handler/pull/3756 restored calling `triggerAction` to all gestures that were affected by https://github.com/software-mansion/react-native-gesture-handler/pull/3740, but not to Pan. This is causing Pan to trigger `onBegin` without then triggering `onFinalize`.

This PR restores calling `triggerAction` in `reset`.

## Test plan

```jsx
import { View, ScrollView } from 'react-native';
import {
  Gesture,
  GestureDetector,
  GestureHandlerRootView,
} from 'react-native-gesture-handler';

export default function App() {
  const pan = Gesture.Pan()
    .runOnJS(true)
    .onBegin(() => {
      'worklet';
      console.log('begin');
    })
    .onFinalize(() => {
      'worklet';
      console.log('finalize');
    });
  return (
    <GestureHandlerRootView>
      <GestureDetector gesture={pan}>
        <View style={{ flex: 1, backgroundColor: 'blue' }}>
          <ScrollViewExample pan={pan} />
        </View>
      </GestureDetector>
    </GestureHandlerRootView>
  );
}

function ScrollViewExample({ pan }: any) {
  const native = Gesture.Native().blocksExternalGesture(pan).runOnJS(true);
  return (
    <GestureDetector gesture={native}>
      <ScrollView
        horizontal
        pagingEnabled
        style={{
          flex: 1,
          backgroundColor: 'yellow',
        }}>
        <View
          style={{
            width: 250,
            height: '100%',
            backgroundColor: 'green',
          }}
        />
        <View
          style={{
            width: 250,
            height: '100%',
            backgroundColor: 'purple',
          }}
        />
      </ScrollView>
    </GestureDetector>
  );
}

```
