### PR TITLE
[Web] Fix `Pinch` and `Rotation`

### DIFF
--- a/packages/react-native-gesture-handler/src/web/detectors/RotationGestureDetector.ts
+++ b/packages/react-native-gesture-handler/src/web/detectors/RotationGestureDetector.ts
@@ -75,12 +75,11 @@ export default class RotationGestureDetector
   }
 
   private finish(): void {
-    if (!this.isInProgress) {
-      return;
+    if (this.isInProgress) {
+      this.isInProgress = false;
+      this.keyPointers = [NaN, NaN];
     }
 
-    this.isInProgress = false;
-    this.keyPointers = [NaN, NaN];
     this.onRotationEnd(this);
   }
 
@@ -138,9 +137,8 @@ export default class RotationGestureDetector
         break;
 
       case EventTypes.UP:
-        if (this.isInProgress) {
-          this.finish();
-        }
+        this.finish();
+
         break;
     }
 

--- a/packages/react-native-gesture-handler/src/web/handlers/PinchGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PinchGestureHandler.ts
@@ -100,6 +100,7 @@ export default class PinchGestureHandler extends GestureHandler {
     this.tracker.removeFromTracker(event.pointerId);
 
     if (this.state === State.ACTIVE) {
+      // We don't have to call it in the else branch as it would simply return `true`.
       this.scaleGestureDetector.onTouchEvent(event, this.tracker);
 
       this.end();

--- a/packages/react-native-gesture-handler/src/web/handlers/PinchGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PinchGestureHandler.ts
@@ -98,12 +98,10 @@ export default class PinchGestureHandler extends GestureHandler {
   protected override onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
     this.tracker.removeFromTracker(event.pointerId);
-    if (this.state !== State.ACTIVE) {
-      return;
-    }
-    this.scaleGestureDetector.onTouchEvent(event, this.tracker);
 
     if (this.state === State.ACTIVE) {
+      this.scaleGestureDetector.onTouchEvent(event, this.tracker);
+
       this.end();
     } else {
       this.fail();

--- a/packages/react-native-gesture-handler/src/web/handlers/RotationGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/RotationGestureHandler.ts
@@ -41,7 +41,11 @@ export default class RotationGestureHandler extends GestureHandler {
       return true;
     },
     onRotationEnd: (_detector: RotationGestureDetector): void => {
-      this.end();
+      if (this.state === State.ACTIVE) {
+        this.end();
+      } else {
+        this.fail();
+      }
     },
   };
 
@@ -136,16 +140,6 @@ export default class RotationGestureHandler extends GestureHandler {
     super.onPointerUp(event);
     this.tracker.removeFromTracker(event.pointerId);
     this.rotationGestureDetector.onTouchEvent(event, this.tracker);
-
-    if (this.state !== State.ACTIVE) {
-      return;
-    }
-
-    if (this.state === State.ACTIVE) {
-      this.end();
-    } else {
-      this.fail();
-    }
   }
 
   protected override onPointerRemove(event: AdaptedEvent): void {


### PR DESCRIPTION
## Description

I've noticed that `Pinch` and `Rotation` behave weirdly when it comes to ending gesture on web. I've took a look and fixed some minor issues.

> [!NOTE]
> This PR may introduce mismatch between `android` and `web` versions of `Rotation`. I still think that this is how it is supposed to work, so we may want to [make required changes to `android` as well](https://github.com/software-mansion/react-native-gesture-handler/pull/4079) (or drop this PR if you prefer to).

### Pinch

I've noticed that `Pinch` is not reset when pointers are placed on view and then released. This was because for some reason `Pinch` simply ignored finished states if it had not activated earlier. 

### Rotation 

`Rotation`, always finalized with `true`. This was because we always tried to move it to `end` state. Our internal event handler hadn't been sending `onDeactivate`, but `true` was still passed into `onFinalize`.

## Test plan

<details>
<summary>Tested on Transformations example and code below:</summary>

```tsx
import { StyleSheet, View } from 'react-native';
import {
  GestureDetector,
  GestureHandlerRootView,
  usePinchGesture,
  useRotationGesture,
} from 'react-native-gesture-handler';

export default function App() {
  const g = useRotationGesture({
    onBegin: () => console.log('onBegin'),
    onActivate: () => console.log('onActivate'),
    onUpdate: (e) => console.log('onUpdate', e.rotation),
    onDeactivate: () => console.log('onDeactivate'),
    onFinalize: (_, s) => console.log('onFinalize', s),
  });

  return (
    <GestureHandlerRootView style={styles.container}>
      <GestureDetector gesture={g}>
        <View style={styles.box} />
      </GestureDetector>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  box: {
    width: 200,
    height: 200,
    backgroundColor: 'blue',
    borderRadius: 12,
  },
});
```

</details>