### PR TITLE
Add `children` to button mock

### DIFF
--- a/packages/react-native-gesture-handler/src/mocks/GestureButtons.tsx
+++ b/packages/react-native-gesture-handler/src/mocks/GestureButtons.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { TouchableNativeFeedback, View } from 'react-native';
-export const RawButton = ({ enabled, ...rest }: any) => (
+export const RawButton = ({ enabled, children, ...rest }: any) => (
   <TouchableNativeFeedback disabled={enabled === false} {...rest}>
-    <View />
+    {children ?? <View />}
   </TouchableNativeFeedback>
 );
 export const BaseButton = RawButton;


### PR DESCRIPTION
## Description

This PR ports #4048 behavior to our current setup.

## Test plan

```tsx
import {fireEvent, render} from '@testing-library/react-native';
import {Text} from 'react-native';
import {RectButton} from 'react-native-gesture-handler';

test('Trigger press by text', () => {
  const onPress = jest.fn();
  const {getByText} = render(
    <RectButton onPress={onPress}>
      <Text>Press Me</Text>
    </RectButton>,
  );

  fireEvent.press(getByText('Press Me'));

  expect(onPress).toHaveBeenCalled();
});
```
