### PR TITLE
Fix `fillInDefaultValues` warning

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
@@ -72,6 +72,7 @@ export const PropsToFilter = new Set<
   ...ExternalRelationsConfig,
 
   // Config props
+  'fillInDefaultValues',
   'changeEventCalculator',
   'disableReanimated',
   'shouldUseReanimatedDetector',


### PR DESCRIPTION
## Description

`fillInDefaultValues` is meant to be used only on `JS` side. However, it was not included in [`PropsToFilter`](https://github.com/software-mansion/react-native-gesture-handler/blob/9a72a5cc9762a0d3a3736b6e47ef359f81db82f1/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts#L68), so the following warning could be observed:

```
WARN  [react-native-gesture-handler] fillInDefaultValues is not a valid property for PanGestureHandler and will be ignored.
```

This PR fixes this problem.

## Test plan

Check that warning is no longer present in console (any example with either `Pan`, `Hover`, `Pinch` or `Rotation`)