### PR TITLE
Move @types/react-test-renderer to dependencies

### DIFF
--- a/packages/react-native-gesture-handler/package.json
+++ b/packages/react-native-gesture-handler/package.json
@@ -66,6 +66,7 @@
   },
   "homepage": "https://docs.swmansion.com/react-native-gesture-handler/",
   "dependencies": {
+    "@types/react-test-renderer": "^19.1.0",
     "invariant": "^2.2.4"
   },
   "devDependencies": {
@@ -77,7 +78,6 @@
     "@types/invariant": "^2.2.37",
     "@types/jest": "^27.0.3",
     "@types/react": "^19.2.0",
-    "@types/react-test-renderer": "^19.1.0",
     "@typescript-eslint/eslint-plugin": "^6.9.0",
     "@typescript-eslint/parser": "^6.9.0",
     "babel-plugin-module-resolver": "^5.0.2",


### PR DESCRIPTION
## Summary

Move `@types/react-test-renderer` from `devDependencies` to `dependencies`.

The published `lib/typescript/jestUtils/jestUtils.d.ts` imports `ReactTestInstance` from `react-test-renderer` (line 1). Since `@types/react-test-renderer` is only in `devDependencies`, it's not installed for consumers — causing `TS2307: Cannot find module 'react-test-renderer'` for projects with `skipLibCheck: false`.

The [TypeScript handbook](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) is explicit: when published `.d.ts` files reference `@types/*` packages, those packages must be in `dependencies` so consumers resolve them automatically. Several major packages have fixed this exact pattern:

- [webpack/schema-utils#97](https://github.com/webpack/schema-utils/issues/97) — moved `@types/json-schema` to `dependencies` for the same reason
- [@mui/material#14508](https://github.com/mui/material-ui/issues/14508) — keeps `@types/react-transition-group` in `dependencies` because published types extend it
- [react-native-testing-library#1534](https://github.com/callstack/react-native-testing-library/issues/1534) — shipped `.d.ts` broke `skipLibCheck: false` consumers, fixed within 2 days

This repo dealt with the same class of issue in #1990 (move `@types/react-native` to `dependencies` — closed only because RN 0.71+ bundled its own types, not because the approach was rejected) and #2259 (shipped `.d.ts` type errors).

Note: `react-test-renderer` is [deprecated in React 19](https://react.dev/warnings/react-test-renderer). As more projects drop it from their own dependencies, this breakage will increase for downstream consumers.

## Test plan

**Consumer reproduction:**

```bash
mkdir test-rngh && cd test-rngh
npm init -y
npm install react react-native react-native-gesture-handler typescript @types/react
```

`tsconfig.json`:
```json
{
  "compilerOptions": {
    "strict": true,
    "noEmit": true,
    "skipLibCheck": false,
    "moduleResolution": "bundler",
    "module": "esnext",
    "target": "esnext",
    "jsx": "react-jsx"
  },
  "include": ["*.ts"]
}
```

`repro.ts`:
```typescript
import type { fireGestureHandler } from 'react-native-gesture-handler/lib/typescript/jestUtils/jestUtils';
export type { fireGestureHandler };
```

```bash
npx tsc --noEmit
# Error: Cannot find module 'react-test-renderer' or its corresponding type declarations.
# At: node_modules/react-native-gesture-handler/lib/typescript/jestUtils/jestUtils.d.ts(1,35)

npm install @types/react-test-renderer
npx tsc --noEmit
# Clean — zero errors
```

**Upstream quality gates:**

```bash
yarn workspace react-native-gesture-handler ts-check  # PASS
yarn workspace react-native-gesture-handler build      # PASS — module + commonjs + typescript
```

Zero regressions.
