### PR TITLE
Remove remaining `commonjs` references

### DIFF
--- a/packages/docs-gesture-handler/docs/guides/testing.md
+++ b/packages/docs-gesture-handler/docs/guides/testing.md
@@ -4,7 +4,29 @@ title: Testing with Jest
 sidebar_position: 4
 ---
 
-## Mocking native modules
+## Setup
+
+### Jest configuration
+
+In order to use functions provided by Gesture Handler, add `react-native-gesture-handler` to `transformIgnorePatterns` in `jest.config.js`, e.g.:
+
+```js
+module.exports = {
+  preset: '@react-native/jest-preset',
+  transformIgnorePatterns: [
+    //highlight-next-line
+    'node_modules/(?!((jest-)?react-native|react-native-gesture-handler)/)',
+  ],
+  ...
+};
+
+```
+
+:::note
+Remember not to split `transformIgnorePatterns` into multiple patterns. For more information check out [Jest documentation](https://jestjs.io/docs/tutorial-react-native#transformignorepatterns-customization).
+:::
+
+### Mocking native modules
 
 In order to load mocks provided by RNGH, add the following to your jest config in `package.json`:
 

--- a/packages/docs-gesture-handler/docs/guides/testing.md
+++ b/packages/docs-gesture-handler/docs/guides/testing.md
@@ -14,7 +14,7 @@ In order to use functions provided by Gesture Handler, add `react-native-gesture
 module.exports = {
   preset: '@react-native/jest-preset',
   transformIgnorePatterns: [
-    //highlight-next-line
+    // highlight-next-line
     'node_modules/(?!((jest-)?react-native|react-native-gesture-handler)/)',
   ],
   ...

--- a/packages/docs-gesture-handler/docs/guides/testing.mdx
+++ b/packages/docs-gesture-handler/docs/guides/testing.mdx
@@ -20,7 +20,7 @@ transformIgnorePatterns: [
 ```
 
 :::note
-Remember not to split `transformIgnorePatterns` into multiple patterns. For more information check out [Jest documentation](https://jestjs.io/docs/tutorial-react-native#transformignorepatterns-customization).
+Be careful when adding multiple entries to `transformIgnorePatterns`. Since `Jest` ignores a file if it matches any pattern in the list, splitting negative lookaheads into separate strings often causes them to override each other. It is safer to combine your exceptions into a single regex using the `|` operator. See the [Jest documentation](https://jestjs.io/docs/tutorial-react-native#transformignorepatterns-customization) for an example.
 :::
 
 ### Mocking native modules

--- a/packages/docs-gesture-handler/docs/guides/testing.mdx
+++ b/packages/docs-gesture-handler/docs/guides/testing.mdx
@@ -4,22 +4,19 @@ title: Testing with Jest
 sidebar_position: 4
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Setup
 
 ### Jest configuration
 
-In order to use functions provided by Gesture Handler, add `react-native-gesture-handler` to `transformIgnorePatterns` in `jest.config.js`, e.g.:
+In order to use functions provided by Gesture Handler, add `react-native-gesture-handler` to `transformIgnorePatterns` in jest config.
 
 ```js
-module.exports = {
-  preset: '@react-native/jest-preset',
-  transformIgnorePatterns: [
-    // highlight-next-line
-    'node_modules/(?!((jest-)?react-native|react-native-gesture-handler)/)',
-  ],
-  ...
-};
-
+transformIgnorePatterns: [
+  'node_modules/(?!((jest-)?react-native|react-native-gesture-handler)/)',
+],
 ```
 
 :::note
@@ -28,20 +25,40 @@ Remember not to split `transformIgnorePatterns` into multiple patterns. For more
 
 ### Mocking native modules
 
-In order to load mocks provided by RNGH, add the following to your jest config in `package.json`:
+In order to load mocks provided by RNGH, add the following to your jest config:
 
 ```json
 "setupFiles": ["./node_modules/react-native-gesture-handler/jestSetup.js"]
 ```
 
-Example:
+### Example jest config
 
-```json
-"jest": {
-  "preset": "react-native",
-  "setupFiles": ["./node_modules/react-native-gesture-handler/jestSetup.js"]
-}
-```
+<Tabs groupId="package-managers">
+  <TabItem value="js" label="jest.config.js" default>
+    ```js
+    module.exports = {
+      preset: '@react-native/jest-preset',
+      transformIgnorePatterns: [
+        'node_modules/(?!((jest-)?react-native|react-native-gesture-handler)/)',
+      ],
+      setupFiles: ['react-native-gesture-handler/jestSetup.js'],
+    };
+    ```
+  </TabItem>
+  <TabItem value="json" label="package.json">
+    ```json
+    "jest": {
+      "preset": "@react-native/jest-preset",
+      "transformIgnorePatterns": [
+        "node_modules/(?!((jest-)?react-native|react-native-gesture-handler)/)"
+      ],
+      "setupFiles": [
+        "react-native-gesture-handler/jestSetup.js"
+      ]
+    }
+    ```
+  </TabItem>
+</Tabs>
 
 ## Testing Gestures' and Gesture handlers' callbacks
 

--- a/packages/react-native-gesture-handler/ReanimatedDrawerLayout/package.json
+++ b/packages/react-native-gesture-handler/ReanimatedDrawerLayout/package.json
@@ -1,5 +1,5 @@
 {
-  "main": "../lib/commonjs/components/ReanimatedDrawerLayout",
+  "main": "../lib/module/components/ReanimatedDrawerLayout",
   "module": "../lib/module/components/ReanimatedDrawerLayout",
   "react-native": "../src/components/ReanimatedDrawerLayout",
   "types": "../lib/typescript/components/ReanimatedDrawerLayout.d.ts"

--- a/packages/react-native-gesture-handler/ReanimatedSwipeable/package.json
+++ b/packages/react-native-gesture-handler/ReanimatedSwipeable/package.json
@@ -1,5 +1,5 @@
 {
-  "main": "../lib/commonjs/components/ReanimatedSwipeable/",
+  "main": "../lib/module/components/ReanimatedSwipeable/",
   "module": "../lib/module/components/ReanimatedSwipeable/",
   "react-native": "../src/components/ReanimatedSwipeable/",
   "types": "../lib/typescript/components/ReanimatedSwipeable/"

--- a/packages/react-native-gesture-handler/jest-utils/package.json
+++ b/packages/react-native-gesture-handler/jest-utils/package.json
@@ -1,5 +1,5 @@
 {
-  "main": "../lib/commonjs/jestUtils/index",
+  "main": "../lib/module/jestUtils/index",
   "module": "../lib/module/jestUtils/index",
   "react-native": "../src/jestUtils/index",
   "types": "../lib/typescript/jestUtils/index.d.ts"


### PR DESCRIPTION
## Description

In #4069 we stopped emitting `commonjs`. Turns out that `package.json` in `jest-utils`, as well as in Reanimated components, still referenced this path, thus the tests were failing. 

Drawback of removing `commonjs` is one extra step in tests configuration. This was described in docs.

## Test plan

- Check that functions are available in test app
- Checked ReanimatedDrawerLayout and ReanimatedSwipeable examples