### PR TITLE
Publish proper nightly releases

### DIFF
--- a/.github/actions/publish-npm-package/action.yml
+++ b/.github/actions/publish-npm-package/action.yml
@@ -2,8 +2,8 @@ name: publish-npm-package
 description: Build and publish react-native-gesture-handler package to npm
 inputs:
   release-type:
-    description: Release type to be published (stable, commitly, beta, rc).
-    default: "commitly"
+    description: Release type to be published (stable, nightly, beta, rc).
+    default: "nightly"
   version:
     description: Specific version to publish (usually inferred from x.y-stable branch name).
     default: ""
@@ -31,7 +31,7 @@ runs:
       id: set-package-version
       shell: bash
       run: |
-        VERSION=$(node ./scripts/release/set-package-version.js ${{ inputs.release-type == 'commitly' && '--commitly' || '' }} ${{ inputs.release-type == 'beta' && '--beta' || '' }} ${{ inputs.release-type == 'rc' && '--rc' || '' }} ${{ inputs.version != '' && format('--version ''{0}''', inputs.version) || '' }})
+        VERSION=$(node ./scripts/release/set-package-version.js ${{ inputs.release-type == 'nightly' && '--nightly' || '' }} ${{ inputs.release-type == 'beta' && '--beta' || '' }} ${{ inputs.release-type == 'rc' && '--rc' || '' }} ${{ inputs.version != '' && format('--version ''{0}''', inputs.version) || '' }})
         echo "Updated package version to $VERSION"
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
@@ -39,7 +39,7 @@ runs:
       id: figure-out-npm-tag
       shell: bash
       run: |
-        if [ "${{ inputs.release-type == 'commitly' }}" = "true" ]; then
+        if [ "${{ inputs.release-type == 'nightly' }}" = "true" ]; then
           TAG_ARGUMENT="--tag nightly"
         else
           if [ "${{ inputs.release-type == 'beta' || inputs.release-type == 'rc' }}" = "true" ]; then

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,11 +1,8 @@
 name: Publish release to npm
 on:
