### PR TITLE
Enable `exactOptionalPropertyTypes` support

### DIFF
--- a/packages/react-native-gesture-handler/src/components/GestureButtonsProps.ts
+++ b/packages/react-native-gesture-handler/src/components/GestureButtonsProps.ts
@@ -18,42 +18,42 @@ export interface LegacyRawButtonProps
    * Defines if more than one button could be pressed simultaneously. By default
    * set true.
    */
-  exclusive?: boolean;
+  exclusive?: boolean | undefined;
   // TODO: we should transform props in `createNativeWrapper`
   /**
    * Android only.
    *
    * Defines color of native ripple animation used since API level 21.
    */
-  rippleColor?: number | ColorValue | null;
+  rippleColor?: number | ColorValue | null | undefined;
 
   /**
    * Android only.
    *
    * Defines radius of native ripple animation used since API level 21.
    */
-  rippleRadius?: number | null;
+  rippleRadius?: number | null | undefined;
 
   /**
    * Android only.
    *
    * Set this to true if you want the ripple animation to render outside the view bounds.
    */
-  borderless?: boolean;
+  borderless?: boolean | undefined;
 
   /**
    * Android only.
    *
    * Defines whether the ripple animation should be drawn on the foreground of the view.
    */
-  foreground?: boolean;
+  foreground?: boolean | undefined;
 
   /**
    * Android only.
    *
    * Set this to true if you don't want the system to play sound when the button is pressed.
    */
-  touchSoundDisabled?: boolean;
+  touchSoundDisabled?: boolean | undefined;
 
   /**
    * Style object, use it to set additional styles.
@@ -70,31 +70,31 @@ export interface LegacyRawButtonProps
    * @deprecated test-only props are deprecated and will be removed in the future.
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  testOnly_onPress?: Function | null;
+  testOnly_onPress?: Function | null | undefined;
 
   /**
    * Used for testing-library compatibility, not passed to the native component.
    * @deprecated test-only props are deprecated and will be removed in the future.
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  testOnly_onPressIn?: Function | null;
+  testOnly_onPressIn?: Function | null | undefined;
 
   /**
    * Used for testing-library compatibility, not passed to the native component.
    * @deprecated test-only props are deprecated and will be removed in the future.
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  testOnly_onPressOut?: Function | null;
+  testOnly_onPressOut?: Function | null | undefined;
 
   /**
    * Used for testing-library compatibility, not passed to the native component.
    * @deprecated test-only props are deprecated and will be removed in the future.
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  testOnly_onLongPress?: Function | null;
+  testOnly_onLongPress?: Function | null | undefined;
 }
 interface ButtonWithRefProps {
-  innerRef?: React.ForwardedRef<React.ComponentType<any>>;
+  innerRef?: React.ForwardedRef<React.ComponentType<any>> | undefined;
 }
 
 /**
@@ -105,28 +105,28 @@ export interface LegacyBaseButtonProps extends LegacyRawButtonProps {
    * Called when the button gets pressed (analogous to `onPress` in
    * `TouchableHighlight` from RN core).
    */
-  onPress?: (pointerInside: boolean) => void;
+  onPress?: ((pointerInside: boolean) => void) | undefined;
 
   /**
    * Called when the button gets pressed and is held for `delayLongPress`
    * milliseconds.
    */
-  onLongPress?: () => void;
+  onLongPress?: (() => void) | undefined;
 
   /**
    * Called when button changes from inactive to active and vice versa. It
    * passes active state as a boolean variable as a first parameter for that
    * method.
    */
-  onActiveStateChange?: (active: boolean) => void;
+  onActiveStateChange?: ((active: boolean) => void) | undefined;
   style?: StyleProp<ViewStyle>;
-  testID?: string;
+  testID?: string | undefined;
 
   /**
    * Delay, in milliseconds, after which the `onLongPress` callback gets called.
    * Defaults to 600.
    */
-  delayLongPress?: number;
+  delayLongPress?: number | undefined;
 }
 export interface BaseButtonWithRefProps
   extends LegacyBaseButtonProps,
@@ -139,14 +139,14 @@ export interface LegacyRectButtonProps extends LegacyBaseButtonProps {
   /**
    * Background color that will be dimmed when button is in active state.
    */
-  underlayColor?: string;
+  underlayColor?: string | undefined;
 
   /**
    * iOS only.
    *
    * Opacity applied to the underlay when button is in active state.
    */
-  activeOpacity?: number;
+  activeOpacity?: number | undefined;
 }
 export interface RectButtonWithRefProps
   extends LegacyRectButtonProps,
