### PR TITLE
[General] Fix `onBegin` not being called when the native recognizer skips the `BEGAN` state

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/callbacks/stateChangeHandler.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/callbacks/stateChangeHandler.ts
@@ -38,6 +38,11 @@ export function getStateChangeHandler<THandlerData>(
       (oldState === State.BEGAN || oldState === State.UNDETERMINED) &&
       state === State.ACTIVE
     ) {
+      // If the native recognizer skipped the BEGAN state, we still need to call the callback
+      if (oldState === State.UNDETERMINED) {
+        runCallback(CALLBACK_TYPE.BEGAN, callbacks, event);
+      }
+
       runCallback(CALLBACK_TYPE.START, callbacks, event);
     } else if (oldState !== state && state === State.END) {
       if (oldState === State.ACTIVE) {


### PR DESCRIPTION
## Description

The current state machine implementation allows for `onBegin` callback to be skipped if the native recognizer goes from `UNDETERMINED` directly to `ACTIVE` state (which is a valid transition in some cases).

This PR updates the logic to "backfill" the `onBegin` callback when receiving the `UNDETERMINED -> ACTIVE` transition, before calling `onActivate`.

Note: this PR only changes the behavior for the V3 API. I'm not sure whether it should be backported to V2 as it would likely be a breaking change.

## Test plan

This scenario: https://github.com/software-mansion/react-native-gesture-handler/blob/59a5311e3cf517e9147017f20aa41bc644790a05/packages/react-native-gesture-handler/src/components/GestureButtons.tsx#L67-L68
