### PR TITLE
Bring back `onUpdate` to `Native` gesture

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/NativeTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/NativeTypes.ts
@@ -1,5 +1,5 @@
 import {
-  BaseDiscreteGestureConfig,
+  BaseGestureConfig,
   ExcludeInternalConfigProps,
   GestureEvent,
   SingleGesture,
@@ -33,7 +33,7 @@ export type NativeHandlerData = {
 export type NativeGestureProperties =
   WithSharedValue<NativeGestureNativeProperties>;
 
-export type NativeGestureInternalConfig = BaseDiscreteGestureConfig<
+export type NativeGestureInternalConfig = BaseGestureConfig<
   NativeGestureProperties,
   NativeHandlerData
 >;


### PR DESCRIPTION
## Description

`onUpdate` callback was removed from `Native` gesture config. However, `Native` can be treated as continuous gesture and having this callback might be useful.

## Test plan

<details>
<summary>Tested on Android on the following code: </summary>

```tsx
import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
import {
  RectButton,
  GestureHandlerRootView,
  useNativeGesture,
  GestureDetector,
} from 'react-native-gesture-handler';

export default function App() {
  const native = useNativeGesture({
    onBegin: (e) => {
      console.log('Native onBegin', e, Date.now());
    },
    onUpdate: (e) => {
      console.log('Native onUpdate', e, Date.now());
    },
  });
  return (
    <GestureHandlerRootView style={styles.container}>
      <GestureDetector gesture={native}>
        <Pressable style={styles.box} />
      </GestureDetector>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
  box: {
    width: 200,
    height: 50,
    borderRadius: 15,
    backgroundColor: '#007AFF',
  },
});
```

</details>