### PR TITLE
[iOS] Restore scroll view behavior on gesture unbind

### DIFF
--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -159,6 +159,15 @@
   scrollView.delaysContentTouches = YES;
 }
 
+- (void)unbindFromView
+{
+  // Restore the React Native's overriden behavor for not delaying content touches
+  UIScrollView *scrollView = [self retrieveScrollView:self.recognizer.view];
+  scrollView.delaysContentTouches = NO;
+
+  [super unbindFromView];
+}
+
 - (void)handleTouchDown:(UIView *)sender forEvent:(UIEvent *)event
 {
   [self setCurrentPointerType:event];


### PR DESCRIPTION
## Description

The new architecture comes with a new fancy tool - view recycling. After a view is no longer used, instead of deallocating it, it's restored to a "pristine" state and moved to a recycling pool. The restoration covers only the properties that may have been modified by React in the default implementation, and `delaysContentTouches` is not one of them.

By setting it to `YES` on a ScrollView and never resetting it back, we may cause an unrelated scroll view to appear with that field set.

This PR resets the field when the gesture unbinds from view.

## Test plan

Remove native gesture from the scroll view, verify that the touches are no longer delayed.
