### PR TITLE
Revert "Change direction type"

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/FlingProperties.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/FlingProperties.ts
@@ -1,5 +1,3 @@
-import { Directions } from '../../../../Directions';
-
 export type FlingGestureNativeProperties = {
   /**
    * Expressed allowed direction of movement. It's possible to pass one or many
@@ -15,7 +13,7 @@ export type FlingGestureNativeProperties = {
    * direction={Directions.DOWN}
    * ```
    */
-  direction?: Directions;
+  direction?: number;
 
   /**
    * Determine exact number of points required to handle the fling gesture.

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/useFlingGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/useFlingGesture.ts
@@ -1,4 +1,3 @@
-import { Directions } from '../../../../Directions';
 import {
   BaseDiscreteGestureConfig,
   ExcludeInternalConfigProps,
@@ -18,10 +17,7 @@ type FlingHandlerData = {
   absoluteY: number;
 };
 
-type FlingGestureProperties = WithSharedValue<
-  FlingGestureNativeProperties,
-  Directions
->;
+type FlingGestureProperties = WithSharedValue<FlingGestureNativeProperties>;
 
 type FlingGestureInternalConfig = BaseDiscreteGestureConfig<
   FlingHandlerData,


### PR DESCRIPTION
This reverts commit 3d5e298124ea1c41dc243c8ade517510a7eb4871.

## Description

I have overlooked that result of using bitwise `OR` operator on `Directions` is of type `number`. This caused CI to [fail](https://github.com/software-mansion/react-native-gesture-handler/actions/runs/20177351781/job/57928739635#step:5:1).

Also, now I see that it didn't cover all cases, so reverting it makes sense.

## Test plan

```tsx
const fling = useFlingGesture({
  direction: Directions.RIGHT | Directions.LEFT,
});
```
