### PR TITLE
Bring back missing fields from events

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/types/EventTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/EventTypes.ts
@@ -49,7 +49,7 @@ export type TouchEvent =
   | GestureTouchEvent
   | NativeSyntheticEvent<GestureTouchEvent>;
 
-export type GestureEvent<THandlerData> = THandlerData;
+export type GestureEvent<THandlerData> = HandlerData<THandlerData>;
 
 export type UnpackedGestureHandlerEvent<THandlerData> =
   | GestureEvent<THandlerData>


### PR DESCRIPTION
## Description

Some of common attributes were missing from events passed to callback (only types). This PR brings them back.

## Test plan

1. Check that TS correctly suggests `numberOfPointers` and `pointerType`
2. `yarn ts-check`
3. `yarn lint-js`