### PR TITLE
State manager deactivate

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/gestureStateManager.ts
+++ b/packages/react-native-gesture-handler/src/v3/gestureStateManager.ts
@@ -5,7 +5,7 @@ export type GestureStateManagerType = {
   begin(handlerTag: number): void;
   activate(handlerTag: number): void;
   fail(handlerTag: number): void;
-  end(handlerTag: number): void;
+  deactivate(handlerTag: number): void;
 };
 
 const setGestureState = (handlerTag: number, state: State) => {
@@ -36,7 +36,7 @@ export const GestureStateManager: GestureStateManagerType = {
     setGestureState(handlerTag, State.FAILED);
   },
 
-  end(handlerTag: number) {
+  deactivate(handlerTag: number) {
     'worklet';
     setGestureState(handlerTag, State.END);
   },

--- a/packages/react-native-gesture-handler/src/v3/gestureStateManager.web.ts
+++ b/packages/react-native-gesture-handler/src/v3/gestureStateManager.web.ts
@@ -25,7 +25,7 @@ export const GestureStateManager: GestureStateManagerType = {
     NodeManager.getHandler(handlerTag).fail();
   },
 
-  end(handlerTag: number): void {
+  deactivate(handlerTag: number): void {
     'worklet';
     NodeManager.getHandler(handlerTag).end();
   },


### PR DESCRIPTION
## Description

In https://github.com/software-mansion/react-native-gesture-handler/pull/3880 I forgot to rename end to deactivate in StateManager following other api changes. This PR fixes the issue.


## Test plan

