### PR TITLE
Pin nightlies to 3.0.0

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -73,4 +73,5 @@ jobs:
           package-json-path: 'packages/react-native-gesture-handler/package.json'
           install-dependencies-command: 'yarn install --immutable'
           release-type: 'nightly'
+          version: "3.0.0"
           dry-run: false


### PR DESCRIPTION
## Description

Pins the published nightly version to 3.0.0.

This is due to this change in the package publishing action: https://github.com/software-mansion-labs/npm-package-publish/commit/c014b49bf6dd48daa8492a430601049eee6d41c7, which previously was handling that in the script itself. Since there is no stable 3.0.0 release yet, the action is picking up 2.30.0 as the latest release, and would publish `2.31.0-nightly` without the override.

## Test plan

Tested on a fork:
- https://github.com/j-piasecki/react-native-gesture-handler/actions/runs/22438802435/job/64975545299
- https://github.com/j-piasecki/react-native-gesture-handler/actions/runs/22438807471/job/64975561566
- https://github.com/j-piasecki/react-native-gesture-handler/actions/runs/22438703729/job/64975199133
