### PR TITLE
add manualActivation prop

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
@@ -22,6 +22,7 @@ const CommonConfig = new Set<keyof CommonGestureConfig>([
   'activeCursor',
   'mouseButton',
   'testID',
+  'manualActivation',
 ]);
 
 const ExternalRelationsConfig = new Set<keyof ExternalRelations>([

--- a/packages/react-native-gesture-handler/src/v3/types/ConfigTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/ConfigTypes.ts
@@ -66,6 +66,7 @@ export type CommonGestureConfig = {
     activeCursor?: ActiveCursor;
     mouseButton?: MouseButton;
     cancelsTouchesInView?: boolean;
+    manualActivation?: boolean;
   },
   HitSlop | ActiveCursor | MouseButton
 >;


### PR DESCRIPTION
## Description

`manualActivation` prop was missing in v3, this PR adds it.
## Test plan

<details>

```tsx
import React from 'react';
import { View, Text, StyleSheet } from 'react-native';
import { GestureHandlerRootView, GestureDetector, usePanGesture } from 'react-native-gesture-handler';

export default function TwoPressables() {
  const pan = usePanGesture({
    onActivate: (e) => { console.log(e) },
    disableReanimated: true,
    manualActivation: true,
    runOnJS: true,
  });
  return (
    <GestureHandlerRootView>
      <View style={styles.root}>
        <GestureDetector gesture={pan}>
          <View style={styles.outer}>
            <Text style={styles.label}>Pan</Text>
          </View>
        </GestureDetector>

      </View>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  root: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#f7f7f7',
  },
  outer: {
    padding: 20,
    backgroundColor: '#ddd',
    borderRadius: 12,
    marginBottom: 50
  },
  label: {
    fontSize: 18,
    marginBottom: 10,
  },
})
```

</details>
