### PR TITLE
Add missing `cancelsTouchesInView`

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/types/ConfigTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/ConfigTypes.ts
@@ -57,6 +57,7 @@ export type CommonGestureConfig = {
     mouseButton?: MouseButton;
     enableContextMenu?: boolean;
     touchAction?: TouchAction;
+    cancelsTouchesInView?: boolean;
   },
   HitSlop | UserSelect | ActiveCursor | MouseButton | TouchAction
 >;


### PR DESCRIPTION
## Description

Seems like `cancelsTouchesInView` was missing in config. This PR adds it again.

## Test plan

1. Check that TS correctly suggests `cancelsTouchesInView`
2. `yarn ts-check`
3. `yarn lint-js`