### PR TITLE
[Android] Clear blocking relations on drop

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.kt
@@ -65,6 +65,7 @@ class RNGestureHandlerInteractionManager : GestureHandlerInteractionController {
   fun reset() {
     waitForRelations.clear()
     simultaneousRelations.clear()
+    blockingRelations.clear()
   }
 
   companion object {


### PR DESCRIPTION
## Description

During tests of new `Clickable` component Gemini pointed out that we have small leak. This PR adds cleanup of blocking relation array on handlers' drop.

## Test plan

Expo examples works as it used to