### PR TITLE
[General] Restore `handlerTag` to events

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/eventUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/eventUtils.ts
@@ -41,7 +41,7 @@ export function flattenAndFilterEvent<THandlerData>(
 ): GestureEvent<THandlerData> {
   'worklet';
 
-  return { ...event.handlerData };
+  return { handlerTag: event.handlerTag, ...event.handlerData };
 }
 
 export function isEventForHandlerWithTag<THandlerData>(

--- a/packages/react-native-gesture-handler/src/v3/types/EventTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/EventTypes.ts
@@ -49,7 +49,9 @@ export type TouchEvent =
   | GestureTouchEvent
   | NativeSyntheticEvent<GestureTouchEvent>;
 
-export type GestureEvent<THandlerData> = HandlerData<THandlerData>;
+export type GestureEvent<THandlerData> = {
+  handlerTag: number;
+} & HandlerData<THandlerData>;
 
 export type UnpackedGestureHandlerEvent<THandlerData> =
   | GestureEvent<THandlerData>


### PR DESCRIPTION
## Description

Restores `handlerTag` to the update and state change events. This information will be necessary to use the new state manager added in https://github.com/software-mansion/react-native-gesture-handler/pull/3880.

## Test plan

Verify that `handlerTag` exists on events
