### PR TITLE
Correctly expose `avgTouches`

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/PanProperties.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/PanProperties.ts
@@ -8,7 +8,7 @@ type CommonPanGestureProperties = {
   /**
    * Android only.
    */
-  avgTouches?: boolean;
+  averageTouches?: boolean;
 
   /**
    * Enables two-finger gestures on supported devices, for example iPads with
@@ -84,9 +84,10 @@ export type PanGestureExternalProperties = CommonPanGestureProperties &
 
 export type PanGestureNativeProperties = Omit<
   CommonPanGestureProperties,
-  'minDistance'
+  'minDistance' | 'averageTouches'
 > & {
   minDist?: number;
+  avgTouches?: boolean;
   activeOffsetYStart?: number;
   activeOffsetYEnd?: number;
   activeOffsetXStart?: number;

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/usePanGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/usePanGesture.ts
@@ -59,7 +59,10 @@ export type PanGesture = SingleGesture<
 const PanPropsMapping = new Map<
   keyof PanGestureProperties,
   keyof PanGestureInternalProperties
->([['minDistance', 'minDist']]);
+>([
+  ['minDistance', 'minDist'],
+  ['averageTouches', 'avgTouches'],
+]);
 
 function validateOffsetsArray(
   offsets: WithSharedValue<number | [number, number] | undefined>,


### PR DESCRIPTION
## Description

While working on docs I've noticed that `averageTouches` was exposed as `avgTouches`. This PR fixes this problem.

## Test plan

1. Check that now TS suggests `averageTouches` instead of `avgTouches`
2. `yarn ts-check` 
3. `yarn lint-js`