-  # For commitlies
-  push:
-    branches:
-      - main
-    paths:
-      - packages/react-native-gesture-handler/**
+  # For nightly releases
+  schedule:
+    - cron: '27 23 * * *' # at 23:27 every day
   # For manual releases
   workflow_dispatch:
     inputs:
@@ -14,6 +11,7 @@ on:
         type: choice
         options:
           - stable
+          - nightly
           - beta
           - rc
         default: stable
@@ -52,9 +50,9 @@ jobs:
           version: ${{ inputs.version }}
           dry-run: ${{ inputs.dry-run }}
 
-      - name: Publish automatic commitly release
-        if: ${{ github.event_name == 'push' }}
+      - name: Publish automatic nightly release
+        if: ${{ github.event_name == 'schedule' }}
         uses: ./.github/actions/publish-npm-package
         with:
-          release-type: 'commitly'
+          release-type: 'nightly'
           dry-run: false

--- a/scripts/release/__tests__/parse-arguments.test.js
+++ b/scripts/release/__tests__/parse-arguments.test.js
@@ -26,10 +26,10 @@ describe('parse-arguments', () => {
     });
 
     // Single flag tests
-    test('returns commitly release type with --commitly flag', () => {
-      process.argv = ['node', 'script.js', '--commitly'];
+    test('returns nightly release type with --nightly flag', () => {
+      process.argv = ['node', 'script.js', '--nightly'];
       const result = parseArguments();
-      expect(result).toEqual({ releaseType: ReleaseType.COMMITLY, version: null });
+      expect(result).toEqual({ releaseType: ReleaseType.NIGHTLY, version: null });
     });
 
     test('returns beta release type with --beta flag', () => {
@@ -64,29 +64,29 @@ describe('parse-arguments', () => {
     });
 
     // Mutual exclusivity tests
-    test('throws error when --commitly and --beta are both provided', () => {
-      process.argv = ['node', 'script.js', '--commitly', '--beta'];
-      expect(() => parseArguments()).toThrow('Release flags --commitly, --beta, and --rc are mutually exclusive');
+    test('throws error when --nightly and --beta are both provided', () => {
+      process.argv = ['node', 'script.js', '--nightly', '--beta'];
+      expect(() => parseArguments()).toThrow('Release flags --nightly, --beta, and --rc are mutually exclusive');
     });
 
-    test('throws error when --commitly and --rc are both provided', () => {
-      process.argv = ['node', 'script.js', '--commitly', '--rc'];
-      expect(() => parseArguments()).toThrow('Release flags --commitly, --beta, and --rc are mutually exclusive');
+    test('throws error when --nightly and --rc are both provided', () => {
+      process.argv = ['node', 'script.js', '--nightly', '--rc'];
+      expect(() => parseArguments()).toThrow('Release flags --nightly, --beta, and --rc are mutually exclusive');
     });
 
     test('throws error when --beta and --rc are both provided', () => {
       process.argv = ['node', 'script.js', '--beta', '--rc'];
-      expect(() => parseArguments()).toThrow('Release flags --commitly, --beta, and --rc are mutually exclusive');
+      expect(() => parseArguments()).toThrow('Release flags --nightly, --beta, and --rc are mutually exclusive');
     });
 
     test('throws error when all three flags are provided', () => {
-      process.argv = ['node', 'script.js', '--commitly', '--beta', '--rc'];
-      expect(() => parseArguments()).toThrow('Release flags --commitly, --beta, and --rc are mutually exclusive');
+      process.argv = ['node', 'script.js', '--nightly', '--beta', '--rc'];
+      expect(() => parseArguments()).toThrow('Release flags --nightly, --beta, and --rc are mutually exclusive');
     });
 
-    // Version not allowed for commitly
-    test('throws error when version provided for commitly release', () => {
-      process.argv = ['node', 'script.js', '--commitly', '--version', '2.22.0'];
+    // Version not allowed for nightly
+    test('throws error when version provided for nightly release', () => {
+      process.argv = ['node', 'script.js', '--nightly', '--version', '2.22.0'];
       expect(() => parseArguments()).toThrow();
     });
 
@@ -147,7 +147,7 @@ describe('parse-arguments', () => {
       expect(ReleaseType.STABLE).toBe('stable');
       expect(ReleaseType.BETA).toBe('beta');
       expect(ReleaseType.RELEASE_CANDIDATE).toBe('rc');
-      expect(ReleaseType.COMMITLY).toBe('commitly');
+      expect(ReleaseType.NIGHTLY).toBe('nightly');
     });
   });
 });

--- a/scripts/release/parse-arguments.js
+++ b/scripts/release/parse-arguments.js
@@ -4,19 +4,19 @@ const ReleaseType = {
   STABLE: 'stable',
   BETA: 'beta',
   RELEASE_CANDIDATE: 'rc',
-  COMMITLY: 'commitly',
+  NIGHTLY: 'nightly',
 };
 
 function parseArguments() {
   let version = null;
-  let isCommitly = false;
+  let isNightly = false;
   let isBeta = false;
   let isReleaseCandidate = false;
 
   for (let i = 2; i < process.argv.length; i++) {
     const arg = process.argv[i];
-    if (arg === '--commitly') {
-      isCommitly = true;
+    if (arg === '--nightly') {
+      isNightly = true;
     } else if (arg === '--beta') {
       isBeta = true;
     } else if (arg === '--rc') {
@@ -31,11 +31,11 @@ function parseArguments() {
     }
   }
 
-  assert([isCommitly, isBeta, isReleaseCandidate].filter(Boolean).length <= 1, 'Release flags --commitly, --beta, and --rc are mutually exclusive; specify at most one');
-  assert(version === null || isBeta || isReleaseCandidate || !isCommitly, 'Version should not be provided for commitly releases');
+  assert([isNightly, isBeta, isReleaseCandidate].filter(Boolean).length <= 1, 'Release flags --nightly, --beta, and --rc are mutually exclusive; specify at most one');
+  assert(version === null || isBeta || isReleaseCandidate || !isNightly, 'Version should not be provided for nightly releases');
 
-  const releaseType = isCommitly
-    ? ReleaseType.COMMITLY
+  const releaseType = isNightly
+    ? ReleaseType.NIGHTLY
     : isBeta
       ? ReleaseType.BETA
       : isReleaseCandidate


### PR DESCRIPTION
## Description

Changes the release scripts to release proper nightly versions instead of commitlies. The script will now run once per day and publish a new nightly version, assuming there were any new commits on `main` branch. If there were no new commits, the job should fail.

`nightly` is now also available in the dropdown when running a release manually, in case a new release is needed quickly to easily test the latest commit.

Updated the `get-version` script to return `3.0.0-nightly-...` when the `latest` tag on NPM points to 2.x.
