### PR TITLE
Do not import `NativeWrapperProps` as type

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/components/GestureComponents.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/GestureComponents.tsx
@@ -15,7 +15,7 @@ import {
 import createNativeWrapper from '../createNativeWrapper';
 
 import type { NativeWrapperProperties } from '../types/NativeWrapperType';
-import type { NativeWrapperProps } from '../hooks/utils';
+import { NativeWrapperProps } from '../hooks/utils';
 import { GestureDetectorType } from '../detectors';
 import type { NativeGesture } from '../hooks/gestures/native/NativeTypes';
 import { ghQueueMicrotask } from '../../ghQueueMicrotask';


### PR DESCRIPTION
## Description

Currently in `GestureComponents.tsx` we import `NativeWrapperProps` as `type`. However, in `FlatList` we need this as value to be able to [iterate over values](https://github.com/software-mansion/react-native-gesture-handler/blob/3918d8ae52020d6b64f31c2ae0b06b19b284c699/packages/react-native-gesture-handler/src/v3/components/GestureComponents.tsx#L136). When imported as type, it crashes.

## Test plan

<details>
<summary>Tested on the following code:</summary>

```tsx
import { Pressable as RNPressable, Text } from 'react-native';
import {
  GestureHandlerRootView,
  FlatList,
  Pressable,
} from 'react-native-gesture-handler';

export default function TestComponent() {
  return (
    <GestureHandlerRootView>
      <Text>RN</Text>
      <FlatList
        horizontal
        data={[1, 2, 3, 4, 5]}
        renderItem={() => (
          <RNPressable
            style={{
              borderWidth: 5,
              width: 50,
              height: 50,
              borderColor: 'black',
            }}
          />
        )}
      />

      <Text>RNGH</Text>
      <FlatList
        horizontal
        data={[1, 2, 3, 4, 5]}
        renderItem={() => (
          <Pressable
            style={{
              borderWidth: 5,
              width: 50,
              height: 50,
              borderColor: 'blue',
            }}
          />
        )}
      />
    </GestureHandlerRootView>
  );
}
```

</details>