@@ -162,7 +162,7 @@ export interface LegacyBorderlessButtonProps extends LegacyBaseButtonProps {
    *
    * Opacity applied to the button when it is in an active state.
    */
-  activeOpacity?: number;
+  activeOpacity?: number | undefined;
 }
 export interface BorderlessButtonWithRefProps
   extends LegacyBorderlessButtonProps,

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -19,48 +19,48 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
   /**
    * Defines if buttons should respond to touches. By default set to true.
    */
-  enabled?: boolean;
+  enabled?: boolean | undefined;
 
   /**
    * Defines if more than one button could be pressed simultaneously. By default
    * set true.
    */
-  exclusive?: boolean;
+  exclusive?: boolean | undefined;
 
   /**
    * Android only.
    *
    * Defines color of native ripple animation used since API level 21.
    */
-  rippleColor?: number | ColorValue | null;
+  rippleColor?: number | ColorValue | null | undefined;
 
   /**
    * Android only.
    *
    * Defines radius of native ripple animation used since API level 21.
    */
-  rippleRadius?: number | null;
+  rippleRadius?: number | null | undefined;
 
   /**
    * Android only.
    *
    * Set this to true if you want the ripple animation to render outside the view bounds.
    */
-  borderless?: boolean;
+  borderless?: boolean | undefined;
 
   /**
    * Android only.
    *
    * Defines whether the ripple animation should be drawn on the foreground of the view.
    */
-  foreground?: boolean;
+  foreground?: boolean | undefined;
 
   /**
    * Android only.
    *
    * Set this to true if you don't want the system to play sound when the button is pressed.
    */
-  touchSoundDisabled?: boolean;
+  touchSoundDisabled?: boolean | undefined;
 
   /**
    * Style object, use it to set additional styles.
@@ -77,28 +77,28 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
    * @deprecated test-only props are deprecated and will be removed in the future.
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  testOnly_onPress?: Function | null;
+  testOnly_onPress?: Function | null | undefined;
 
   /**
    * Used for testing-library compatibility, not passed to the native component.
    * @deprecated test-only props are deprecated and will be removed in the future.
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  testOnly_onPressIn?: Function | null;
+  testOnly_onPressIn?: Function | null | undefined;
 
   /**
    * Used for testing-library compatibility, not passed to the native component.
    * @deprecated test-only props are deprecated and will be removed in the future.
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  testOnly_onPressOut?: Function | null;
+  testOnly_onPressOut?: Function | null | undefined;
 
   /**
    * Used for testing-library compatibility, not passed to the native component.
    * @deprecated test-only props are deprecated and will be removed in the future.
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  testOnly_onLongPress?: Function | null;
+  testOnly_onLongPress?: Function | null | undefined;
 }
 
 const ButtonComponent =

--- a/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
@@ -26,7 +26,7 @@ export type InnerPressableEvent = {
   target: number;
   timestamp: number;
   touches: InnerPressableEvent[];
-  force?: number;
+  force?: number | undefined;
 };
 
 export type PressableEvent = { nativeEvent: InnerPressableEvent };

--- a/packages/react-native-gesture-handler/src/components/touchables/ExtraButtonProps.ts
+++ b/packages/react-native-gesture-handler/src/components/touchables/ExtraButtonProps.ts
@@ -1,7 +1,7 @@
 export type ExtraButtonProps = {
-  borderless?: boolean;
-  rippleColor?: number | string | null;
-  rippleRadius?: number | null;
-  foreground?: boolean;
-  exclusive?: boolean;
+  borderless?: boolean | undefined;
+  rippleColor?: number | string | null | undefined;
+  rippleRadius?: number | null | undefined;
+  foreground?: boolean | undefined;
+  exclusive?: boolean | undefined;
 };

--- a/packages/react-native-gesture-handler/src/components/touchables/TouchableHighlight.tsx
+++ b/packages/react-native-gesture-handler/src/components/touchables/TouchableHighlight.tsx
@@ -12,10 +12,10 @@ import {
 
 interface State {
   extraChildStyle: null | {
-    opacity?: number;
+    opacity?: number | undefined;
   };
   extraUnderlayStyle: null | {
-    backgroundColor?: ColorValue;
+    backgroundColor?: ColorValue | undefined;
   };
 }
 

--- a/packages/react-native-gesture-handler/src/handlers/GestureHandlerEventPayload.ts
+++ b/packages/react-native-gesture-handler/src/handlers/GestureHandlerEventPayload.ts
@@ -129,7 +129,7 @@ export type PanGestureHandlerEventPayload = {
   /**
    * Object containing additional stylus data.
    */
