### PR TITLE
[tvOS] Fix build error

### DIFF
--- a/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
@@ -166,11 +166,13 @@ API_AVAILABLE(ios(13.4))
 {
   _pointerType = pointerType;
 
+#if CHECK_TARGET(16_1)
   if (@available(iOS 16.1, *)) {
     if (((UIHoverGestureRecognizer *)self.recognizer).zOffset > 0.0) {
       _pointerType = RNGestureHandlerStylus;
     }
   }
+#endif
 }
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIGestureRecognizer *)recognizer


### PR DESCRIPTION
## Description

In #3991 we introduced some changes to `Hover`. However, we forgot to guard it with `CHECK_TARGET` macro, which resulted in build errors on tvOS.

Fixes #4059 

## Test plan

Tested on `tvos-example` from Reanimated (that it builds) and our expo-example.