### PR TITLE
[General] Change nightly version name

### DIFF
--- a/scripts/release/set-package-version.js
+++ b/scripts/release/set-package-version.js
@@ -48,7 +48,7 @@ function getVersion(isCommitly) {
     const day = String(now.getDate()).padStart(2, '0');
     const currentDate = `${year}${month}${day}`;
 
-    const commitlyVersion = `${major}.${minor + 1}.${0}-${currentDate}-${currentSHA.slice(0, 9)}`;
+    const commitlyVersion = `${major}.${minor + 1}.${0}-nightly-${currentDate}-${currentSHA.slice(0, 9)}`;
     return commitlyVersion;
   }
 


### PR DESCRIPTION
## Description

Adds `nightly` to the releases happening on the `nightly` tag to align with Reanimated and Screens.
