### PR TITLE
Import legacy pressables in examples

### DIFF
--- a/apps/common-app/src/legacy/release_tests/gesturizedPressable/testingBase.tsx
+++ b/apps/common-app/src/legacy/release_tests/gesturizedPressable/testingBase.tsx
@@ -3,26 +3,26 @@ import {
   StyleSheet,
   Text,
   View,
-  Pressable,
+  Pressable as RNPressable,
   PressableProps as RNPressableProps,
 } from 'react-native';
 import {
-  LegacyPressable as GesturizedPressable,
+  LegacyPressable as GHPressable,
   LegacyPressableProps as GHPressableProps,
 } from 'react-native-gesture-handler';
 
 const TestingBase = (props: GHPressableProps & RNPressableProps) => (
   <>
-    <GesturizedPressable {...props}>
+    <GHPressable {...props}>
       <View style={styles.textWrapper}>
-        <Text style={styles.text}>Gesturized pressable!</Text>
+        <Text style={styles.text}>RNGH pressable!</Text>
       </View>
-    </GesturizedPressable>
-    <Pressable {...props}>
+    </GHPressable>
+    <RNPressable {...props}>
       <View style={styles.textWrapper}>
-        <Text style={styles.text}>Legacy pressable!</Text>
+        <Text style={styles.text}>RN pressable!</Text>
       </View>
-    </Pressable>
+    </RNPressable>
   </>
 );
 

--- a/apps/common-app/src/legacy/release_tests/nestedPressables/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/nestedPressables/index.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import {
-  Pressable as LegacyPressable,
+  Pressable as RNPressable,
   PressableStateCallbackType,
   StyleSheet,
   Text,
   View,
 } from 'react-native';
-import {
-  ScrollView,
-  Pressable as GesturizedPressable,
-} from 'react-native-gesture-handler';
+import { ScrollView, LegacyPressable } from 'react-native-gesture-handler';
 
 export default function Example() {
   return (
@@ -50,21 +47,21 @@ const outerStyle = ({ pressed }: PressableStateCallbackType) => [
 
 function GesturizedBoxes() {
   return (
-    <GesturizedPressable
+    <LegacyPressable
       style={outerStyle}
       testID="outer"
       onPressIn={() => console.log('[outer] onPressIn')}
       onPressOut={() => console.log('[outer] onPressOut')}
       onPress={() => console.log('[outer] onPress')}
       onLongPress={() => console.log('[outer] onLongPress')}>
-      <GesturizedPressable
+      <LegacyPressable
         style={middleStyle}
         testID="middle"
         onPressIn={() => console.log('[middle] onPressIn')}
         onPressOut={() => console.log('[middle] onPressOut')}
         onPress={() => console.log('[middle] onPress')}
         onLongPress={() => console.log('[middle] onLongPress')}>
-        <GesturizedPressable
+        <LegacyPressable
           style={innerStyle}
           testID="inner"
           onPressIn={() => console.log('[inner] onPressIn')}
@@ -72,34 +69,34 @@ function GesturizedBoxes() {
           onPress={() => console.log('[inner] onPress')}
           onLongPress={() => console.log('[inner] onLongPress')}
         />
-      </GesturizedPressable>
-    </GesturizedPressable>
+      </LegacyPressable>
+    </LegacyPressable>
   );
 }
 
 function LegacyBoxes() {
   return (
-    <LegacyPressable
+    <RNPressable
       style={outerStyle}
       onPressIn={() => console.log('[outer] onPressIn')}
       onPressOut={() => console.log('[outer] onPressOut')}
       onPress={() => console.log('[outer] onPress')}
       onLongPress={() => console.log('[outer] onLongPress')}>
-      <LegacyPressable
+      <RNPressable
         style={middleStyle}
         onPressIn={() => console.log('[middle] onPressIn')}
         onPressOut={() => console.log('[middle] onPressOut')}
         onPress={() => console.log('[middle] onPress')}
         onLongPress={() => console.log('[middle] onLongPress')}>
-        <LegacyPressable
+        <RNPressable
           style={innerStyle}
           onPressIn={() => console.log('[inner] onPressIn')}
           onPressOut={() => console.log('[inner] onPressOut')}
           onPress={() => console.log('[inner] onPress')}
           onLongPress={() => console.log('[inner] onLongPress')}
         />
-      </LegacyPressable>
-    </LegacyPressable>
+      </RNPressable>
+    </RNPressable>
   );
 }
 

--- a/apps/common-app/src/legacy/v2_api/pressable/index.tsx
+++ b/apps/common-app/src/legacy/v2_api/pressable/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { Pressable } from 'react-native-gesture-handler';
+import { LegacyPressable } from 'react-native-gesture-handler';
 
 const SECTION_RADIUS = 40;
 const BASE_SIZE = 120;
@@ -33,7 +33,7 @@ export default function PressableExample() {
     <View style={{ flex: 1, backgroundColor: 'white' }}>
       <View style={styles.pressRectContainer}>
         <View style={styles.hitRectContainer}>
-          <Pressable
+          <LegacyPressable
             style={({ pressed }) =>
               pressed ? styles.highlight : styles.pressable
             }
@@ -48,7 +48,7 @@ export default function PressableExample() {
             <View style={styles.textWrapper}>
               <Text style={styles.text}>Pressable!</Text>
             </View>
-          </Pressable>
+          </LegacyPressable>
           <Text style={styles.rectText}>Hit Rect</Text>
         </View>
         <Text style={styles.rectText}>Press Rect</Text>


### PR DESCRIPTION
## Description

Legacy examples imported the new v3 pressable instead of legacy pressable. This PR fixes the imports

## Test plan

Look what pressable is imported in the legacy examples
