### PR TITLE
[Android] Correct `Rotation` handler

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
@@ -35,7 +35,11 @@ class RotationGestureHandler : GestureHandler() {
     override fun onRotationBegin(detector: RotationGestureDetector) = true
 
     override fun onRotationEnd(detector: RotationGestureDetector) {
-      end()
+      if (state == STATE_ACTIVE) {
+        end()
+      } else {
+        fail()
+      }
     }
   }
 
@@ -64,12 +68,11 @@ class RotationGestureHandler : GestureHandler() {
       anchorX = point.x
       anchorY = point.y
     }
-    if (sourceEvent.actionMasked == MotionEvent.ACTION_UP) {
-      if (state == STATE_ACTIVE) {
-        end()
-      } else {
-        fail()
-      }
+
+    // ACTION_UP is already handled in rotationGestureDetector.onTouchEvent (and effectively in onRotationEnd)
+    // if more than one pointer was used
+    if (sourceEvent.actionMasked == MotionEvent.ACTION_UP && state == STATE_BEGAN) {
+      fail()
     }
   }
 


### PR DESCRIPTION
## Description

Follow up for #4078 

I've noticed that when `Rotation` does not activate, but pointers are released, `onFinalize` is called with `true`. This happens because we try to move it to `END` state, but our internal logic does not send `onDeactivate`. 

Code in `onHandle` that I removed was effectively dead, as `ACTION_UP` was handled in rotation detector - the only possible branch was `else` statement which fails handler if only one pointer was present.


## Test plan

<details>
<summary>Tested on Transformations example and the following code:</summary>

```tsx
import { StyleSheet, View } from 'react-native';
import {
  GestureDetector,
  GestureHandlerRootView,
  usePinchGesture,
  useRotationGesture,
} from 'react-native-gesture-handler';

export default function App() {
  const g = useRotationGesture({
    onBegin: () => console.log('onBegin'),
    onActivate: () => console.log('onActivate'),
    onUpdate: (e) => console.log('onUpdate', e.rotation),
    onDeactivate: () => console.log('onDeactivate'),
    onFinalize: (_, s) => console.log('onFinalize', s),
  });

  return (
    <GestureHandlerRootView style={styles.container}>
      <GestureDetector gesture={g}>
        <View style={styles.box} />
      </GestureDetector>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  box: {
    width: 200,
    height: 200,
    backgroundColor: 'blue',
    borderRadius: 12,
  },
});
```
</details>