### PR TITLE
[General] Throw when no gesture is passed to the `GestureDetector`

### DIFF
--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/index.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/index.tsx
@@ -95,6 +95,10 @@ export const GestureDetector = (props: GestureDetectorProps) => {
     );
   }
 
+  if (!props.gesture) {
+    throw new Error('GestureDetector must have a gesture prop provided.');
+  }
+
   // Gesture config should be wrapped with useMemo to prevent unnecessary re-renders
   const gestureConfig = props.gesture;
   propagateDetectorConfig(props, gestureConfig);


### PR DESCRIPTION
## Description

Adds an explicit error message when `GestureDetector` is rendered without any gesture. The current behavior is a random error when trying to call a method on `undefined`.

## Test plan

Verify that the error is thrown when no gesture is passed.
