### PR TITLE
Do not export `PureNativeButton`

### DIFF
--- a/packages/react-native-gesture-handler/src/index.ts
+++ b/packages/react-native-gesture-handler/src/index.ts
@@ -85,7 +85,6 @@ export {
   LegacyBaseButton,
   LegacyRectButton,
   LegacyBorderlessButton,
-  LegacyPureNativeButton,
 } from './components/GestureButtons';
 
 export type {

--- a/packages/react-native-gesture-handler/src/v3/index.ts
+++ b/packages/react-native-gesture-handler/src/v3/index.ts
@@ -63,7 +63,6 @@ export {
   BaseButton,
   RectButton,
   BorderlessButton,
-  PureNativeButton,
   Pressable,
   ScrollView,
   Switch,


### PR DESCRIPTION
## Description

This PR removes `PureNativeButton` from public API.

> [!NOTE]
> Docs for this are already present in #3968 

## Test plan

Check that it is not possible to import it from package.