### PR TITLE
[Native] Automatically unflatten detector children

### DIFF
--- a/packages/react-native-gesture-handler/shared/shadowNodes/react/renderer/components/rngesturehandler_codegen/RNGestureHandlerDetectorShadowNode.h
+++ b/packages/react-native-gesture-handler/shared/shadowNodes/react/renderer/components/rngesturehandler_codegen/RNGestureHandlerDetectorShadowNode.h
@@ -53,9 +53,17 @@ class RNGestureHandlerDetectorShadowNode final
     initialize();
   }
 
+  void appendChild(const std::shared_ptr<const ShadowNode> &child) override;
+  void replaceChild(
+      const ShadowNode &oldChild,
+      const std::shared_ptr<const ShadowNode> &newChild,
+      size_t suggestedIndex = SIZE_MAX) override;
+
   void layout(LayoutContext layoutContext) override;
 
  private:
+  std::shared_ptr<const ShadowNode> unflattenNode(
+      const std::shared_ptr<const ShadowNode> &node);
   void initialize();
 
   std::optional<LayoutMetrics> previousLayoutMetrics_;


### PR DESCRIPTION
## Description

On Android this requires https://github.com/software-mansion/react-native-gesture-handler/pull/3962 to test, as the non-transparent views are never flattened.

Automatically unflattens the child node of the detector component, so that setting `collapsable={false}` is no longer needed.

## Test plan

Notce the lack of `collapsable={false}` on the detector's child.
```jsx
import React from 'react';
import { StyleSheet, View } from 'react-native';
import {
  GestureDetector,
  GestureHandlerRootView,
  useTapGesture,
} from 'react-native-gesture-handler';

export default function EmptyExample() {
  const tap = useTapGesture({
    onActivate: () => {
      console.log('tap');
    },
  });

  return (
    <GestureHandlerRootView style={styles.container}>
      <GestureDetector gesture={tap}>
        <View style={{ flex: 1, backgroundColor: 'transparent' }} />
      </GestureDetector>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
  },
});
```
