### PR TITLE
[General] Only overwrite ref if the dropped handler didn't change

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -90,7 +90,10 @@ export function useGesture<THandlerData, TConfig>(
 
   useEffect(() => {
     return () => {
-      currentGestureRef.current = { type: '', handlerTag: -1 };
+      if (currentGestureRef.current.handlerTag === handlerTag) {
+        currentGestureRef.current = { type: '', handlerTag: -1 };
+      }
+
       NativeProxy.dropGestureHandler(handlerTag);
       scheduleFlushOperations();
     };


### PR DESCRIPTION
## Description

It's possible that when a gesture is updated, the new values in the ref will be overwritten after being updated, due to the cleanup not checking what it's deleting.

It was possible to get this scenario:
```
 LOG  useGesture createGestureHandler TapGestureHandler 1 previous  -1
 LOG  useGesture useEffect TapGestureHandler 1
 LOG  useGesture createGestureHandler TapGestureHandler 2 previous TapGestureHandler 1
 LOG  useGesture useEffect cleanup TapGestureHandler 1
 LOG  useGesture createGestureHandler TapGestureHandler 2 previous  -1
```

where the last update would crash due to the ref being cleared by the cleanup of `TapGestureHandler 1` AFTER being updated by `TapGestureHandler 2`.

## Test plan

File 1:

```jsx
import React from 'react';
import { View } from 'react-native';
import { GestureDetector, useTapGesture } from 'react-native-gesture-handler';

function Test() {
  const gesture = useTapGesture({
    onActivate: () => {
      console.log('onActivate');
    },
  });

  const COMMENT_THIS_FIRST = 2;

  return (
    <GestureDetector gesture={gesture}>
      <View style={{ width: 100, height: 100, backgroundColor: 'red' }} />
    </GestureDetector>
  );
}

export default Test;
```

File2:
```jsx
import React from 'react';
import { GestureHandlerRootView } from 'react-native-gesture-handler';

import Test from './File1';

function Example() {
  let COMMENT_THIS_SECOND = 1;

  return (
    <GestureHandlerRootView>
      <Test />
    </GestureHandlerRootView>
  );
}

export default Example;
```

Comment out `COMMENT_THIS_FIRST`, save, then comment out `COMMENT_THIS_SECOND` and save.
