### PR TITLE
Change `direction` type in `Fling`

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/FlingProperties.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/FlingProperties.ts
@@ -1,3 +1,5 @@
+import { Directions } from '../../../../Directions';
+
 export type FlingGestureNativeProperties = {
   /**
    * Expressed allowed direction of movement. It's possible to pass one or many
@@ -13,7 +15,7 @@ export type FlingGestureNativeProperties = {
    * direction={Directions.DOWN}
    * ```
    */
-  direction?: number;
+  direction?: Directions;
 
   /**
    * Determine exact number of points required to handle the fling gesture.

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/useFlingGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/useFlingGesture.ts
@@ -1,3 +1,4 @@
+import { Directions } from '../../../../Directions';
 import {
   BaseDiscreteGestureConfig,
   ExcludeInternalConfigProps,
@@ -17,7 +18,10 @@ type FlingHandlerData = {
   absoluteY: number;
 };
 
-type FlingGestureProperties = WithSharedValue<FlingGestureNativeProperties>;
+type FlingGestureProperties = WithSharedValue<
+  FlingGestureNativeProperties,
+  Directions
+>;
 
 type FlingGestureInternalConfig = BaseDiscreteGestureConfig<
   FlingHandlerData,


### PR DESCRIPTION
## Description

Right now, `direction` property in `Fling` is typed as `number`. This means that user may pass any number, not only those that reflect `Directions` and TS will not show error. This PR changes this behavior.

## Test plan

1. Check that passing value other than from `Directions` results in TS error
2. `yarn ts-check`
3. `yarn lint-js`
