### PR TITLE
Add `Pan` offset props to `PropsToFilter`

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
@@ -78,6 +78,12 @@ export const PropsToFilter = new Set<
   'shouldUseReanimatedDetector',
   'useAnimated',
   'runOnJS',
+
+  // Pan offset props before remapping:
+  'activeOffsetY',
+  'failOffsetX',
+  'failOffsetY',
+  'activeOffsetX',
 ]);
 
 export const PropsWhiteLists = new Map<


### PR DESCRIPTION
## Description

In `Pan` gesture, offset properties are handled differently than other props. Before they're sent to native side, they are mapped to separate `start` and `end` offset properties. This happens when offset props are present. However, if one explicitly sets value of offset property to `undefined`, e.g.:

```ts
activeOffsetY: Platform.OS === 'android' ? [-75, 75] : undefined,
```

the following warning can be observed:

```
WARN  [react-native-gesture-handler] activeOffsetY is not a valid property for PanGestureHandler and will be ignored.
```

This PR adds offset properties to our filter. With this change, warning no longer appears.

Fixes #4021

> [!NOTE]
> It could also be solved by dynamically deleting `undefined` fields from config, but simply ignoring them sounds safer.

## Test plan

<details>
<summary>Tested on the following code:</summary>

```tsx
import React from 'react';
import { StyleSheet, Text, View, Platform } from 'react-native';
import { usePanGesture } from 'react-native-gesture-handler';

export default function EmptyExample() {
  const panGesture = usePanGesture({
    activeOffsetY: Platform.OS === 'android' ? [-75, 75] : undefined,
  });

  return (
    <View style={styles.container}>
      <Text style={{ fontSize: 64, opacity: 0.25 }}>😞</Text>
      <Text style={{ fontSize: 24, opacity: 0.25 }}>It's so empty here</Text>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
});
```

</details>