### PR TITLE
Add missing handlers callbacks to buttons

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/components/GestureButtons.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/GestureButtons.tsx
@@ -39,6 +39,8 @@ export const BaseButton = (props: BaseButtonProps) => {
       if (onLongPress) {
         longPressTimeout.current = setTimeout(wrappedLongPress, delayLongPress);
       }
+
+      props.onBegin?.(e);
     }
   };
 
@@ -50,27 +52,35 @@ export const BaseButton = (props: BaseButtonProps) => {
       if (onLongPress) {
         longPressTimeout.current = setTimeout(wrappedLongPress, delayLongPress);
       }
+
+      props.onBegin?.(e);
     }
 
     if (!e.pointerInside && longPressTimeout.current !== undefined) {
       clearTimeout(longPressTimeout.current);
       longPressTimeout.current = undefined;
     }
+
+    props.onActivate?.(e);
   };
 
-  const onDeactivate = (e: CallbackEventType, success: boolean) => {
+  const onDeactivate = (e: CallbackEventType, didSucceed: boolean) => {
     onActiveStateChange?.(false);
 
-    if (success && !longPressDetected.current) {
+    if (didSucceed && !longPressDetected.current) {
       onPress?.(e.pointerInside);
     }
+
+    props.onDeactivate?.(e, didSucceed);
   };
 
-  const onFinalize = (_e: CallbackEventType) => {
+  const onFinalize = (e: CallbackEventType, didSucceed: boolean) => {
     if (longPressTimeout.current !== undefined) {
       clearTimeout(longPressTimeout.current);
       longPressTimeout.current = undefined;
     }
+
+    props.onFinalize?.(e, didSucceed);
   };
 
   return (


### PR DESCRIPTION
## Description

In our buttons implementations we override `on*` callbacks for `Native` gesture (except of `onUpdate`). This PR fixes this issue by calling originally passed callbacks inside overriden ones.

## Test plan

<details>
<summary>Tested on the following example:</summary>

```tsx
import { StyleSheet } from 'react-native';
import {
  RectButton,
  GestureHandlerRootView,
} from 'react-native-gesture-handler';

export default function App() {
  return (
    <GestureHandlerRootView style={styles.container}>
      <RectButton
        style={styles.box}
        onBegin={(e) => {
          console.log('onBegin', e, Date.now());
        }}
        onActivate={(e) => {
          console.log('onActivate', e, Date.now());
        }}
        onUpdate={(e) => {
          console.log('onUpdate', e, Date.now());
        }}
        onDeactivate={(e, s) => {
          console.log('onDeactivate', e, s, Date.now());
        }}
        onFinalize={(e, s) => {
          console.log('onFinalize', e, s, Date.now());
        }}
      />
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
  box: {
    width: 200,
    height: 50,
    borderRadius: 15,
    backgroundColor: '#007AFF',
  },
});
```

</details>