### PR TITLE
[iOS] Fix missing `onFinalize` callback in `Tap`

### DIFF
--- a/packages/react-native-gesture-handler/apple/Handlers/RNTapHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNTapHandler.m
@@ -148,6 +148,8 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
   self.state = UIGestureRecognizerStateCancelled;
+
+  [self triggerAction];
 }
 
 #if TARGET_OS_OSX


### PR DESCRIPTION
## Description

On iOS, `onFinalize` callback is not triggered when `Tap` fails. Turns out that `handleGesture:` is not called from `interactionsCancelled` method. This PR fixes this problem.

## Test plan

Tested on iOS 26.1 and 18.5.

<details>
<summary>Tested on the following example:</summary>

```tsx
import { StyleSheet, View } from 'react-native';
import {
  GestureDetector,
  GestureHandlerRootView,
  useTapGesture,
} from 'react-native-gesture-handler';

export default function App() {
  const tap = useTapGesture({
    onFinalize: () => {
      console.log('[tap] onFinalize');
    },
    onTouchesCancel: () => {
      console.log('[tap] onTouchesCancel');
    },
  });

  return (
    <GestureHandlerRootView style={styles.container}>
      <GestureDetector gesture={tap}>
        <View style={styles.box} />
      </GestureDetector>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
  box: {
    width: 100,
    height: 100,
    backgroundColor: 'crimson',
    borderRadius: 10,
  },
});
```

</details>
