### PR TITLE
Fix failing `Jest` CI

### DIFF
--- a/packages/react-native-gesture-handler/babel.config.js
+++ b/packages/react-native-gesture-handler/babel.config.js
@@ -1,8 +1,7 @@
 module.exports = {
   presets: [
-    '@babel/preset-env',
+    ['@babel/preset-env', { targets: { node: 'current' } }],
     '@babel/preset-typescript',
     'module:@react-native/babel-preset',
   ],
-  targets: { node: 'current' },
 };


### PR DESCRIPTION
## Description

Currently our CI fail with the following error:

```
ReferenceError: regeneratorRuntime is not defined
```

Based on [this issue comment](https://github.com/jestjs/jest/issues/3126#issuecomment-723998132) I've updated out `babel.config.js`. This fixed issue locally, so it should also work on CI.

## Test plan

Check CI