-  stylusData?: StylusData;
+  stylusData?: StylusData | undefined;
 };
 
 export type PinchGestureHandlerEventPayload = {
@@ -225,5 +225,5 @@ export type HoverGestureHandlerEventPayload = {
   /**
    * Object containing additional stylus data.
    */
-  stylusData?: StylusData;
+  stylusData?: StylusData | undefined;
 };

--- a/packages/react-native-gesture-handler/src/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/NativeViewGestureHandler.ts
@@ -17,13 +17,13 @@ export interface NativeViewGestureConfig {
    * Determines whether the handler should check for an existing touch event on
    * instantiation.
    */
-  shouldActivateOnStart?: boolean;
+  shouldActivateOnStart?: boolean | undefined;
 
   /**
    * When `true`, cancels all other gesture handlers when this
    * `NativeViewGestureHandler` receives an `ACTIVE` state event.
    */
-  disallowInterruption?: boolean;
+  disallowInterruption?: boolean | undefined;
 }
 
 /**

--- a/packages/react-native-gesture-handler/src/handlers/gestureHandlerCommon.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestureHandlerCommon.ts
@@ -63,7 +63,7 @@ export type HitSlop =
   | Partial<
       Record<
         'left' | 'right' | 'top' | 'bottom' | 'vertical' | 'horizontal',
-        number
+        number | undefined
       >
     >
   | Record<'width' | 'left', number>
@@ -181,14 +181,14 @@ export type GestureStateChangeEvent<
 > = HandlerStateChangeEventPayload & GestureStateChangeEventPayloadT;
 
 export type CommonGestureConfig = {
-  enabled?: boolean;
-  shouldCancelWhenOutside?: boolean;
-  hitSlop?: HitSlop;
-  userSelect?: UserSelect;
-  activeCursor?: ActiveCursor;
-  mouseButton?: MouseButton;
-  enableContextMenu?: boolean;
-  touchAction?: TouchAction;
+  enabled?: boolean | undefined;
+  shouldCancelWhenOutside?: boolean | undefined;
+  hitSlop?: HitSlop | undefined;
+  userSelect?: UserSelect | undefined;
+  activeCursor?: ActiveCursor | undefined;
+  mouseButton?: MouseButton | undefined;
+  enableContextMenu?: boolean | undefined;
+  touchAction?: TouchAction | undefined;
 };
 
 // Events payloads are types instead of interfaces due to TS limitation.
@@ -196,24 +196,26 @@ export type CommonGestureConfig = {
 export type BaseGestureHandlerProps<
   ExtraEventPayloadT extends Record<string, unknown> = Record<string, unknown>,
 > = CommonGestureConfig & {
-  id?: string;
-  waitFor?: React.Ref<unknown> | React.Ref<unknown>[];
-  simultaneousHandlers?: React.Ref<unknown> | React.Ref<unknown>[];
-  blocksHandlers?: React.Ref<unknown> | React.Ref<unknown>[];
-  testID?: string;
-  cancelsTouchesInView?: boolean;
+  id?: string | undefined;
+  waitFor?: React.Ref<unknown> | React.Ref<unknown>[] | undefined;
+  simultaneousHandlers?: React.Ref<unknown> | React.Ref<unknown>[] | undefined;
+  blocksHandlers?: React.Ref<unknown> | React.Ref<unknown>[] | undefined;
+  testID?: string | undefined;
+  cancelsTouchesInView?: boolean | undefined;
   // TODO(TS) - fix event types
-  onBegan?: (event: HandlerStateChangeEvent) => void;
-  onFailed?: (event: HandlerStateChangeEvent) => void;
-  onCancelled?: (event: HandlerStateChangeEvent) => void;
-  onActivated?: (event: HandlerStateChangeEvent) => void;
-  onEnded?: (event: HandlerStateChangeEvent) => void;
+  onBegan?: ((event: HandlerStateChangeEvent) => void) | undefined;
+  onFailed?: ((event: HandlerStateChangeEvent) => void) | undefined;
+  onCancelled?: ((event: HandlerStateChangeEvent) => void) | undefined;
+  onActivated?: ((event: HandlerStateChangeEvent) => void) | undefined;
+  onEnded?: ((event: HandlerStateChangeEvent) => void) | undefined;
 
   // TODO(TS) consider using NativeSyntheticEvent
-  onGestureEvent?: (event: GestureEvent<ExtraEventPayloadT>) => void;
-  onHandlerStateChange?: (
-    event: HandlerStateChangeEvent<ExtraEventPayloadT>
-  ) => void;
+  onGestureEvent?:
+    | ((event: GestureEvent<ExtraEventPayloadT>) => void)
+    | undefined;
+  onHandlerStateChange?:
+    | ((event: HandlerStateChangeEvent<ExtraEventPayloadT>) => void)
+    | undefined;
   // Implicit `children` prop has been removed in @types/react^18.0.0
   children?: React.ReactNode;
 };

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerDetectorNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerDetectorNativeComponent.ts
@@ -51,13 +51,25 @@ export interface VirtualChildrenProps {
 // @ts-expect-error WithDefault adds `| null` to the type, which doesn't align with ViewProps.pointerEvents
 // Using Exclude to remove null from the type makes the error go away, but breaks codegen.
 export interface NativeProps extends ViewProps {
-  onGestureHandlerEvent?: DirectEventHandler<GestureHandlerEvent>;
-  onGestureHandlerStateChange?: DirectEventHandler<GestureHandlerStateChangeEvent>;
-  onGestureHandlerTouchEvent?: DirectEventHandler<GestureHandlerTouchEvent>;
-  onGestureHandlerReanimatedEvent?: DirectEventHandler<GestureHandlerEvent>;
-  onGestureHandlerReanimatedStateChange?: DirectEventHandler<GestureHandlerStateChangeEvent>;
-  onGestureHandlerReanimatedTouchEvent?: DirectEventHandler<GestureHandlerTouchEvent>;
-  onGestureHandlerAnimatedEvent?: DirectEventHandler<GestureHandlerEvent>;
+  onGestureHandlerEvent?: DirectEventHandler<GestureHandlerEvent> | undefined;
+  onGestureHandlerStateChange?:
+    | DirectEventHandler<GestureHandlerStateChangeEvent>
+    | undefined;
+  onGestureHandlerTouchEvent?:
+    | DirectEventHandler<GestureHandlerTouchEvent>
+    | undefined;
+  onGestureHandlerReanimatedEvent?:
+    | DirectEventHandler<GestureHandlerEvent>
+    | undefined;
+  onGestureHandlerReanimatedStateChange?:
+    | DirectEventHandler<GestureHandlerStateChangeEvent>
+    | undefined;
+  onGestureHandlerReanimatedTouchEvent?:
+    | DirectEventHandler<GestureHandlerTouchEvent>
+    | undefined;
+  onGestureHandlerAnimatedEvent?:
+    | DirectEventHandler<GestureHandlerEvent>
+    | undefined;
 
   handlerTags: Int32[];
   moduleId: Int32;

--- a/packages/react-native-gesture-handler/src/v3/components/GestureButtonsProps.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/GestureButtonsProps.ts
@@ -16,41 +16,41 @@ export interface BaseButtonProps extends RawButtonProps {
    * Called when the button gets pressed (analogous to `onPress` in
    * `TouchableHighlight` from RN core).
    */
-  onPress?: (pointerInside: boolean) => void;
+  onPress?: ((pointerInside: boolean) => void) | undefined;
 
   /**
    * Called when the button gets pressed and is held for `delayLongPress`
    * milliseconds.
    */
-  onLongPress?: () => void;
+  onLongPress?: (() => void) | undefined;
 
   /**
    * Called when button changes from inactive to active and vice versa. It
    * passes active state as a boolean variable as a first parameter for that
    * method.
    */
-  onActiveStateChange?: (active: boolean) => void;
+  onActiveStateChange?: ((active: boolean) => void) | undefined;
   style?: StyleProp<ViewStyle>;
 
   /**
    * Delay, in milliseconds, after which the `onLongPress` callback gets called.
    * Defaults to 600.
    */
-  delayLongPress?: number;
+  delayLongPress?: number | undefined;
 }
 
 export interface RectButtonProps extends BaseButtonProps {
   /**
    * Background color that will be dimmed when button is in active state.
    */
-  underlayColor?: string;
+  underlayColor?: string | undefined;
 
   /**
    * iOS only.
    *
    * Opacity applied to the underlay when button is in active state.
    */
-  activeOpacity?: number;
+  activeOpacity?: number | undefined;
 }
 
 export interface BorderlessButtonProps extends BaseButtonProps {
@@ -59,5 +59,5 @@ export interface BorderlessButtonProps extends BaseButtonProps {
    *
    * Opacity applied to the button when it is in an active state.
    */
-  activeOpacity?: number;
+  activeOpacity?: number | undefined;
 }

--- a/packages/react-native-gesture-handler/src/v3/detectors/HostGestureDetector.web.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/HostGestureDetector.web.tsx
@@ -11,18 +11,18 @@ export interface GestureHandlerDetectorProps extends PropsRef {
   moduleId: number;
   children?: React.ReactNode;
   virtualChildren?: Set<VirtualChildrenWeb>;
-  userSelect?: UserSelect;
-  touchAction?: TouchAction;
-  enableContextMenu?: boolean;
+  userSelect?: UserSelect | undefined;
+  touchAction?: TouchAction | undefined;
+  enableContextMenu?: boolean | undefined;
 }
 
 export interface VirtualChildrenWeb {
   viewTag: number;
   handlerTags: number[];
   viewRef: RefObject<Element | null>;
-  userSelect?: UserSelect;
-  touchAction?: TouchAction;
-  enableContextMenu?: boolean;
+  userSelect?: UserSelect | undefined;
+  touchAction?: TouchAction | undefined;
+  enableContextMenu?: boolean | undefined;
 }
 
 const EMPTY_HANDLERS = new Set<number>();

--- a/packages/react-native-gesture-handler/src/v3/detectors/common.ts
+++ b/packages/react-native-gesture-handler/src/v3/detectors/common.ts
@@ -13,9 +13,9 @@ export enum GestureDetectorType {
 
 interface CommonGestureDetectorProps {
   children?: React.ReactNode;
-  userSelect?: UserSelect;
-  touchAction?: TouchAction;
-  enableContextMenu?: boolean;
+  userSelect?: UserSelect | undefined;
+  touchAction?: TouchAction | undefined;
+  enableContextMenu?: boolean | undefined;
 }
 
 export interface NativeDetectorProps<

--- a/packages/react-native-gesture-handler/src/v3/types/ConfigTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/ConfigTypes.ts
@@ -28,15 +28,20 @@ export type GestureCallbacks<
   THandlerData,
   TExtendedHandlerData extends THandlerData = THandlerData,
 > = {
-  onBegin?: GestureEventCallback<THandlerData>;
-  onActivate?: GestureEventCallback<TExtendedHandlerData>;
-  onUpdate?: GestureEventCallback<TExtendedHandlerData> | AnimatedEvent;
-  onDeactivate?: GestureEventCallbackWithDidSucceed<TExtendedHandlerData>;
-  onFinalize?: GestureEventCallbackWithDidSucceed<THandlerData>;
-  onTouchesDown?: GestureTouchEventCallback;
-  onTouchesMove?: GestureTouchEventCallback;
-  onTouchesUp?: GestureTouchEventCallback;
-  onTouchesCancel?: GestureTouchEventCallback;
+  onBegin?: GestureEventCallback<THandlerData> | undefined;
+  onActivate?: GestureEventCallback<TExtendedHandlerData> | undefined;
+  onUpdate?:
+    | GestureEventCallback<TExtendedHandlerData>
+    | AnimatedEvent
+    | undefined;
+  onDeactivate?:
+    | GestureEventCallbackWithDidSucceed<TExtendedHandlerData>
+    | undefined;
+  onFinalize?: GestureEventCallbackWithDidSucceed<THandlerData> | undefined;
+  onTouchesDown?: GestureTouchEventCallback | undefined;
+  onTouchesMove?: GestureTouchEventCallback | undefined;
+  onTouchesUp?: GestureTouchEventCallback | undefined;
+  onTouchesCancel?: GestureTouchEventCallback | undefined;
 };
 
 export type GestureRelations = {
@@ -46,31 +51,35 @@ export type GestureRelations = {
 };
 
 export type InternalConfigProps<TExtendedHandlerData> = {
-  shouldUseReanimatedDetector?: boolean;
-  dispatchesReanimatedEvents?: boolean;
-  dispatchesAnimatedEvents?: boolean;
-  needsPointerData?: boolean;
-  userSelect?: UserSelect;
-  touchAction?: TouchAction;
-  enableContextMenu?: boolean;
-  changeEventCalculator?: ChangeCalculatorType<TExtendedHandlerData>;
-  fillInDefaultValues?: (event: GestureEvent<TExtendedHandlerData>) => void;
+  shouldUseReanimatedDetector?: boolean | undefined;
+  dispatchesReanimatedEvents?: boolean | undefined;
+  dispatchesAnimatedEvents?: boolean | undefined;
+  needsPointerData?: boolean | undefined;
+  userSelect?: UserSelect | undefined;
+  touchAction?: TouchAction | undefined;
+  enableContextMenu?: boolean | undefined;
+  changeEventCalculator?:
+    | ChangeCalculatorType<TExtendedHandlerData>
+    | undefined;
+  fillInDefaultValues?:
+    | ((event: GestureEvent<TExtendedHandlerData>) => void)
+    | undefined;
 };
 
 export type CommonGestureConfig = {
-  disableReanimated?: boolean;
-  useAnimated?: boolean;
-  testID?: string;
+  disableReanimated?: boolean | undefined;
+  useAnimated?: boolean | undefined;
+  testID?: string | undefined;
 } & WithSharedValue<
   {
-    runOnJS?: boolean;
-    enabled?: boolean;
-    shouldCancelWhenOutside?: boolean;
-    hitSlop?: HitSlop;
-    activeCursor?: ActiveCursor;
-    mouseButton?: MouseButton;
-    cancelsTouchesInView?: boolean;
-    manualActivation?: boolean;
+    runOnJS?: boolean | undefined;
+    enabled?: boolean | undefined;
+    shouldCancelWhenOutside?: boolean | undefined;
+    hitSlop?: HitSlop | undefined;
+    activeCursor?: ActiveCursor | undefined;
+    mouseButton?: MouseButton | undefined;
+    cancelsTouchesInView?: boolean | undefined;
+    manualActivation?: boolean | undefined;
   },
   ActiveCursor | MouseButton
 >;

--- a/packages/react-native-gesture-handler/src/v3/types/DetectorTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/DetectorTypes.ts
@@ -40,7 +40,7 @@ export type VirtualChild = {
 
   // only set on web
   viewRef: unknown;
-  userSelect?: UserSelect;
-  touchAction?: TouchAction;
-  enableContextMenu?: boolean;
+  userSelect?: UserSelect | undefined;
+  touchAction?: TouchAction | undefined;
+  enableContextMenu?: boolean | undefined;
 };

--- a/packages/react-native-gesture-handler/src/v3/types/GestureTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/GestureTypes.ts
@@ -10,9 +10,9 @@ import { FilterNeverProperties } from './UtilityTypes';
 
 // Unfortunately, this type cannot be moved into ConfigTypes.ts because of circular dependency
 export type ExternalRelations = {
-  simultaneousWith?: AnyGesture | AnyGesture[];
-  requireToFail?: AnyGesture | AnyGesture[];
-  block?: AnyGesture | AnyGesture[];
+  simultaneousWith?: AnyGesture | AnyGesture[] | undefined;
+  requireToFail?: AnyGesture | AnyGesture[] | undefined;
+  block?: AnyGesture | AnyGesture[] | undefined;
 };
 
 // Similarly, this type cannot be moved into ConfigTypes.ts because it depends on `ExternalRelations`

--- a/packages/react-native-gesture-handler/src/v3/types/ReanimatedTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/ReanimatedTypes.ts
@@ -37,7 +37,7 @@ type WithSharedValueRecursive<T extends object, P> = {
     ? Simplify<SharedValueOrT<T[K], P>>
     : // Special case for boolean as passing `boolean` as P doesn't look ok.
       boolean extends T[K]
-      ? boolean | SharedValue<boolean>
+      ? boolean | SharedValue<boolean> | Extract<T[K], undefined>
       : // Special handling for tuples [number, number].
         T[K] extends [number, number]
         ? [WithSharedValue<number, P>, WithSharedValue<number, P>]

--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -48,18 +48,18 @@ export default abstract class GestureHandler implements IGestureHandler {
   private forAnimated: boolean = false;
   private forReanimated: boolean = false;
   private _handlerTag!: number;
-  private _testID?: string = undefined;
+  private _testID?: string | undefined = undefined;
 
-  private hitSlop?: HitSlop = undefined;
+  private hitSlop?: HitSlop | undefined = undefined;
   private manualActivation: boolean = false;
-  private mouseButton?: MouseButton = undefined;
+  private mouseButton?: MouseButton | undefined = undefined;
   private needsPointerData: boolean = false;
   private _tracker: PointerTracker = new PointerTracker();
 
   private _enableContextMenu: boolean = false;
-  private _activeCursor?: ActiveCursor = undefined;
-  private _touchAction?: TouchAction = undefined;
-  private _userSelect?: UserSelect = undefined;
+  private _activeCursor?: ActiveCursor | undefined = undefined;
+  private _touchAction?: TouchAction | undefined = undefined;
+  private _userSelect?: UserSelect | undefined = undefined;
 
   // Orchestrator properties
   private _activationIndex = 0;

--- a/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
@@ -18,7 +18,7 @@ export default interface IGestureHandler {
   activationIndex: number;
   awaiting: boolean;
   handlerTag: number;
-  readonly testID?: string;
+  readonly testID?: string | undefined;
   readonly delegate: GestureHandlerDelegate<unknown, this>;
   readonly tracker: PointerTracker;
   readonly name: SingleGestureName;
@@ -28,9 +28,9 @@ export default interface IGestureHandler {
   readonly enabled: boolean | null;
   readonly pointerType: PointerType;
   enableContextMenu: boolean;
-  readonly activeCursor?: ActiveCursor;
-  readonly touchAction?: TouchAction;
-  readonly userSelect?: UserSelect;
+  readonly activeCursor?: ActiveCursor | undefined;
+  readonly touchAction?: TouchAction | undefined;
+  readonly userSelect?: UserSelect | undefined;
 
   attachEventManager: (manager: EventManager<unknown>) => void;
 

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -147,7 +147,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
   }
 
   public override shouldRecognizeSimultaneously(
-    handler: GestureHandler
+    handler: IGestureHandler
   ): boolean {
     if (super.shouldRecognizeSimultaneously(handler)) {
       return true;
@@ -176,7 +176,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
     );
   }
 
-  public override shouldBeCancelledByOther(_handler: GestureHandler): boolean {
+  public override shouldBeCancelledByOther(_handler: IGestureHandler): boolean {
     return !this.disallowInterruption;
   }
 

--- a/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
@@ -16,7 +16,7 @@ export default class PanGestureHandler extends GestureHandler {
   public velocityX = 0;
   public velocityY = 0;
 
-  private minDist?: number = undefined;
+  private minDist?: number | undefined = undefined;
   private minDistSq = DEFAULT_MIN_DIST_SQ;
 
   private activeOffsetXStart = -Number.MAX_SAFE_INTEGER;

--- a/packages/react-native-gesture-handler/src/web/interfaces.ts
+++ b/packages/react-native-gesture-handler/src/web/interfaces.ts
@@ -15,14 +15,14 @@ import {
 import { State } from '../State';
 
 export interface HitSlop {
-  left?: number;
-  right?: number;
-  top?: number;
-  bottom?: number;
-  horizontal?: number;
-  vertical?: number;
-  width?: number;
-  height?: number;
+  left?: number | undefined;
+  right?: number | undefined;
+  top?: number | undefined;
+  bottom?: number | undefined;
+  horizontal?: number | undefined;
+  vertical?: number | undefined;
+  width?: number | undefined;
+  height?: number | undefined;
 }
 
 export interface Handler {
@@ -44,21 +44,21 @@ type ConfigArgs =
 
 export interface Config extends Record<string, ConfigArgs> {
   enabled: boolean;
-  simultaneousHandlers?: Handler[] | null;
-  waitFor?: Handler[] | null;
-  blocksHandlers?: Handler[] | null;
-  hitSlop?: HitSlop;
-  shouldCancelWhenOutside?: boolean;
-  userSelect?: UserSelect;
-  activeCursor?: ActiveCursor;
-  mouseButton?: MouseButton;
-  enableContextMenu?: boolean;
-  touchAction?: TouchAction;
-  manualActivation?: boolean;
-  dispatchesAnimatedEvents?: false;
-  dispatchesReanimatedEvents?: boolean;
-  needsPointerData?: false;
-  testID?: string;
+  simultaneousHandlers?: Handler[] | null | undefined;
+  waitFor?: Handler[] | null | undefined;
+  blocksHandlers?: Handler[] | null | undefined;
+  hitSlop?: HitSlop | undefined;
+  shouldCancelWhenOutside?: boolean | undefined;
+  userSelect?: UserSelect | undefined;
+  activeCursor?: ActiveCursor | undefined;
+  mouseButton?: MouseButton | undefined;
+  enableContextMenu?: boolean | undefined;
+  touchAction?: TouchAction | undefined;
+  manualActivation?: boolean | undefined;
+  dispatchesAnimatedEvents?: false | undefined;
+  dispatchesReanimatedEvents?: boolean | undefined;
+  needsPointerData?: false | undefined;
+  testID?: string | undefined;
 
   activateAfterLongPress?: number;
   failOffsetXStart?: number;
@@ -98,7 +98,7 @@ export interface GestureHandlerNativeEvent
   numberOfPointers: number;
   state: State;
   handlerTag: number;
-  oldState?: State;
+  oldState?: State | undefined;
   pointerType: PointerType;
 }
 
@@ -147,9 +147,9 @@ export interface AdaptedEvent {
   eventType: EventTypes;
   pointerType: PointerType;
   time: number;
-  button?: MouseButton;
-  stylusData?: StylusData;
-  wheelDeltaY?: number;
+  button?: MouseButton | undefined;
+  stylusData?: StylusData | undefined;
+  wheelDeltaY?: number | undefined;
 }
 
 export enum EventTypes {

--- a/packages/react-native-gesture-handler/tsconfig.json
+++ b/packages/react-native-gesture-handler/tsconfig.json
@@ -2,9 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "lib/typescript",
+    "exactOptionalPropertyTypes": true,
     "paths": {
       "react-native-gesture-handler": ["./src"]
-    }, "types": ["./src/global.d.ts", "jest"]
+    },
+    "types": ["./src/global.d.ts", "jest"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "jestSetup.js"]
 }


### PR DESCRIPTION
## Description

This PR enables TypeScript's [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) flag in `react-native-gesture-handler` and fixes all 60 resulting type errors across 22 files.

`exactOptionalPropertyTypes` is a strict TypeScript flag (not included in `strict: true`) that distinguishes between "property is missing" and "property is explicitly `undefined`". When enabled, `prop?: T` means the property can be omitted but cannot be set to `undefined` — the fix is `prop?: T | undefined`.

This matters for downstream projects that enable this flag — without this change, they get type errors when using gesture-handler components. This is currently blocking [react-navigation from enabling the flag](https://github.com/react-navigation/react-navigation/pull/12995).

### What changed

Three categories of fixes across v2 (class-based), v3 (hooks-based), and web handler code:

1. **Type declarations** — Added `| undefined` to optional properties in interfaces and types (`HitSlop`, `CommonGestureConfig`, `BaseGestureHandlerProps`, `ButtonProps`, `ExternalRelations`, `VirtualChild`, `IGestureHandler`, etc.)

2. **Class property types** — Updated class property declarations in `GestureHandler.ts` to include `| undefined` for optional config properties (`_testID`, `hitSlop`, `mouseButton`, `_activeCursor`, etc.)

3. **`WithSharedValueRecursive` mapped type** — Fixed the boolean special case in `ReanimatedTypes.ts` to preserve `undefined` from optional properties using `| Extract<T[K], undefined>`

All changes are type annotations only — zero runtime changes.

### Codegen compatibility

The `src/specs/` files are consumed by `@react-native/codegen`. One spec file was modified (`RNGestureHandlerDetectorNativeComponent.ts` — 7 `DirectEventHandler` event props). Adding `| undefined` to these is safe — the codegen parser ([`parseTopLevelType.js`](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js)) explicitly strips `undefined` from union types and treats the result identically to `prop?: T`.

I verified that the codegen schema output is **byte-identical** between `main` and this branch:
```bash
node node_modules/@react-native/codegen/lib/cli/combine/combine-js-to-schema-cli.js \
  /tmp/schema.json --libraryName rngesturehandler_codegen \
  packages/react-native-gesture-handler/src/specs/RNGestureHandlerDetectorNativeComponent.ts \
  packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
```

## Test plan

All quality gates pass:

- `yarn workspace react-native-gesture-handler ts-check` — 0 errors
- `yarn workspace react-native-gesture-handler lint-js` — 0 errors
- `yarn workspace react-native-gesture-handler test` — 5 suites, 41 tests pass
- `yarn workspace react-native-gesture-handler circular-dependency-check` — pass