### PR TITLE
[iOS] Fix `ScrollView` detection when used with NativeDetector

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -10,6 +10,7 @@
 
 #import <React/UIView+React.h>
 
+#import <React/RCTEnhancedScrollView.h>
 #import <React/RCTParagraphComponentView.h>
 #import <React/RCTScrollViewComponentView.h>
 
@@ -646,6 +647,10 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 - (RNGHUIScrollView *)retrieveScrollView:(RNGHUIView *)view
 {
+  if ([view isKindOfClass:[RCTEnhancedScrollView class]]) {
+    return (RCTEnhancedScrollView *)view;
+  }
+
   if ([view isKindOfClass:[RCTScrollViewComponentView class]]) {
     RNGHUIScrollView *scrollView = ((RCTScrollViewComponentView *)view).scrollView;
     return scrollView;


### PR DESCRIPTION
## Description

Our check for `ScrollView` was checking for `RCTScrollViewComponentView`, but inside NativeDetector, we extract `contentView` from `RCTViewComponentViews`: https://github.com/software-mansion/react-native-gesture-handler/blob/08c46d8232ce41dc195459b8b58b5d818bdfd15f/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm#L298-L303

And it so happens that `RCTScrollViewComponentView` inherits from `RCTViewComponentView`, which broke the `ScrollView` detection. The `contentView` of `RCTScrollViewComponentView` is `RCTEnhancedScrollView`.

## Test plan

ScrollView from RNGH should now correctly delay touches on native buttons.
