### PR TITLE
[General] Cleanup duplicated callbacks

### DIFF
--- a/packages/react-native-gesture-handler/src/jestUtils/jestUtils.ts
+++ b/packages/react-native-gesture-handler/src/jestUtils/jestUtils.ts
@@ -445,12 +445,12 @@ function getHandlerData(
         };
 
         if (eventName === 'onGestureHandlerStateChange') {
-          componentOrGesture.detectorCallbacks.defaultEventHandler?.({
+          componentOrGesture.detectorCallbacks.jsEventHandler?.({
             oldState: oldState as State,
             ...event,
           });
         } else if (eventName === 'onGestureHandlerEvent') {
-          componentOrGesture.detectorCallbacks.defaultEventHandler?.(event);
+          componentOrGesture.detectorCallbacks.jsEventHandler?.(event);
         }
       },
     };

--- a/packages/react-native-gesture-handler/src/v3/detectors/NativeDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/NativeDetector.tsx
@@ -60,13 +60,11 @@ export function NativeDetector<THandlerData, TConfig>({
       enableContextMenu={enableContextMenu}
       pointerEvents={'box-none'}
       // @ts-ignore This is a type mismatch between RNGH types and RN Codegen types
-      onGestureHandlerStateChange={
-        gesture.detectorCallbacks.defaultEventHandler
-      }
+      onGestureHandlerStateChange={gesture.detectorCallbacks.jsEventHandler}
       // @ts-ignore This is a type mismatch between RNGH types and RN Codegen types
-      onGestureHandlerEvent={gesture.detectorCallbacks.defaultEventHandler}
+      onGestureHandlerEvent={gesture.detectorCallbacks.jsEventHandler}
       // @ts-ignore This is a type mismatch between RNGH types and RN Codegen types
-      onGestureHandlerTouchEvent={gesture.detectorCallbacks.defaultEventHandler}
+      onGestureHandlerTouchEvent={gesture.detectorCallbacks.jsEventHandler}
       // @ts-ignore This is a type mismatch between RNGH types and RN Codegen types
       onGestureHandlerReanimatedStateChange={
         reanimatedHandlers.onGestureHandlerReanimatedStateChange

--- a/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/InterceptingGestureDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/InterceptingGestureDetector.tsx
@@ -217,7 +217,7 @@ export function InterceptingGestureDetector<THandlerData, TConfig>({
         };
 
   const jsEventHandler = useMemo(
-    () => createGestureEventHandler('defaultEventHandler'),
+    () => createGestureEventHandler('jsEventHandler'),
     [createGestureEventHandler]
   );
 

--- a/packages/react-native-gesture-handler/src/v3/hooks/composition/useComposedGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/composition/useComposedGesture.ts
@@ -43,12 +43,12 @@ export function useComposedGesture(
     );
   }
 
-  const defaultEventHandler = (
+  const jsEventHandler = (
     event: GestureHandlerEventWithHandlerData<unknown>
   ) => {
     for (const gesture of gestures) {
-      if (gesture.detectorCallbacks.defaultEventHandler) {
-        gesture.detectorCallbacks.defaultEventHandler(event);
+      if (gesture.detectorCallbacks.jsEventHandler) {
+        gesture.detectorCallbacks.jsEventHandler(event);
       }
     }
   };
@@ -83,7 +83,7 @@ export function useComposedGesture(
     type,
     config,
     detectorCallbacks: {
-      defaultEventHandler,
+      jsEventHandler,
       reanimatedEventHandler,
       animatedEventHandler,
     },

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -36,7 +36,7 @@ export function useGesture<THandlerData, TConfig>(
   prepareConfig(config);
 
   // TODO: Call only necessary hooks depending on which callbacks are defined (?)
-  const { defaultEventHandler, reanimatedEventHandler, animatedEventHandler } =
+  const { jsEventHandler, reanimatedEventHandler, animatedEventHandler } =
     useGestureCallbacks(handlerTag, config);
 
   if (config.shouldUseReanimatedDetector && !reanimatedEventHandler) {
@@ -71,7 +71,7 @@ export function useGesture<THandlerData, TConfig>(
       type,
       config,
       detectorCallbacks: {
-        defaultEventHandler,
+        jsEventHandler,
         animatedEventHandler,
         reanimatedEventHandler,
       },
@@ -81,7 +81,7 @@ export function useGesture<THandlerData, TConfig>(
       handlerTag,
       type,
       config,
-      defaultEventHandler,
+      jsEventHandler,
       reanimatedEventHandler,
       animatedEventHandler,
       gestureRelations,

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGestureCallbacks.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGestureCallbacks.ts
@@ -42,11 +42,7 @@ export function useGestureCallbacks<THandlerData, TConfig>(
 ) {
   const callbacks = useMemoizedGestureCallbacks(config);
 
-  const defaultEventHandler = useGestureEventHandler(
-    handlerTag,
-    callbacks,
-    config
-  );
+  const jsEventHandler = useGestureEventHandler(handlerTag, callbacks, config);
 
   let reanimatedEventHandler;
 
@@ -81,7 +77,7 @@ export function useGestureCallbacks<THandlerData, TConfig>(
   }
 
   return {
-    defaultEventHandler,
+    jsEventHandler,
     reanimatedEventHandler,
     animatedEventHandler,
   };

--- a/packages/react-native-gesture-handler/src/v3/types/DetectorTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/DetectorTypes.ts
@@ -5,7 +5,7 @@ import {
 } from './EventTypes';
 
 export type DetectorCallbacks<THandlerData> = {
-  defaultEventHandler:
+  jsEventHandler:
     | undefined
     | ((event: GestureHandlerEventWithHandlerData<THandlerData>) => void);
   reanimatedEventHandler:


### PR DESCRIPTION
## Description

After the optimization PRs, the event handlers for js/ui thread were collapsed to a single function, but throughout the code, those are still being passed like before those changes - as three separate functions. Those are the same exact functions but under different names. This PR changes that, so that only one function is passed. Ultimately, this function still ends up in three different events, but the split now happens at the leafs instead of the root.

## Test plan

Gestures should still work
