### PR TITLE
[iOS] Handle `FullWindowOverlay` as the native root

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
@@ -271,9 +271,10 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
 - (void)registerViewWithGestureRecognizerAttachedIfNeeded:(RNGHUIView *)childView
 {
   RNGHUIView *touchHandlerView = childView;
-  Class fullWindowOverlayContainerClass = NSClassFromString(@"RNSFullWindowOverlayContainer");
 
 #if !TARGET_OS_OSX
+  Class fullWindowOverlayContainerClass = NSClassFromString(@"RNSFullWindowOverlayContainer");
+
   if ([[childView reactViewController] isKindOfClass:[RCTFabricModalHostViewController class]]) {
     touchHandlerView = [childView reactViewController].view;
   } else {


### PR DESCRIPTION
## Description

Current logic dedicated to handling `RNRootViewGestureRecognizer` on iOS looks only for RN's native roots. When gestures are used inside Screens' `FullWindowOverlay`, the logic doesn't do anything, but the overlay has its own [`RCTSurfaceTouchHandler`](https://github.com/software-mansion/react-native-screens/blob/be64b6d9a17c3a4647806f252e075b96b9f690cc/ios/RNSFullWindowOverlay.mm#L158).

This PR updates the traversal logic so it handles `RNSFullWindowOverlayContainer` the same way as `RCTSurfaceView`.

## Test plan

I wasn't able to reproduce the problem, but in theory, it's possible that without this change, recognizers from RNGH and RCTSurfaceTouchHandler could run simultaneously, since this path never ran: https://github.com/software-mansion/react-native-gesture-handler/blob/5587435679eabe3f8690f077ba7c2ecc3e354a14/packages/react-native-gesture-handler/apple/RNRootViewGestureRecognizer.m#L55-L63
