### PR TITLE
[Android] Check all pointers in move events

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -649,12 +649,15 @@ open class GestureHandler {
       return false
     }
 
-    return if (event.actionMasked == MotionEvent.ACTION_MOVE) {
-      (0 until event.pointerCount).any { i ->
-        isTrackingPointer(event.getPointerId(i))
+    if (event.actionMasked == MotionEvent.ACTION_MOVE) {
+      for (i in 0 until event.pointerCount) {
+        if (isTrackingPointer(event.getPointerId(i))) {
+          return true
+        }
       }
+      return false
     } else {
-      isTrackingPointer(event.getPointerId(event.actionIndex))
+      return isTrackingPointer(event.getPointerId(event.actionIndex))
     }
   }
 


### PR DESCRIPTION
## Description

When one pointer is placed on the background, handlers don't respond to other pointers. Instead, they fail on [this line](https://github.com/software-mansion/react-native-gesture-handler/blob/41fbd374a85def52eb7051f96e3d4c63e6eb0724/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt#L295). This is because on Android events with `ACTION_MOVE` are batched and all pointers are contained within one event. As [Android docs say](https://developer.android.com/reference/android/view/MotionEvent#getActionIndex()), `actionIndex` is fine to check for up and down actions. However, we use it for move action and it always returns `0`. 

To solve this problem, I've added loop that checks whether any pointer from event is tracked by the handler. 

Fixes #3995

## Test plan

Tested on example code from #3995