### PR TITLE
[iOS] Fix manual activation crash

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNManualActivationRecognizer.m
+++ b/packages/react-native-gesture-handler/apple/RNManualActivationRecognizer.m
@@ -8,7 +8,7 @@
 
 - (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler
 {
-  if ((self = [super initWithTarget:self action:@selector(handleGesture:fromReset:)])) {
+  if ((self = [super initWithTarget:self action:@selector(handleGesture:)])) {
     _handler = gestureHandler;
     _activePointers = 0;
     self.delegate = self;


### PR DESCRIPTION
## Description

In #3855 we've introduced `fromReset` argument for `handleGesture`. However, `ManualActivationRecognizer` does not have such signature. This PR removes it from selector as `fromReset` is not passed anyway.

## Test plan

Check that on `Pressable` example app no longer crashes when clicking on **press retention** area.