### PR TITLE
fix(ios): guard +load with #ifdef RCT_DYNAMIC_FRAMEWORKS

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
@@ -45,10 +45,12 @@ static RNGestureHandlerPointerEvents RCTPointerEventsToEnum(facebook::react::Poi
 #endif
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 - (instancetype)initWithFrame:(CGRect)frame
 {


### PR DESCRIPTION
## Summary

The `+load` method in `RNGestureHandlerButtonComponentView` is unconditional, but its parent `RCTViewComponentView` correctly guards its `+load` behind `#ifdef RCT_DYNAMIC_FRAMEWORKS`. 

Without the guard, the child's `+load` runs even when dynamic frameworks are not used, causing conflicts with third-party SDKs (e.g. Akamai BMP) that also use `+load` — particularly on x86_64 simulators where the load order differs from arm64.

This matches the pattern used by React Native core in `RCTViewComponentView.mm` (see facebook/react-native#37274).

## Test plan

- Build xcframework with static linking (no `USE_FRAMEWORKS=dynamic`)
- Verify `RNGestureHandlerButtonComponentView +load` is not in the binary (`nm` check)
- Run on x86_64 simulator alongside Akamai BMP — no crash at launch
- Run on arm64 simulator — gesture handler works normally