### PR TITLE
[eslint] Consistent `import` rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,6 +43,8 @@
     "@typescript-eslint/no-unsafe-return": "warn",
     "@typescript-eslint/no-non-null-assertion": "warn",
     "@typescript-eslint/ban-types": "warn",
+    "@typescript-eslint/consistent-type-imports": "error",
+    "@typescript-eslint/consistent-type-exports": "error",
 
     // common
     "@typescript-eslint/explicit-module-boundary-types": "off",
@@ -85,6 +87,7 @@
     ],
     "curly": "error",
     "spaced-comment": "error",
-    "no-alert": "warn"
+    "no-alert": "warn",
+    "sort-imports": "error"
   }
 }

--- a/apps/basic-example/src/App.tsx
+++ b/apps/basic-example/src/App.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
-import { SafeAreaView, Platform } from 'react-native';
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
-
-import Navigator from './Navigator';
-
-import Text from './Text';
-import NativeDetector from './NativeDetector';
-import RuntimeDecoration from './RuntimeDecoration';
+import { Platform, SafeAreaView } from 'react-native';
 import ContentsButton from './ContentsButton';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import NativeDetector from './NativeDetector';
+import Navigator from './Navigator';
+import RuntimeDecoration from './RuntimeDecoration';
+import Text from './Text';
 
 const EXAMPLES = [
   {

--- a/apps/basic-example/src/ContentsButton.tsx
+++ b/apps/basic-example/src/ContentsButton.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { View, StyleSheet, Text, SafeAreaView } from 'react-native';
 import {
   GestureHandlerRootView,
-  ScrollView,
   RectButton,
+  ScrollView,
 } from 'react-native-gesture-handler';
+import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import React from 'react';
 
 export default function ComplexUI() {
   return (

--- a/apps/basic-example/src/NativeDetector.tsx
+++ b/apps/basic-example/src/NativeDetector.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Animated, Button, useAnimatedValue } from 'react-native';
 import {
-  GestureHandlerRootView,
   GestureDetector,
+  GestureHandlerRootView,
   usePanGesture,
 } from 'react-native-gesture-handler';
 

--- a/apps/basic-example/src/Navigator.tsx
+++ b/apps/basic-example/src/Navigator.tsx
@@ -1,5 +1,5 @@
+import { BackHandler, Pressable, Text, View } from 'react-native';
 import React, { useEffect, useState } from 'react';
-import { View, Text, Pressable, BackHandler } from 'react-native';
 
 export interface RouteInfo {
   component: React.ComponentType;

--- a/apps/basic-example/src/RuntimeDecoration.tsx
+++ b/apps/basic-example/src/RuntimeDecoration.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-
-import { COLORS } from './colors';
 import Animated, {
   runOnJS,
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { StyleSheet, Text, View } from 'react-native';
+import { COLORS } from './colors';
 import { useState } from 'react';
 
 export function RuntimeChecker({

--- a/apps/basic-example/src/Text.tsx
+++ b/apps/basic-example/src/Text.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
 import {
   Gesture,
   GestureDetector,
@@ -7,7 +6,7 @@ import {
   VirtualGestureDetector,
   useTapGesture,
 } from 'react-native-gesture-handler';
-
+import { StyleSheet, Text, View } from 'react-native';
 import { COLORS } from './colors';
 
 function NativeDetectorExample() {

--- a/apps/common-app/src/ListWithHeader/Header.tsx
+++ b/apps/common-app/src/ListWithHeader/Header.tsx
@@ -1,8 +1,5 @@
-import React, { useEffect } from 'react';
-import { Platform, StyleSheet } from 'react-native';
 import Animated, {
   Easing,
-  SharedValue,
   interpolate,
   measure,
   useAnimatedRef,
@@ -11,7 +8,10 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { Platform, StyleSheet } from 'react-native';
+import React, { useEffect } from 'react';
 import { COLORS } from '../common';
+import type { SharedValue } from 'react-native-reanimated';
 
 // eslint-disable-next-line import-x/no-commonjs, @typescript-eslint/no-var-requires
 const SIGNET = require('./signet.png');

--- a/apps/common-app/src/ListWithHeader/ListWithHeader.tsx
+++ b/apps/common-app/src/ListWithHeader/ListWithHeader.tsx
@@ -1,29 +1,20 @@
-import React, { useEffect } from 'react';
-import {
-  Platform,
-  ScrollViewProps,
-  SectionList,
-  SectionListProps,
-  StyleSheet,
-} from 'react-native';
 import Animated, {
-  SharedValue,
-  useAnimatedRef,
-  useScrollViewOffset,
-  useAnimatedReaction,
-  useSharedValue,
-  useAnimatedProps,
-  useAnimatedStyle,
   runOnJS,
+  useAnimatedProps,
+  useAnimatedReaction,
+  useAnimatedRef,
+  useAnimatedStyle,
+  useScrollViewOffset,
+  useSharedValue,
   withSpring,
-  AnimatedRef,
 } from 'react-native-reanimated';
+import type { AnimatedRef, SharedValue } from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Header, { HEADER_HEIGHT } from './Header';
-import {
-  Gesture,
-  GestureDetector,
-  GestureType,
-} from 'react-native-gesture-handler';
+import { Platform, SectionList, StyleSheet } from 'react-native';
+import React, { useEffect } from 'react';
+import type { ScrollViewProps, SectionListProps } from 'react-native';
+import type { GestureType } from 'react-native-gesture-handler';
 
 const IS_ANDROID = Platform.OS === 'android';
 

--- a/apps/common-app/src/common.tsx
+++ b/apps/common-app/src/common.tsx
@@ -1,25 +1,19 @@
-import React, {
-  RefObject,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from 'react';
-import {
-  Text,
-  StyleSheet,
-  ViewStyle,
-  StyleProp,
-  View,
-  Platform,
-} from 'react-native';
 import Animated, {
   Easing,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import type { Platform, StyleProp, ViewStyle } from 'react-native';
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import type { RefObject } from 'react';
 
 export interface Example {
   name: string;

--- a/apps/common-app/src/common_assets/AnimatedCameraView/AnimatedCameraView.tsx
+++ b/apps/common-app/src/common_assets/AnimatedCameraView/AnimatedCameraView.tsx
@@ -1,11 +1,9 @@
-import React from 'react';
-import { CameraView, useCameraPermissions, CameraViewProps } from 'expo-camera';
+import Animated, { useAnimatedProps } from 'react-native-reanimated';
+import type { AnimatedRef, SharedValue } from 'react-native-reanimated';
 import { Button, StyleSheet, Text, View } from 'react-native';
-import Animated, {
-  SharedValue,
-  useAnimatedProps,
-  AnimatedRef,
-} from 'react-native-reanimated';
+import { CameraView, useCameraPermissions } from 'expo-camera';
+import type { CameraViewProps } from 'expo-camera';
+import React from 'react';
 
 const AnimatedCameraView = Animated.createAnimatedComponent(CameraView);
 

--- a/apps/common-app/src/empty/index.tsx
+++ b/apps/common-app/src/empty/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import React from 'react';
 
 export default function EmptyExample() {
   return (

--- a/apps/common-app/src/images.d.ts
+++ b/apps/common-app/src/images.d.ts
@@ -1,0 +1,6 @@
+declare module '*.png' {
+  import type { ImageSourcePropType } from 'react-native';
+
+  const value: ImageSourcePropType;
+  export default value;
+}

--- a/apps/common-app/src/legacy/basic/bouncing/index.tsx
+++ b/apps/common-app/src/legacy/basic/bouncing/index.tsx
@@ -1,16 +1,17 @@
-import React, { Component, PropsWithChildren } from 'react';
 import { Animated, StyleSheet, View } from 'react-native';
-
 import {
   PanGestureHandler,
   RotationGestureHandler,
   State,
+} from 'react-native-gesture-handler';
+import type {
   PanGestureHandlerGestureEvent,
   PanGestureHandlerStateChangeEvent,
   RotationGestureHandlerGestureEvent,
   RotationGestureHandlerStateChangeEvent,
 } from 'react-native-gesture-handler';
-
+import React, { Component } from 'react';
+import type { PropsWithChildren } from 'react';
 import { USE_NATIVE_DRIVER } from '../../../config';
 
 class Snappable extends Component<PropsWithChildren<Record<string, unknown>>> {

--- a/apps/common-app/src/legacy/basic/draggable/index.tsx
+++ b/apps/common-app/src/legacy/basic/draggable/index.tsx
@@ -1,16 +1,17 @@
-import React, { Component } from 'react';
-import { Animated, StyleProp, StyleSheet, ViewStyle } from 'react-native';
-
+import { Animated, StyleSheet } from 'react-native';
 import {
   PanGestureHandler,
-  State,
-  PanGestureHandlerStateChangeEvent,
-  PanGestureHandlerGestureEvent,
   ScrollView,
+  State,
 } from 'react-native-gesture-handler';
-
-import { USE_NATIVE_DRIVER } from '../../../config';
+import type {
+  PanGestureHandlerGestureEvent,
+  PanGestureHandlerStateChangeEvent,
+} from 'react-native-gesture-handler';
+import React, { Component } from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
 import { LoremIpsum } from '../../../common';
+import { USE_NATIVE_DRIVER } from '../../../config';
 
 type DraggableBoxProps = {
   minDist?: number;

--- a/apps/common-app/src/legacy/basic/fling/index.tsx
+++ b/apps/common-app/src/legacy/basic/fling/index.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import {
   Directions,
   Gesture,
   GestureDetector,
 } from 'react-native-gesture-handler';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-  Easing,
-} from 'react-native-reanimated';
+import { StyleSheet, View } from 'react-native';
+import React from 'react';
 
 export default function Example() {
   const position = useSharedValue(0);

--- a/apps/common-app/src/legacy/basic/forcetouch/index.tsx
+++ b/apps/common-app/src/legacy/basic/forcetouch/index.tsx
@@ -1,12 +1,7 @@
+import { Animated, StyleSheet, Text, View } from 'react-native';
+import { ForceTouchGestureHandler, State } from 'react-native-gesture-handler';
 import React, { Component } from 'react';
-import { Animated, StyleSheet, View, Text } from 'react-native';
-
-import {
-  State,
-  ForceTouchGestureHandler,
-  ForceTouchGestureHandlerStateChangeEvent,
-} from 'react-native-gesture-handler';
-
+import type { ForceTouchGestureHandlerStateChangeEvent } from 'react-native-gesture-handler';
 import { USE_NATIVE_DRIVER } from '../../../config';
 
 export default class Example extends Component {

--- a/apps/common-app/src/legacy/basic/multitap/index.tsx
+++ b/apps/common-app/src/legacy/basic/multitap/index.tsx
@@ -1,15 +1,15 @@
-import React, { Component } from 'react';
-import { StyleSheet, View, Text } from 'react-native';
-
 import {
   LongPressGestureHandler,
   ScrollView,
   State,
   TapGestureHandler,
+} from 'react-native-gesture-handler';
+import type {
   LongPressGestureHandlerStateChangeEvent,
   TapGestureHandlerStateChangeEvent,
 } from 'react-native-gesture-handler';
-
+import React, { Component } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 import { LoremIpsum } from '../../../common';
 
 interface PressBoxProps {

--- a/apps/common-app/src/legacy/basic/pagerAndDrawer/index.android.tsx
+++ b/apps/common-app/src/legacy/basic/pagerAndDrawer/index.android.tsx
@@ -1,10 +1,10 @@
-import ViewPagerAndroid from '@react-native-community/viewpager';
+import {
+  LegacyDrawerLayoutAndroid,
+  legacy_createNativeWrapper,
+} from 'react-native-gesture-handler';
 import React, { Component } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import {
-  legacy_createNativeWrapper,
-  LegacyDrawerLayoutAndroid,
-} from 'react-native-gesture-handler';
+import ViewPagerAndroid from '@react-native-community/viewpager';
 
 const WrappedViewPagerAndroid = legacy_createNativeWrapper(ViewPagerAndroid, {
   disallowInterruption: true,

--- a/apps/common-app/src/legacy/basic/panResponder/index.tsx
+++ b/apps/common-app/src/legacy/basic/panResponder/index.tsx
@@ -1,18 +1,13 @@
-import React, { Component } from 'react';
-import {
-  StyleSheet,
-  View,
-  PanResponder,
-  I18nManager,
+import type {
   GestureResponderEvent,
-  PanResponderGestureState,
   GestureResponderHandlers,
+  PanResponderGestureState,
 } from 'react-native';
-
-import { ScrollView } from 'react-native-gesture-handler';
-
+import { I18nManager, PanResponder, StyleSheet, View } from 'react-native';
+import React, { Component } from 'react';
 import { DraggableBox } from '../draggable';
 import { LoremIpsum } from '../../../common';
+import { ScrollView } from 'react-native-gesture-handler';
 
 const CIRCLE_SIZE = 80;
 

--- a/apps/common-app/src/legacy/index.tsx
+++ b/apps/common-app/src/legacy/index.tsx
@@ -1,60 +1,53 @@
-import OverflowParent from './release_tests/overflowParent';
-import DoublePinchRotate from './release_tests/doubleScalePinchAndRotate';
-import DoubleDraggable from './release_tests/doubleDraggable';
-import GesturizedPressable from './release_tests/gesturizedPressable';
-import { ComboWithGHScroll } from './release_tests/combo';
-import { TouchablesIndex } from './release_tests/touchables';
-import NestedFling from './release_tests/nestedFling';
-import MouseButtons from './release_tests/mouseButtons';
-import ContextMenu from './release_tests/contextMenu';
-import NestedTouchables from './release_tests/nestedTouchables';
-import NestedPressables from './release_tests/nestedPressables';
-import NestedButtons from './release_tests/nestedButtons';
-import PointerType from './release_tests/pointerType';
-import NestedGestureHandlerRootViewWithModal from './release_tests/nestedGHRootViewWithModal';
-import TwoFingerPan from './release_tests/twoFingerPan';
-import SvgCompatibility from './release_tests/svg';
-import NestedText from './release_tests/nestedText';
-
-import { PinchableBox } from './recipes/scaleAndRotate';
-import PanAndScroll from './recipes/panAndScroll';
-
 import { BottomSheet } from './showcase/bottomSheet';
-import ChatHeads from './showcase/chatHeads';
-
-import Draggable from './basic/draggable';
-import MultiTap from './basic/multitap';
-import BouncingBox from './basic/bouncing';
-import PanResponder from './basic/panResponder';
-import PagerAndDrawer from './basic/pagerAndDrawer';
-import ForceTouch from './basic/forcetouch';
-import Fling from './basic/fling';
-import WebStylesResetExample from './release_tests/webStylesReset';
-import StylusData from './release_tests/StylusData';
-
-import Camera from './v2_api/camera';
-import Transformations from './v2_api/transformations';
-import Overlap from './v2_api/overlap';
-import Calculator from './v2_api/calculator';
 import BottomSheetNewApi from './v2_api/bottom_sheet';
+import BouncingBox from './basic/bouncing';
+import Calculator from './v2_api/calculator';
+import Camera from './v2_api/camera';
+import ChatHeads from './showcase/chatHeads';
 import ChatHeadsNewApi from './v2_api/chat_heads';
+import { ComboWithGHScroll } from './release_tests/combo';
+import ContextMenu from './release_tests/contextMenu';
+import DoubleDraggable from './release_tests/doubleDraggable';
+import DoublePinchRotate from './release_tests/doubleScalePinchAndRotate';
 import DragNDrop from './v2_api/drag_n_drop';
-import ManualGestures from './v2_api/manualGestures/index';
+import Draggable from './basic/draggable';
+import EmptyExample from '../empty';
+import type { ExamplesSection } from '../common';
+import Fling from './basic/fling';
+import ForceTouch from './basic/forcetouch';
+import GesturizedPressable from './release_tests/gesturizedPressable';
 import Hover from './v2_api/hover';
 import HoverableIcons from './v2_api/hoverable_icons';
-import VelocityTest from './v2_api/velocityTest';
-import Pressable from './v2_api/pressable';
-
-import RectButtonBorders from './release_tests/rectButton';
-
-import MacosDraggable from './simple/draggable';
-import Tap from './simple/tap';
 import LongPressExample from './simple/longPress';
+import MacosDraggable from './simple/draggable';
 import ManualExample from './simple/manual';
+import ManualGestures from './v2_api/manualGestures/index';
+import MouseButtons from './release_tests/mouseButtons';
+import MultiTap from './basic/multitap';
+import NestedButtons from './release_tests/nestedButtons';
+import NestedFling from './release_tests/nestedFling';
+import NestedGestureHandlerRootViewWithModal from './release_tests/nestedGHRootViewWithModal';
+import NestedPressables from './release_tests/nestedPressables';
+import NestedText from './release_tests/nestedText';
+import NestedTouchables from './release_tests/nestedTouchables';
+import OverflowParent from './release_tests/overflowParent';
+import Overlap from './v2_api/overlap';
+import PagerAndDrawer from './basic/pagerAndDrawer';
+import PanAndScroll from './recipes/panAndScroll';
+import PanResponder from './basic/panResponder';
+import { PinchableBox } from './recipes/scaleAndRotate';
+import PointerType from './release_tests/pointerType';
+import Pressable from './v2_api/pressable';
+import RectButtonBorders from './release_tests/rectButton';
 import SimpleFling from './simple/fling';
-
-import { ExamplesSection } from '../common';
-import EmptyExample from '../empty';
+import StylusData from './release_tests/StylusData';
+import SvgCompatibility from './release_tests/svg';
+import Tap from './simple/tap';
+import { TouchablesIndex } from './release_tests/touchables';
+import Transformations from './v2_api/transformations';
+import TwoFingerPan from './release_tests/twoFingerPan';
+import VelocityTest from './v2_api/velocityTest';
+import WebStylesResetExample from './release_tests/webStylesReset';
 export const OLD_EXAMPLES: ExamplesSection[] = [
   {
     sectionTitle: 'Empty',

--- a/apps/common-app/src/legacy/recipes/panAndScroll/index.tsx
+++ b/apps/common-app/src/legacy/recipes/panAndScroll/index.tsx
@@ -1,16 +1,17 @@
-import React, { Component } from 'react';
 import { Animated, Dimensions, StyleSheet } from 'react-native';
 import {
+  LegacyScrollView,
   PanGestureHandler,
-  TapGestureHandler,
   State,
+  TapGestureHandler,
+} from 'react-native-gesture-handler';
+import type {
   PanGestureHandlerGestureEvent,
   TapGestureHandlerStateChangeEvent,
-  LegacyScrollView,
 } from 'react-native-gesture-handler';
-
-import { USE_NATIVE_DRIVER } from '../../../config';
+import React, { Component } from 'react';
 import { LoremIpsum } from '../../../common';
+import { USE_NATIVE_DRIVER } from '../../../config';
 
 const windowWidth = Dimensions.get('window').width;
 const circleRadius = 30;

--- a/apps/common-app/src/legacy/recipes/scaleAndRotate/index.tsx
+++ b/apps/common-app/src/legacy/recipes/scaleAndRotate/index.tsx
@@ -1,19 +1,19 @@
-import React from 'react';
 import { Animated, Platform, StyleSheet } from 'react-native';
-
 import {
   PanGestureHandler,
   PinchGestureHandler,
   RotationGestureHandler,
   State,
+} from 'react-native-gesture-handler';
+import type {
   PanGestureHandlerGestureEvent,
   PanGestureHandlerStateChangeEvent,
-  RotationGestureHandlerGestureEvent,
   PinchGestureHandlerGestureEvent,
   PinchGestureHandlerStateChangeEvent,
+  RotationGestureHandlerGestureEvent,
   RotationGestureHandlerStateChangeEvent,
 } from 'react-native-gesture-handler';
-
+import React from 'react';
 import { USE_NATIVE_DRIVER } from '../../../config';
 
 export class PinchableBox extends React.Component {

--- a/apps/common-app/src/legacy/release_tests/StylusData/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/StylusData/index.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { StyleSheet, View, Image } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { Image, StyleSheet, View } from 'react-native';
+import React from 'react';
 
 // eslint-disable-next-line import-x/no-commonjs, @typescript-eslint/no-var-requires
 const GH = require('../../../common_assets/hoverable_icons/gh.png');

--- a/apps/common-app/src/legacy/release_tests/combo/InfoButton.tsx
+++ b/apps/common-app/src/legacy/release_tests/combo/InfoButton.tsx
@@ -1,8 +1,7 @@
-import React, { View, Text, StyleSheet } from 'react-native';
-import {
-  BorderlessButton,
-  BorderlessButtonProps,
-} from 'react-native-gesture-handler';
+import { StyleSheet, Text, View } from 'react-native';
+import { BorderlessButton } from 'react-native-gesture-handler';
+import type { BorderlessButtonProps } from 'react-native-gesture-handler';
+import React from 'react';
 
 export const InfoButton = (props: BorderlessButtonProps & { name: string }) => (
   <BorderlessButton

--- a/apps/common-app/src/legacy/release_tests/combo/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/combo/index.tsx
@@ -1,32 +1,28 @@
-import React, { Component } from 'react';
 import {
-  StyleSheet,
+  Alert,
   ScrollView as RNScroll,
+  StyleSheet,
   Switch,
   Text,
   View,
-  Alert,
-  TouchableHighlightProps as RNTouchableHighlightProps,
 } from 'react-native';
-
 import {
-  NativeViewGestureHandler,
   LegacyScrollView as GHScroll,
+  NativeViewGestureHandler,
+  RectButton,
   State,
   TapGestureHandler,
   TextInput,
-  RectButton,
-  TapGestureHandlerStateChangeEvent,
 } from 'react-native-gesture-handler';
-
-import Swipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
-
+import React, { Component } from 'react';
 import { DraggableBox } from '../../basic/draggable';
+import { InfoButton } from './InfoButton';
+import { LoremIpsum } from '../../../common';
 import { PinchableBox } from '../../recipes/scaleAndRotate';
 import { PressBox } from '../../basic/multitap';
-
-import { LoremIpsum } from '../../../common';
-import { InfoButton } from './InfoButton';
+import type { TouchableHighlightProps as RNTouchableHighlightProps } from 'react-native';
+import Swipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
+import type { TapGestureHandlerStateChangeEvent } from 'react-native-gesture-handler';
 
 type TouchableHighlightProps = RNTouchableHighlightProps & {
   onClick: () => void;

--- a/apps/common-app/src/legacy/release_tests/contextMenu/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/contextMenu/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { StyleSheet, View } from 'react-native';
 import {
   Gesture,
   GestureDetector,
   MouseButton,
 } from 'react-native-gesture-handler';
+import { StyleSheet, View } from 'react-native';
+import React from 'react';
 
 export default function ContextMenuExample() {
   const p1 = Gesture.Pan().mouseButton(MouseButton.RIGHT);

--- a/apps/common-app/src/legacy/release_tests/doubleDraggable/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/doubleDraggable/index.tsx
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
 import { StyleSheet, View } from 'react-native';
-
-import { LoremIpsum } from '../../../common';
 import { DraggableBox } from '../../basic/draggable/index';
+import { LoremIpsum } from '../../../common';
 
 export default class Example extends Component {
   render() {

--- a/apps/common-app/src/legacy/release_tests/gesturizedPressable/androidRippleExample.tsx
+++ b/apps/common-app/src/legacy/release_tests/gesturizedPressable/androidRippleExample.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
+import React from 'react';
 import TestingBase from './testingBase';
 
 export function RippleExample() {

--- a/apps/common-app/src/legacy/release_tests/gesturizedPressable/delayedPressExample.tsx
+++ b/apps/common-app/src/legacy/release_tests/gesturizedPressable/delayedPressExample.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import { StyleSheet, View } from 'react-native';
-import TestingBase from './testingBase';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSequence,
   withSpring,
 } from 'react-native-reanimated';
+import { StyleSheet, View } from 'react-native';
+import React from 'react';
+import TestingBase from './testingBase';
 
 const signalerConfig = {
   stiffness: 500,

--- a/apps/common-app/src/legacy/release_tests/gesturizedPressable/functionalStylesExample.tsx
+++ b/apps/common-app/src/legacy/release_tests/gesturizedPressable/functionalStylesExample.tsx
@@ -1,5 +1,6 @@
+import { StyleSheet, View } from 'react-native';
+import type { PressableStateCallbackType } from 'react-native';
 import React from 'react';
-import { PressableStateCallbackType, StyleSheet, View } from 'react-native';
 import TestingBase from './testingBase';
 
 export function FunctionalStyleExample() {

--- a/apps/common-app/src/legacy/release_tests/gesturizedPressable/hitSlopExample.tsx
+++ b/apps/common-app/src/legacy/release_tests/gesturizedPressable/hitSlopExample.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import React from 'react';
 import TestingBase from './testingBase';
 
 const HIT_SLOP = 40;

--- a/apps/common-app/src/legacy/release_tests/gesturizedPressable/hoverDelayExample.tsx
+++ b/apps/common-app/src/legacy/release_tests/gesturizedPressable/hoverDelayExample.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { StyleSheet, View } from 'react-native';
+import React from 'react';
 import TestingBase from './testingBase';
 
 export function DelayHoverExample() {

--- a/apps/common-app/src/legacy/release_tests/gesturizedPressable/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/gesturizedPressable/index.tsx
@@ -1,13 +1,13 @@
-import React, { ReactNode } from 'react';
-import { Text, View, StyleSheet } from 'react-native';
-import { ScrollView } from 'react-native-gesture-handler';
-
+import { StyleSheet, Text, View } from 'react-native';
 import { BACKGROUND_COLOR } from './testingBase';
-import { HitSlopExample } from './hitSlopExample';
-import { RippleExample } from './androidRippleExample';
-import { FunctionalStyleExample } from './functionalStylesExample';
-import { DelayedPressExample } from './delayedPressExample';
 import { DelayHoverExample } from './hoverDelayExample';
+import { DelayedPressExample } from './delayedPressExample';
+import { FunctionalStyleExample } from './functionalStylesExample';
+import { HitSlopExample } from './hitSlopExample';
+import React from 'react';
+import type { ReactNode } from 'react';
+import { RippleExample } from './androidRippleExample';
+import { ScrollView } from 'react-native-gesture-handler';
 
 type TestingEntryProps = {
   title: string;

--- a/apps/common-app/src/legacy/release_tests/gesturizedPressable/testingBase.tsx
+++ b/apps/common-app/src/legacy/release_tests/gesturizedPressable/testingBase.tsx
@@ -1,15 +1,8 @@
+import { Pressable as RNPressable, StyleSheet, Text, View } from 'react-native';
+import { LegacyPressable as GHPressable } from 'react-native-gesture-handler';
+import type { LegacyPressableProps as GHPressableProps } from 'react-native-gesture-handler';
+import type { PressableProps as RNPressableProps } from 'react-native';
 import React from 'react';
-import {
-  StyleSheet,
-  Text,
-  View,
-  Pressable as RNPressable,
-  PressableProps as RNPressableProps,
-} from 'react-native';
-import {
-  LegacyPressable as GHPressable,
-  LegacyPressableProps as GHPressableProps,
-} from 'react-native-gesture-handler';
 
 const TestingBase = (props: GHPressableProps & RNPressableProps) => (
   <>

--- a/apps/common-app/src/legacy/release_tests/mouseButtons/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/mouseButtons/index.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
 import {
+  Directions,
   Gesture,
   GestureDetector,
-  GestureType,
   MouseButton,
-  Directions,
   ScrollView,
 } from 'react-native-gesture-handler';
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import type { GestureType } from 'react-native-gesture-handler';
+import React from 'react';
 
 const COLORS = ['darkmagenta', 'darkgreen', 'darkblue', 'crimson', 'pink'];
 

--- a/apps/common-app/src/legacy/release_tests/nestedButtons/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/nestedButtons/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { View } from 'react-native';
-
 import { RectButton } from 'react-native-gesture-handler';
+import { View } from 'react-native';
 
 export default function Example() {
   return (

--- a/apps/common-app/src/legacy/release_tests/nestedFling/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/nestedFling/index.tsx
@@ -1,12 +1,11 @@
-import React, { Component } from 'react';
 import { Animated, Dimensions, StyleSheet, Text, View } from 'react-native';
 import {
-  FlingGestureHandler,
   Directions,
+  FlingGestureHandler,
   State,
-  FlingGestureHandlerStateChangeEvent,
 } from 'react-native-gesture-handler';
-
+import React, { Component } from 'react';
+import type { FlingGestureHandlerStateChangeEvent } from 'react-native-gesture-handler';
 import { USE_NATIVE_DRIVER } from '../../../config';
 
 const windowWidth = Dimensions.get('window').width;

--- a/apps/common-app/src/legacy/release_tests/nestedGHRootViewWithModal/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/nestedGHRootViewWithModal/index.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import { useState } from 'react';
-import { StyleSheet, Modal, View, Text } from 'react-native';
-
 import {
   GestureHandlerRootView,
   TouchableOpacity,
 } from 'react-native-gesture-handler';
+import { Modal, StyleSheet, Text, View } from 'react-native';
 import { DraggableBox } from '../../basic/draggable';
+import { useState } from 'react';
 
 export default function App() {
   const [isModalVisible, setIsModalVisible] = useState(false);

--- a/apps/common-app/src/legacy/release_tests/nestedPressables/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/nestedPressables/index.tsx
@@ -1,12 +1,7 @@
+import { LegacyPressable, ScrollView } from 'react-native-gesture-handler';
+import { Pressable as RNPressable, StyleSheet, Text, View } from 'react-native';
+import type { PressableStateCallbackType } from 'react-native';
 import React from 'react';
-import {
-  Pressable as RNPressable,
-  PressableStateCallbackType,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
-import { ScrollView, LegacyPressable } from 'react-native-gesture-handler';
 
 export default function Example() {
   return (

--- a/apps/common-app/src/legacy/release_tests/nestedText/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/nestedText/index.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
-import { StyleSheet } from 'react-native';
 import {
-  LegacyText,
   GestureHandlerRootView,
+  LegacyText,
   TouchableOpacity,
 } from 'react-native-gesture-handler';
+import { StyleSheet } from 'react-native';
+import { useState } from 'react';
 
 export default function NestedText() {
   const [counter, setCounter] = useState(0);

--- a/apps/common-app/src/legacy/release_tests/nestedTouchables/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/nestedTouchables/index.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import { ScrollView, TouchableOpacity } from 'react-native-gesture-handler';
 import { StyleSheet, Text } from 'react-native';
-import { TouchableOpacity, ScrollView } from 'react-native-gesture-handler';
 import { LoremIpsum } from '../../../common';
+import React from 'react';
 
 export default function Example() {
   return (

--- a/apps/common-app/src/legacy/release_tests/overflowParent/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/overflowParent/index.tsx
@@ -1,12 +1,11 @@
-import React, { useRef } from 'react';
-
-import { StyleSheet, Animated, View, Text } from 'react-native';
+import { Animated, StyleSheet, Text, View } from 'react-native';
 import {
   PanGestureHandler,
-  PanGestureHandlerStateChangeEvent,
   State,
   TapGestureHandler,
 } from 'react-native-gesture-handler';
+import React, { useRef } from 'react';
+import type { PanGestureHandlerStateChangeEvent } from 'react-native-gesture-handler';
 import { USE_NATIVE_DRIVER } from '../../../config';
 
 export default function Example() {

--- a/apps/common-app/src/legacy/release_tests/pointerType/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/pointerType/index.tsx
@@ -1,5 +1,3 @@
-import React, { useState } from 'react';
-import { StyleSheet, View, Text } from 'react-native';
 import Animated, {
   interpolateColor,
   useAnimatedStyle,
@@ -7,10 +5,12 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import {
-  GestureDetector,
   Gesture,
+  GestureDetector,
   PointerType,
 } from 'react-native-gesture-handler';
+import React, { useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 
 const Colors = {
   Touch: '#7bbf98',

--- a/apps/common-app/src/legacy/release_tests/rectButton/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/rectButton/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import React from 'react';
 import { RectButton } from 'react-native-gesture-handler';
 
 export default function RectButtonBorders() {

--- a/apps/common-app/src/legacy/release_tests/svg/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/svg/index.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { Text, View, StyleSheet } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-
+import { StyleSheet, Text, View } from 'react-native';
 import Svg, { Circle, Rect } from 'react-native-svg';
+import React from 'react';
 
 export default function SvgExample() {
   const circleElementTap = Gesture.Tap().onStart(() =>

--- a/apps/common-app/src/legacy/release_tests/touchables/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/touchables/index.tsx
@@ -1,5 +1,4 @@
 import {
-  BackgroundPropType,
   FlatList,
   TouchableHighlight as RNTouchableHighlight,
   TouchableNativeFeedback as RNTouchableNativeFeedback,
@@ -18,8 +17,8 @@ import {
   TouchableOpacity,
   TouchableWithoutFeedback,
 } from 'react-native-gesture-handler';
-
-import { StackScreenProps } from '@react-navigation/stack';
+import type { BackgroundPropType } from 'react-native';
+import type { StackScreenProps } from '@react-navigation/stack';
 
 const BOX_SIZE = 80;
 

--- a/apps/common-app/src/legacy/release_tests/twoFingerPan/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/twoFingerPan/index.tsx
@@ -1,11 +1,10 @@
-import { StyleSheet, View } from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
-
-import React from 'react';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { StyleSheet, View } from 'react-native';
+import React from 'react';
 
 const BOX_SIZE = 270;
 

--- a/apps/common-app/src/legacy/release_tests/webStylesReset/index.tsx
+++ b/apps/common-app/src/legacy/release_tests/webStylesReset/index.tsx
@@ -1,16 +1,16 @@
-import React, { useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import {
-  Gesture,
-  GestureDetector,
-  Pressable,
-} from 'react-native-gesture-handler';
 import Animated, {
   interpolateColor,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import {
+  Gesture,
+  GestureDetector,
+  Pressable,
+} from 'react-native-gesture-handler';
+import React, { useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 
 const Colors = {
   enabled: '#32a852',

--- a/apps/common-app/src/legacy/showcase/bottomSheet/index.tsx
+++ b/apps/common-app/src/legacy/showcase/bottomSheet/index.tsx
@@ -1,21 +1,16 @@
-import React, { Component } from 'react';
+import { Animated, Dimensions, StyleSheet, View } from 'react-native';
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import {
-  Animated,
-  StyleSheet,
-  View,
-  Dimensions,
-  NativeSyntheticEvent,
-  NativeScrollEvent,
-} from 'react-native';
-import {
-  PanGestureHandler,
   NativeViewGestureHandler,
+  PanGestureHandler,
   State,
   TapGestureHandler,
-  PanGestureHandlerStateChangeEvent,
-  PanGestureHandlerGestureEvent,
 } from 'react-native-gesture-handler';
-
+import type {
+  PanGestureHandlerGestureEvent,
+  PanGestureHandlerStateChangeEvent,
+} from 'react-native-gesture-handler';
+import React, { Component } from 'react';
 import { LoremIpsum } from '../../../common';
 import { USE_NATIVE_DRIVER } from '../../../config';
 

--- a/apps/common-app/src/legacy/showcase/chatHeads/index.tsx
+++ b/apps/common-app/src/legacy/showcase/chatHeads/index.tsx
@@ -1,12 +1,11 @@
-import React, { Component } from 'react';
-import { Animated, LayoutChangeEvent, StyleSheet, View } from 'react-native';
-
-import {
-  PanGestureHandler,
-  State,
-  PanGestureHandlerStateChangeEvent,
+import { Animated, StyleSheet, View } from 'react-native';
+import { PanGestureHandler, State } from 'react-native-gesture-handler';
+import type {
   PanGestureHandlerGestureEvent,
+  PanGestureHandlerStateChangeEvent,
 } from 'react-native-gesture-handler';
+import React, { Component } from 'react';
+import type { LayoutChangeEvent } from 'react-native';
 
 const USE_NATIVE_DRIVER = false;
 

--- a/apps/common-app/src/legacy/simple/draggable/index.tsx
+++ b/apps/common-app/src/legacy/simple/draggable/index.tsx
@@ -1,9 +1,9 @@
-import React, { FC } from 'react';
-import { ScrollView, StyleProp, StyleSheet, ViewStyle } from 'react-native';
-
 import Animated, { useSharedValue } from 'react-native-reanimated';
-
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { ScrollView, StyleSheet } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+import type { FC } from 'react';
+import React from 'react';
 
 type DraggableBoxProps = {
   minDist?: number;

--- a/apps/common-app/src/legacy/simple/fling/index.tsx
+++ b/apps/common-app/src/legacy/simple/fling/index.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
-import { StyleSheet, View } from 'react-native';
-import {
-  Directions,
-  Gesture,
-  GestureDetector,
-} from 'react-native-gesture-handler';
 import Animated, {
   interpolateColor,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import {
+  Directions,
+  Gesture,
+  GestureDetector,
+} from 'react-native-gesture-handler';
+import { StyleSheet, View } from 'react-native';
+import React from 'react';
 
 const AnimationDuration = 100;
 

--- a/apps/common-app/src/legacy/simple/longPress/index.tsx
+++ b/apps/common-app/src/legacy/simple/longPress/index.tsx
@@ -1,11 +1,11 @@
-import { StyleSheet, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   interpolateColor,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { StyleSheet, View } from 'react-native';
 
 const Durations = {
   LongPress: 750,

--- a/apps/common-app/src/legacy/simple/manual/index.tsx
+++ b/apps/common-app/src/legacy/simple/manual/index.tsx
@@ -1,11 +1,11 @@
-import { StyleSheet, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   interpolateColor,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { StyleSheet, View } from 'react-native';
 
 export default function ManualExample() {
   const isPressed = useSharedValue(false);

--- a/apps/common-app/src/legacy/simple/tap/index.tsx
+++ b/apps/common-app/src/legacy/simple/tap/index.tsx
@@ -1,11 +1,7 @@
 import React, { Component } from 'react';
+import { State, TapGestureHandler } from 'react-native-gesture-handler';
 import { StyleSheet, View } from 'react-native';
-
-import {
-  State,
-  TapGestureHandler,
-  TapGestureHandlerStateChangeEvent,
-} from 'react-native-gesture-handler';
+import type { TapGestureHandlerStateChangeEvent } from 'react-native-gesture-handler';
 
 interface PressBoxProps {
   setDuration?: (duration: number) => void;

--- a/apps/common-app/src/legacy/v2_api/bottom_sheet/index.tsx
+++ b/apps/common-app/src/legacy/v2_api/bottom_sheet/index.tsx
@@ -1,23 +1,15 @@
-import React, { useRef, useState } from 'react';
-import {
-  Dimensions,
-  NativeScrollEvent,
-  NativeSyntheticEvent,
-  StyleSheet,
-  View,
-} from 'react-native';
-import {
-  Gesture,
-  GestureDetector,
-  PanGestureHandlerEventPayload,
-} from 'react-native-gesture-handler';
 import Animated, {
   runOnJS,
   useAnimatedStyle,
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated';
+import { Dimensions, StyleSheet, View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+import React, { useRef, useState } from 'react';
 import { LoremIpsum } from '../../../common';
+import type { PanGestureHandlerEventPayload } from 'react-native-gesture-handler';
 
 const HEADER_HEIGTH = 50;
 const windowHeight = Dimensions.get('window').height;

--- a/apps/common-app/src/legacy/v2_api/calculator/index.tsx
+++ b/apps/common-app/src/legacy/v2_api/calculator/index.tsx
@@ -1,24 +1,19 @@
-import React, { Dispatch, SetStateAction, useRef, useState } from 'react';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
+import type { Dispatch, SetStateAction } from 'react';
 import {
-  StyleSheet,
-  View,
-  Text,
-  Dimensions,
-  LayoutChangeEvent,
-  LayoutRectangle,
-} from 'react-native';
-import {
-  GestureDetector,
   Gesture,
+  GestureDetector,
   LegacyScrollView,
 } from 'react-native-gesture-handler';
-import Animated, {
-  SharedValue,
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-  runOnJS,
-} from 'react-native-reanimated';
+import type { LayoutChangeEvent, LayoutRectangle } from 'react-native';
+import React, { useRef, useState } from 'react';
+import type { SharedValue } from 'react-native-reanimated';
 
 const DRAG_ANIMATION_DURATION = 300;
 const TAP_ANIMATION_DURATION = 100;

--- a/apps/common-app/src/legacy/v2_api/camera/index.tsx
+++ b/apps/common-app/src/legacy/v2_api/camera/index.tsx
@@ -1,8 +1,4 @@
-import React, { useState } from 'react';
-import { StyleSheet, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
-  SharedValue,
   runOnJS,
   useAnimatedProps,
   useAnimatedStyle,
@@ -10,7 +6,11 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { Circle, Svg } from 'react-native-svg';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import React, { useState } from 'react';
+import { StyleSheet, View } from 'react-native';
 import AnimatedCameraView from '../../../common_assets/AnimatedCameraView/AnimatedCameraView';
+import type { SharedValue } from 'react-native-reanimated';
 
 const FILTERS = ['red', 'green', 'blue', 'yellow', 'orange', 'cyan'];
 const CAROUSEL_SIZE = 100;

--- a/apps/common-app/src/legacy/v2_api/chat_heads/index.tsx
+++ b/apps/common-app/src/legacy/v2_api/chat_heads/index.tsx
@@ -1,14 +1,15 @@
-import React, { useState } from 'react';
-import { StyleSheet, ImageStyle, LayoutChangeEvent } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
-  SharedValue,
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import type { ImageStyle, LayoutChangeEvent } from 'react-native';
+import React, { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import type { SharedValue } from 'react-native-reanimated';
+import { StyleSheet } from 'react-native';
 import { useHeaderHeight } from '@react-navigation/elements';
 
 const CHAT_HEADS = [

--- a/apps/common-app/src/legacy/v2_api/drag_n_drop/DragAndDrop.tsx
+++ b/apps/common-app/src/legacy/v2_api/drag_n_drop/DragAndDrop.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { ANIMATE_TO_NEW_PLACE_DURATION, getSizeConstants } from './constants';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import {
   LayoutAnimation,
   Platform,
@@ -6,18 +7,14 @@ import {
   UIManager,
   View,
 } from 'react-native';
-import {
-  Gesture,
-  GestureDetector,
-  PanGestureHandlerEventPayload,
-} from 'react-native-gesture-handler';
+import React, { useEffect, useState } from 'react';
 import {
   useSharedValue,
   withSpring,
   withTiming,
 } from 'react-native-reanimated';
-import { ANIMATE_TO_NEW_PLACE_DURATION, getSizeConstants } from './constants';
 import Draggable from './Draggable';
+import type { PanGestureHandlerEventPayload } from 'react-native-gesture-handler';
 
 if (
   Platform.OS === 'android' &&

--- a/apps/common-app/src/legacy/v2_api/drag_n_drop/Draggable.tsx
+++ b/apps/common-app/src/legacy/v2_api/drag_n_drop/Draggable.tsx
@@ -1,17 +1,13 @@
-import React from 'react';
-import { StyleSheet } from 'react-native';
-import {
-  PanGestureHandlerEventPayload,
-  Gesture,
-  GestureDetector,
+import Animated, { runOnJS, useAnimatedStyle } from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import type {
   LegacyPanGesture,
   LegacyTapGesture,
+  PanGestureHandlerEventPayload,
 } from 'react-native-gesture-handler';
-import Animated, {
-  runOnJS,
-  useAnimatedStyle,
-  SharedValue,
-} from 'react-native-reanimated';
+import React from 'react';
+import type { SharedValue } from 'react-native-reanimated';
+import { StyleSheet } from 'react-native';
 
 type AnimatedPostion = {
   x: SharedValue<number>;

--- a/apps/common-app/src/legacy/v2_api/drag_n_drop/Tile.tsx
+++ b/apps/common-app/src/legacy/v2_api/drag_n_drop/Tile.tsx
@@ -1,5 +1,3 @@
-import React, { useEffect, useRef } from 'react';
-import { StyleSheet } from 'react-native';
 import Animated, {
   Easing,
   interpolate,
@@ -8,6 +6,8 @@ import Animated, {
   withRepeat,
   withTiming,
 } from 'react-native-reanimated';
+import React, { useEffect, useRef } from 'react';
+import { StyleSheet } from 'react-native';
 
 export interface ColorTile {
   id: string;

--- a/apps/common-app/src/legacy/v2_api/drag_n_drop/index.tsx
+++ b/apps/common-app/src/legacy/v2_api/drag_n_drop/index.tsx
@@ -1,6 +1,8 @@
+import type { ColorTile } from './Tile';
+import DragAndDrop from './DragAndDrop';
+import type { DraggableItemData } from './DragAndDrop';
 import React from 'react';
-import DragAndDrop, { DraggableItemData } from './DragAndDrop';
-import Tile, { ColorTile } from './Tile';
+import Tile from './Tile';
 
 const COLORS = [
   '#F94144',

--- a/apps/common-app/src/legacy/v2_api/hover/index.tsx
+++ b/apps/common-app/src/legacy/v2_api/hover/index.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
-import { View, Text } from 'react-native';
-import {
-  Gesture,
-  GestureDetector,
-  GestureType,
-  HoverEffect,
-} from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
+import {
+  Gesture,
+  GestureDetector,
+  HoverEffect,
+} from 'react-native-gesture-handler';
+import { Text, View } from 'react-native';
+import type { GestureType } from 'react-native-gesture-handler';
+import React from 'react';
 
 function useHover(color: string): [GestureType, any] {
   const hovered = useSharedValue(false);

--- a/apps/common-app/src/legacy/v2_api/hoverable_icons/index.tsx
+++ b/apps/common-app/src/legacy/v2_api/hoverable_icons/index.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
-import {
-  Gesture,
-  GestureDetector,
-  HoverEffect,
-} from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useFrameCallback,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import {
+  Gesture,
+  GestureDetector,
+  HoverEffect,
+} from 'react-native-gesture-handler';
 import { Platform, StyleSheet } from 'react-native';
+import React from 'react';
 
 // eslint-disable-next-line import-x/no-commonjs, @typescript-eslint/no-var-requires
 const SVG = require('../../../common_assets/hoverable_icons/svg.png');

--- a/apps/common-app/src/legacy/v2_api/manualGestures/index.tsx
+++ b/apps/common-app/src/legacy/v2_api/manualGestures/index.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 import Animated, {
-  SharedValue,
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { StyleSheet, Text, View } from 'react-native';
+import React from 'react';
+import type { SharedValue } from 'react-native-reanimated';
 
 interface Pointer {
   visible: boolean;

--- a/apps/common-app/src/legacy/v2_api/overlap/index.tsx
+++ b/apps/common-app/src/legacy/v2_api/overlap/index.tsx
@@ -1,6 +1,6 @@
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { StyleSheet, Text, View } from 'react-native';
 import React from 'react';
-import { StyleSheet, View, Text } from 'react-native';
-import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 
 function Box(props: {
   color: string;

--- a/apps/common-app/src/legacy/v2_api/pressable/index.tsx
+++ b/apps/common-app/src/legacy/v2_api/pressable/index.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { LegacyPressable } from 'react-native-gesture-handler';
+import React from 'react';
 
 const SECTION_RADIUS = 40;
 const BASE_SIZE = 120;

--- a/apps/common-app/src/legacy/v2_api/transformations/index.tsx
+++ b/apps/common-app/src/legacy/v2_api/transformations/index.tsx
@@ -1,12 +1,10 @@
-import React from 'react';
-import { StyleSheet, View, Image } from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
-import { GestureDetector, Gesture } from 'react-native-gesture-handler';
-
-// @ts-ignore it's an image
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { Image, StyleSheet, View } from 'react-native';
+import React from 'react';
 import SIGNET from '../../../ListWithHeader/signet.png';
 
 function Photo() {

--- a/apps/common-app/src/legacy/v2_api/velocityTest/index.tsx
+++ b/apps/common-app/src/legacy/v2_api/velocityTest/index.tsx
@@ -1,4 +1,3 @@
-import { StyleSheet, View } from 'react-native';
 import Animated, {
   interpolateColor,
   measure,
@@ -8,9 +7,9 @@ import Animated, {
   withDecay,
   withTiming,
 } from 'react-native-reanimated';
-
-import React from 'react';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { StyleSheet, View } from 'react-native';
+import React from 'react';
 
 const BOX_SIZE = 120;
 

--- a/apps/common-app/src/new_api/complicated/camera/capture.tsx
+++ b/apps/common-app/src/new_api/complicated/camera/capture.tsx
@@ -1,9 +1,7 @@
-import { StyleSheet } from 'react-native';
-import Animated, {
-  SharedValue,
-  useAnimatedProps,
-} from 'react-native-reanimated';
+import Animated, { useAnimatedProps } from 'react-native-reanimated';
 import Svg, { Circle } from 'react-native-svg';
+import type { SharedValue } from 'react-native-reanimated';
+import { StyleSheet } from 'react-native';
 
 const CAROUSEL_SIZE = 100;
 const RECORD_INDICATOR_STROKE = 10;

--- a/apps/common-app/src/new_api/complicated/camera/filters.tsx
+++ b/apps/common-app/src/new_api/complicated/camera/filters.tsx
@@ -1,8 +1,6 @@
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { StyleSheet, View } from 'react-native';
-import Animated, {
-  SharedValue,
-  useAnimatedStyle,
-} from 'react-native-reanimated';
+import type { SharedValue } from 'react-native-reanimated';
 
 interface FilterCarouselProps {
   filters: string[];

--- a/apps/common-app/src/new_api/complicated/camera/index.tsx
+++ b/apps/common-app/src/new_api/complicated/camera/index.tsx
@@ -1,19 +1,19 @@
+import { FilterCarousel, FilterOverlay } from './filters';
+import {
+  GestureDetector,
+  useCompetingGestures,
+  useExclusiveGestures,
+  useLongPressGesture,
+  usePanGesture,
+  usePinchGesture,
+  useSimultaneousGestures,
+  useTapGesture,
+} from 'react-native-gesture-handler';
 import React, { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
-import {
-  useLongPressGesture,
-  usePinchGesture,
-  useTapGesture,
-  useCompetingGestures,
-  GestureDetector,
-  useSimultaneousGestures,
-  usePanGesture,
-  useExclusiveGestures,
-} from 'react-native-gesture-handler';
 import { runOnJS, useSharedValue, withTiming } from 'react-native-reanimated';
 import AnimatedCameraView from '../../../common_assets/AnimatedCameraView/AnimatedCameraView';
 import { COLORS } from '../../../common';
-import { FilterCarousel, FilterOverlay } from './filters';
 import { CaptureButton } from './capture';
 
 const FILTERS = [

--- a/apps/common-app/src/new_api/complicated/chat_heads/index.tsx
+++ b/apps/common-app/src/new_api/complicated/chat_heads/index.tsx
@@ -1,14 +1,15 @@
-import React, { useState } from 'react';
-import { StyleSheet, ImageStyle, LayoutChangeEvent } from 'react-native';
-import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
-  SharedValue,
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
+import type { ImageStyle, LayoutChangeEvent } from 'react-native';
+import React, { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import type { SharedValue } from 'react-native-reanimated';
+import { StyleSheet } from 'react-native';
 import { useHeaderHeight } from '@react-navigation/elements';
 
 const CHAT_HEADS = [

--- a/apps/common-app/src/new_api/complicated/lock/index.tsx
+++ b/apps/common-app/src/new_api/complicated/lock/index.tsx
@@ -1,11 +1,10 @@
-import React, { useState } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
 import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
   runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
 } from 'react-native-reanimated';
+import { COLORS, commonStyles } from '../../../common';
 import {
   GestureDetector,
   useLongPressGesture,
@@ -13,7 +12,8 @@ import {
   useRotationGesture,
   useSimultaneousGestures,
 } from 'react-native-gesture-handler';
-import { COLORS, commonStyles } from '../../../common';
+import React, { useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 
 export default function Lock() {
   const rotation = useSharedValue(-Math.PI / 2);

--- a/apps/common-app/src/new_api/complicated/velocity_test/index.tsx
+++ b/apps/common-app/src/new_api/complicated/velocity_test/index.tsx
@@ -1,4 +1,3 @@
-import { View } from 'react-native';
 import Animated, {
   interpolateColor,
   measure,
@@ -8,10 +7,10 @@ import Animated, {
   withDecay,
   withTiming,
 } from 'react-native-reanimated';
-
-import React from 'react';
-import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import { COLORS, commonStyles } from '../../../common';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
+import React from 'react';
+import { View } from 'react-native';
 
 const BOX_SIZE = 120;
 

--- a/apps/common-app/src/new_api/components/button_underlay/index.tsx
+++ b/apps/common-app/src/new_api/components/button_underlay/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { View, StyleSheet, Text, SafeAreaView } from 'react-native';
 import {
   GestureHandlerRootView,
-  ScrollView,
   RawButton,
+  ScrollView,
 } from 'react-native-gesture-handler';
+import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import React from 'react';
 
 const UNDERLAY_PROPS = {
   underlayColor: 'red',

--- a/apps/common-app/src/new_api/components/buttons/index.tsx
+++ b/apps/common-app/src/new_api/components/buttons/index.tsx
@@ -1,6 +1,3 @@
-import { RefObject, useRef } from 'react';
-import { COLORS, Feedback, FeedbackHandle } from '../../../common';
-import { StyleSheet, Text, View } from 'react-native';
 import {
   BaseButton,
   BorderlessButton,
@@ -8,6 +5,11 @@ import {
   Pressable,
   RectButton,
 } from 'react-native-gesture-handler';
+import { COLORS, Feedback } from '../../../common';
+import { StyleSheet, Text, View } from 'react-native';
+import type { FeedbackHandle } from '../../../common';
+import type { RefObject } from 'react';
+import { useRef } from 'react';
 
 type ButtonWrapperProps = {
   ButtonComponent:

--- a/apps/common-app/src/new_api/components/drawer/index.tsx
+++ b/apps/common-app/src/new_api/components/drawer/index.tsx
@@ -1,15 +1,14 @@
-import React, { useRef, useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { SharedValue } from 'react-native-reanimated';
-
-import ReanimatedDrawerLayout, {
-  DrawerType,
-  DrawerPosition,
-  DrawerLayoutMethods,
-  DrawerLockMode,
-} from 'react-native-gesture-handler/ReanimatedDrawerLayout';
 import { COLORS, LoremIpsum } from '../../../common';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import React, { useRef, useState } from 'react';
+import ReanimatedDrawerLayout, {
+  DrawerLockMode,
+  DrawerPosition,
+  DrawerType,
+} from 'react-native-gesture-handler/ReanimatedDrawerLayout';
+import { StyleSheet, Text, View } from 'react-native';
+import type { DrawerLayoutMethods } from 'react-native-gesture-handler/ReanimatedDrawerLayout';
+import type { SharedValue } from 'react-native-reanimated';
 
 const DrawerPage = ({ progress }: { progress?: SharedValue }) => {
   progress && console.log('Drawer opening progress:', progress);

--- a/apps/common-app/src/new_api/components/flatlist/index.tsx
+++ b/apps/common-app/src/new_api/components/flatlist/index.tsx
@@ -1,11 +1,11 @@
-import { COLORS } from '../../../common';
-import React, { useRef, useState } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
 import {
   FlatList,
-  RefreshControl,
   GestureHandlerRootView,
+  RefreshControl,
 } from 'react-native-gesture-handler';
+import React, { useRef, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { COLORS } from '../../../common';
 
 const DATA = Array.from({ length: 20 }, (_, i) => ({
   id: i.toString(),

--- a/apps/common-app/src/new_api/components/scrollview/index.tsx
+++ b/apps/common-app/src/new_api/components/scrollview/index.tsx
@@ -1,7 +1,7 @@
-import { COLORS } from '../../../common';
 import React, { useRef, useState } from 'react';
-import { Text, StyleSheet, View } from 'react-native';
-import { ScrollView, RefreshControl } from 'react-native-gesture-handler';
+import { RefreshControl, ScrollView } from 'react-native-gesture-handler';
+import { StyleSheet, Text, View } from 'react-native';
+import { COLORS } from '../../../common';
 
 const DATA = Array.from({ length: 20 }, (_, i) => ({
   id: i.toString(),

--- a/apps/common-app/src/new_api/components/swipeable/AppleStyleSwipeableRow.tsx
+++ b/apps/common-app/src/new_api/components/swipeable/AppleStyleSwipeableRow.tsx
@@ -1,16 +1,15 @@
-import React, { ReactNode, useRef } from 'react';
-import { StyleSheet, Text, View, I18nManager } from 'react-native';
-
-import { RectButton } from 'react-native-gesture-handler';
 import Animated, {
   Extrapolation,
-  SharedValue,
   interpolate,
   useAnimatedStyle,
 } from 'react-native-reanimated';
-import Swipeable, {
-  SwipeableMethods,
-} from 'react-native-gesture-handler/ReanimatedSwipeable';
+import { I18nManager, StyleSheet, Text, View } from 'react-native';
+import React, { useRef } from 'react';
+import type { ReactNode } from 'react';
+import { RectButton } from 'react-native-gesture-handler';
+import type { SharedValue } from 'react-native-reanimated';
+import Swipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
+import type { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
 
 interface AppleStyleSwipeableRowProps {
   children?: ReactNode;

--- a/apps/common-app/src/new_api/components/swipeable/GmailStyleSwipeableRow.tsx
+++ b/apps/common-app/src/new_api/components/swipeable/GmailStyleSwipeableRow.tsx
@@ -1,16 +1,15 @@
-import React, { ReactNode, useRef } from 'react';
-import { StyleSheet, I18nManager } from 'react-native';
-
-import { RectButton } from 'react-native-gesture-handler';
 import Animated, {
   Extrapolation,
-  SharedValue,
   interpolate,
   useAnimatedStyle,
 } from 'react-native-reanimated';
-import Swipeable, {
-  SwipeableMethods,
-} from 'react-native-gesture-handler/ReanimatedSwipeable';
+import { I18nManager, StyleSheet } from 'react-native';
+import React, { useRef } from 'react';
+import type { ReactNode } from 'react';
+import { RectButton } from 'react-native-gesture-handler';
+import type { SharedValue } from 'react-native-reanimated';
+import Swipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
+import type { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
 
 interface LeftActionProps {
   dragX: SharedValue<number>;

--- a/apps/common-app/src/new_api/components/swipeable/index.tsx
+++ b/apps/common-app/src/new_api/components/swipeable/index.tsx
@@ -1,19 +1,12 @@
-import React, { useRef } from 'react';
-import { StyleSheet, Text, View, I18nManager } from 'react-native';
-
 import { FlatList, Pressable, RectButton } from 'react-native-gesture-handler';
-
-import Reanimated, {
-  SharedValue,
-  useAnimatedStyle,
-} from 'react-native-reanimated';
-
+import { I18nManager, StyleSheet, Text, View } from 'react-native';
+import React, { useRef } from 'react';
+import Reanimated, { useAnimatedStyle } from 'react-native-reanimated';
 import AppleStyleSwipeableRow from './AppleStyleSwipeableRow';
 import GmailStyleSwipeableRow from './GmailStyleSwipeableRow';
-
-import ReanimatedSwipeable, {
-  SwipeableMethods,
-} from 'react-native-gesture-handler/ReanimatedSwipeable';
+import ReanimatedSwipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
+import type { SharedValue } from 'react-native-reanimated';
+import type { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
 
 //  To toggle LTR/RTL change to `true`
 I18nManager.allowRTL(false);

--- a/apps/common-app/src/new_api/components/switchAndInput/index.tsx
+++ b/apps/common-app/src/new_api/components/switchAndInput/index.tsx
@@ -1,12 +1,12 @@
+import {
+  LegacySwitch,
+  LegacyTextInput,
+  Switch,
+  TextInput,
+} from 'react-native-gesture-handler';
 import React, { useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import type { NativeGestureEvent } from 'react-native-gesture-handler';
-import {
-  TextInput,
-  LegacyTextInput,
-  Switch,
-  LegacySwitch,
-} from 'react-native-gesture-handler';
 
 export default function SwitchTextInputExample() {
   const [switchOn, setSwitchOn] = useState(false);

--- a/apps/common-app/src/new_api/components/touchable/index.tsx
+++ b/apps/common-app/src/new_api/components/touchable/index.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { StyleSheet, Text, View, ScrollView } from 'react-native';
 import {
   GestureHandlerRootView,
   Touchable,
-  TouchableProps,
 } from 'react-native-gesture-handler';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { COLORS } from '../../../common';
+import React from 'react';
+import type { TouchableProps } from 'react-native-gesture-handler';
 
 type ButtonWrapperProps = TouchableProps & {
   name: string;

--- a/apps/common-app/src/new_api/components/touchable_stress/index.tsx
+++ b/apps/common-app/src/new_api/components/touchable_stress/index.tsx
@@ -1,6 +1,6 @@
 import { Profiler, useCallback, useEffect, useRef, useState } from 'react';
+import { ScrollView, Touchable } from 'react-native-gesture-handler';
 import { StyleSheet, Text, View } from 'react-native';
-import { Touchable, ScrollView } from 'react-native-gesture-handler';
 
 const CLICK_COUNT = 2000;
 const N = 25;

--- a/apps/common-app/src/new_api/hover_mouse/context_menu/index.tsx
+++ b/apps/common-app/src/new_api/hover_mouse/context_menu/index.tsx
@@ -1,11 +1,11 @@
-import { COLORS } from '../../../common';
-import React from 'react';
-import { StyleSheet, View } from 'react-native';
 import {
   GestureDetector,
   MouseButton,
   usePanGesture,
 } from 'react-native-gesture-handler';
+import { StyleSheet, View } from 'react-native';
+import { COLORS } from '../../../common';
+import React from 'react';
 
 export default function ContextMenuExample() {
   const p1 = usePanGesture({ mouseButton: MouseButton.RIGHT });

--- a/apps/common-app/src/new_api/hover_mouse/hover/index.tsx
+++ b/apps/common-app/src/new_api/hover_mouse/hover/index.tsx
@@ -1,15 +1,16 @@
-import { COLORS, commonStyles, Feedback } from '../../../common';
-import React, { RefObject, useRef } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated';
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import {
   GestureDetector,
   HoverEffect,
   useHoverGesture,
 } from 'react-native-gesture-handler';
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-} from 'react-native-reanimated';
+import React, { useRef } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import type { RefObject } from 'react';
 
 function useColoredHover(
   color: string,

--- a/apps/common-app/src/new_api/hover_mouse/hoverable_icons/index.tsx
+++ b/apps/common-app/src/new_api/hover_mouse/hoverable_icons/index.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
-import {
-  GestureDetector,
-  HoverEffect,
-  useHoverGesture,
-} from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useFrameCallback,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import {
+  GestureDetector,
+  HoverEffect,
+  useHoverGesture,
+} from 'react-native-gesture-handler';
 import { Platform, StyleSheet } from 'react-native';
+import React from 'react';
 import { commonStyles } from '../../../common';
 
 // eslint-disable-next-line import-x/no-commonjs, @typescript-eslint/no-var-requires

--- a/apps/common-app/src/new_api/hover_mouse/mouse_buttons/index.tsx
+++ b/apps/common-app/src/new_api/hover_mouse/mouse_buttons/index.tsx
@@ -1,16 +1,16 @@
-import React, { useRef } from 'react';
+import { COLORS, Feedback } from '../../../common';
 import {
+  Directions,
   GestureDetector,
   MouseButton,
-  Directions,
   ScrollView,
-  useTapGesture,
-  usePanGesture,
-  useLongPressGesture,
   useFlingGesture,
+  useLongPressGesture,
+  usePanGesture,
+  useTapGesture,
 } from 'react-native-gesture-handler';
-import { StyleSheet, View, Text } from 'react-native';
-import { COLORS, Feedback } from '../../../common';
+import React, { useRef } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 
 export default function Buttons() {
   const feedbackRef = useRef<{ showMessage: (msg: string) => void }>(null);

--- a/apps/common-app/src/new_api/hover_mouse/stylus_data/index.tsx
+++ b/apps/common-app/src/new_api/hover_mouse/stylus_data/index.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { StyleSheet, View, Image } from 'react-native';
-import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
+import { Image, StyleSheet, View } from 'react-native';
+import React from 'react';
 
 // eslint-disable-next-line import-x/no-commonjs, @typescript-eslint/no-var-requires
 const GH = require('../../../common_assets/hoverable_icons/gh.png');

--- a/apps/common-app/src/new_api/index.tsx
+++ b/apps/common-app/src/new_api/index.tsx
@@ -1,52 +1,46 @@
 import AnimatedExample from './showcase/animated';
 import BottomSheetExample from './showcase/bottom_sheet';
-import NestedTextExample from './showcase/nested_text/nested_text';
-import OverlapExample from './showcase/overlap';
-import SharedValueExample from './showcase/shared_value';
-import SvgExample from './showcase/svg';
-import StateManagerExample from './showcase/state_manager';
-import TimerExample from './showcase/timer';
-
+import ButtonUnderlayExample from './components/button_underlay';
+import ButtonsExample from './components/buttons';
 import CameraExample from './complicated/camera';
 import ChatHeadsExample from './complicated/chat_heads';
-import LockExample from './complicated/lock';
-import VelocityExample from './complicated/velocity_test';
-
 import ContextMenuExample from './hover_mouse/context_menu';
-import HoverIconsExample from './hover_mouse/hover';
-import HoverableIconsExample from './hover_mouse/hoverable_icons';
-import MouseButtonsExample from './hover_mouse/mouse_buttons';
-import StylusDataExample from './hover_mouse/stylus_data';
-
+import EmptyExample from '../empty';
+import type { ExamplesSection } from '../common';
+import FlatListExample from './components/flatlist';
 import FlingExample from './simple/fling';
 import HoverExample from './simple/hover';
+import HoverIconsExample from './hover_mouse/hover';
+import HoverableIconsExample from './hover_mouse/hoverable_icons';
+import LockExample from './complicated/lock';
 import LongPressExample from './simple/longPress';
+import MouseButtonsExample from './hover_mouse/mouse_buttons';
+import NestedPressablesExample from './tests/nestedPressables';
+import NestedRootViewExample from './tests/nestedRootView';
+import NestedTextExample from './showcase/nested_text/nested_text';
+import OverlapExample from './showcase/overlap';
 import PanExample from './simple/pan';
 import PinchExample from './simple/pinch';
-import RotationExample from './simple/rotation';
-import TapExample from './simple/tap';
-
-import ButtonsExample from './components/buttons';
-import ButtonUnderlayExample from './components/button_underlay';
-import TouchableExample from './components/touchable';
-import TouchableStressExample from './components/touchable_stress';
+import PointerTypeExample from './tests/pointerType';
+import PressableExample from './tests/pressable';
 import ReanimatedDrawerLayout from './components/drawer';
-import FlatListExample from './components/flatlist';
+import ReattachingExample from './tests/reattaching';
+import RectButtonExample from './tests/rectButton';
+import RotationExample from './simple/rotation';
 import ScrollViewExample from './components/scrollview';
+import SharedValueExample from './showcase/shared_value';
+import StateManagerExample from './showcase/state_manager';
+import StylusDataExample from './hover_mouse/stylus_data';
+import SvgExample from './showcase/svg';
 import Swipeable from './components/swipeable/index';
 import SwitchTextInputExample from './components/switchAndInput';
-
-import RectButtonExample from './tests/rectButton';
+import TapExample from './simple/tap';
+import TimerExample from './showcase/timer';
+import TouchableExample from './components/touchable';
+import TouchableStressExample from './components/touchable_stress';
 import TwoFingerPanExample from './tests/twoFingerPan';
+import VelocityExample from './complicated/velocity_test';
 import WebStylesResetExample from './tests/webStylesReset';
-import PointerTypeExample from './tests/pointerType';
-import ReattachingExample from './tests/reattaching';
-import NestedRootViewExample from './tests/nestedRootView';
-import NestedPressablesExample from './tests/nestedPressables';
-import PressableExample from './tests/pressable';
-
-import { ExamplesSection } from '../common';
-import EmptyExample from '../empty';
 
 export const NEW_EXAMPLES: ExamplesSection[] = [
   {

--- a/apps/common-app/src/new_api/showcase/animated/index.tsx
+++ b/apps/common-app/src/new_api/showcase/animated/index.tsx
@@ -1,7 +1,7 @@
+import { Animated, Dimensions, StyleSheet, Text, View } from 'react-native';
 import { COLORS, commonStyles } from '../../../common';
-import React, { useRef } from 'react';
-import { View, Text, StyleSheet, Animated, Dimensions } from 'react-native';
 import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
+import React, { useRef } from 'react';
 
 const { width } = Dimensions.get('window');
 

--- a/apps/common-app/src/new_api/showcase/bottom_sheet/index.tsx
+++ b/apps/common-app/src/new_api/showcase/bottom_sheet/index.tsx
@@ -1,26 +1,21 @@
-import React, { useState } from 'react';
-import {
-  Dimensions,
-  NativeScrollEvent,
-  NativeSyntheticEvent,
-  StyleSheet,
-  View,
-} from 'react-native';
-import {
-  GestureDetector,
-  PanGestureActiveEvent,
-  useSimultaneousGestures,
-  usePanGesture,
-  useTapGesture,
-  useNativeGesture,
-} from 'react-native-gesture-handler';
 import Animated, {
   runOnJS,
   useAnimatedStyle,
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated';
-import { COLORS, commonStyles, LoremIpsum } from '../../../common';
+import { COLORS, LoremIpsum, commonStyles } from '../../../common';
+import { Dimensions, StyleSheet, View } from 'react-native';
+import {
+  GestureDetector,
+  useNativeGesture,
+  usePanGesture,
+  useSimultaneousGestures,
+  useTapGesture,
+} from 'react-native-gesture-handler';
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+import React, { useState } from 'react';
+import type { PanGestureActiveEvent } from 'react-native-gesture-handler';
 
 const HEADER_HEIGTH = 50;
 const windowHeight = Dimensions.get('window').height;

--- a/apps/common-app/src/new_api/showcase/nested_text/nested_text.tsx
+++ b/apps/common-app/src/new_api/showcase/nested_text/nested_text.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text, View } from 'react-native';
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import {
   Gesture,
   GestureDetector,
@@ -7,8 +7,7 @@ import {
   VirtualGestureDetector,
   useTapGesture,
 } from 'react-native-gesture-handler';
-
-import { COLORS, commonStyles, Feedback } from '../../../common';
+import { Text, View } from 'react-native';
 
 function NativeDetectorExample() {
   const feedbackRef = React.useRef<{ showMessage: (msg: string) => void }>(

--- a/apps/common-app/src/new_api/showcase/overlap/index.tsx
+++ b/apps/common-app/src/new_api/showcase/overlap/index.tsx
@@ -1,11 +1,11 @@
-import { COLORS, commonStyles, Feedback } from '../../../common';
-import React, { useRef } from 'react';
-import { StyleSheet, View, Text } from 'react-native';
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import {
   InterceptingGestureDetector,
-  useTapGesture,
   VirtualGestureDetector,
+  useTapGesture,
 } from 'react-native-gesture-handler';
+import React, { useRef } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 
 function Box(props: {
   color: string;

--- a/apps/common-app/src/new_api/showcase/shared_value/index.tsx
+++ b/apps/common-app/src/new_api/showcase/shared_value/index.tsx
@@ -1,18 +1,18 @@
+import Animated, {
+  interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { COLORS, commonStyles } from '../../../common';
-import React from 'react';
-import { Text, View } from 'react-native';
 import {
   GestureDetector,
   useLongPressGesture,
   usePanGesture,
   useSimultaneousGestures,
 } from 'react-native-gesture-handler';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  interpolateColor,
-  withTiming,
-} from 'react-native-reanimated';
+import { Text, View } from 'react-native';
+import React from 'react';
 
 export default function PanExample() {
   const translateX = useSharedValue(0);

--- a/apps/common-app/src/new_api/showcase/state_manager/index.tsx
+++ b/apps/common-app/src/new_api/showcase/state_manager/index.tsx
@@ -1,18 +1,18 @@
-import { COLORS, commonStyles } from '../../../common';
-import React from 'react';
-import { View } from 'react-native';
-import {
-  GestureHandlerRootView,
-  GestureDetector,
-  useLongPressGesture,
-  GestureStateManager,
-  LongPressGesture,
-} from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { COLORS, commonStyles } from '../../../common';
+import {
+  GestureDetector,
+  GestureHandlerRootView,
+  GestureStateManager,
+  useLongPressGesture,
+} from 'react-native-gesture-handler';
+import type { LongPressGesture } from 'react-native-gesture-handler';
+import React from 'react';
+import { View } from 'react-native';
 
 export default function TwoPressables() {
   const isActivated = [

--- a/apps/common-app/src/new_api/showcase/svg/index.tsx
+++ b/apps/common-app/src/new_api/showcase/svg/index.tsx
@@ -1,12 +1,12 @@
-import { COLORS, commonStyles, Feedback } from '../../../common';
-import React, { useRef } from 'react';
-import { View } from 'react-native';
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import {
   InterceptingGestureDetector,
-  useTapGesture,
   VirtualGestureDetector,
+  useTapGesture,
 } from 'react-native-gesture-handler';
+import React, { useRef } from 'react';
 import Svg, { Circle, Rect } from 'react-native-svg';
+import { View } from 'react-native';
 
 export default function LogicDetectorExample() {
   const feedbackRef = useRef<{ showMessage: (msg: string) => void }>(null);

--- a/apps/common-app/src/new_api/showcase/timer/index.tsx
+++ b/apps/common-app/src/new_api/showcase/timer/index.tsx
@@ -1,25 +1,21 @@
-import React, { useRef } from 'react';
-import { StyleSheet, View, Text, TextInput } from 'react-native';
-import {
-  useLongPressGesture,
-  GestureDetector,
-  GestureHandlerRootView,
-} from 'react-native-gesture-handler';
 import Animated, {
-  useSharedValue,
-  withTiming,
-  cancelAnimation,
   Easing,
+  cancelAnimation,
+  interpolateColor,
   useAnimatedProps,
   useAnimatedStyle,
-  interpolateColor,
+  useSharedValue,
+  withTiming,
 } from 'react-native-reanimated';
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import {
-  Feedback,
-  FeedbackHandle,
-  COLORS,
-  commonStyles,
-} from '../../../common';
+  GestureDetector,
+  GestureHandlerRootView,
+  useLongPressGesture,
+} from 'react-native-gesture-handler';
+import React, { useRef } from 'react';
+import { StyleSheet, Text, TextInput, View } from 'react-native';
+import type { FeedbackHandle } from '../../../common';
 
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 

--- a/apps/common-app/src/new_api/simple/fling/index.tsx
+++ b/apps/common-app/src/new_api/simple/fling/index.tsx
@@ -1,18 +1,18 @@
+import Animated, {
+  Easing,
+  interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { COLORS, commonStyles } from '../../../common';
-import React from 'react';
-import { View } from 'react-native';
 import {
   Directions,
   GestureDetector,
   useFlingGesture,
 } from 'react-native-gesture-handler';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-  Easing,
-  interpolateColor,
-} from 'react-native-reanimated';
+import React from 'react';
+import { View } from 'react-native';
 
 export default function FlingExample() {
   const position = useSharedValue(0);

--- a/apps/common-app/src/new_api/simple/hover/index.tsx
+++ b/apps/common-app/src/new_api/simple/hover/index.tsx
@@ -1,13 +1,13 @@
+import Animated, {
+  interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { COLORS, commonStyles } from '../../../common';
+import { GestureDetector, useHoverGesture } from 'react-native-gesture-handler';
 import React from 'react';
 import { View } from 'react-native';
-import { GestureDetector, useHoverGesture } from 'react-native-gesture-handler';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-  interpolateColor,
-} from 'react-native-reanimated';
 
 export default function TapExample() {
   const colorProgress = useSharedValue(0);

--- a/apps/common-app/src/new_api/simple/longPress/index.tsx
+++ b/apps/common-app/src/new_api/simple/longPress/index.tsx
@@ -1,16 +1,16 @@
+import Animated, {
+  interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { COLORS, commonStyles } from '../../../common';
-import React from 'react';
-import { View } from 'react-native';
 import {
   GestureDetector,
   useLongPressGesture,
 } from 'react-native-gesture-handler';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-  interpolateColor,
-} from 'react-native-reanimated';
+import React from 'react';
+import { View } from 'react-native';
 
 export default function LongPressExample() {
   const colorProgress = useSharedValue(0);

--- a/apps/common-app/src/new_api/simple/pan/index.tsx
+++ b/apps/common-app/src/new_api/simple/pan/index.tsx
@@ -1,13 +1,13 @@
-import { COLORS, commonStyles } from '../../../common';
-import React from 'react';
-import { View } from 'react-native';
-import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
   interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { COLORS, commonStyles } from '../../../common';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
+import React from 'react';
+import { View } from 'react-native';
 
 export default function PanExample() {
   const translateX = useSharedValue(0);

--- a/apps/common-app/src/new_api/simple/pinch/index.tsx
+++ b/apps/common-app/src/new_api/simple/pinch/index.tsx
@@ -1,13 +1,13 @@
-import { commonStyles, COLORS } from '../../../common';
-import React from 'react';
-import { View } from 'react-native';
-import { GestureDetector, usePinchGesture } from 'react-native-gesture-handler';
 import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
   interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { COLORS, commonStyles } from '../../../common';
+import { GestureDetector, usePinchGesture } from 'react-native-gesture-handler';
+import React from 'react';
+import { View } from 'react-native';
 
 export default function PinchExample() {
   const scale = useSharedValue(1);

--- a/apps/common-app/src/new_api/simple/rotation/index.tsx
+++ b/apps/common-app/src/new_api/simple/rotation/index.tsx
@@ -1,16 +1,16 @@
+import Animated, {
+  interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { COLORS, commonStyles } from '../../../common';
-import React from 'react';
-import { View } from 'react-native';
 import {
   GestureDetector,
   useRotationGesture,
 } from 'react-native-gesture-handler';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  interpolateColor,
-  withTiming,
-} from 'react-native-reanimated';
+import React from 'react';
+import { View } from 'react-native';
 
 export default function RotationExample() {
   const rotation = useSharedValue(0);

--- a/apps/common-app/src/new_api/simple/tap/index.tsx
+++ b/apps/common-app/src/new_api/simple/tap/index.tsx
@@ -1,13 +1,13 @@
-import { commonStyles, COLORS } from '../../../common';
+import Animated, {
+  interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { COLORS, commonStyles } from '../../../common';
+import { GestureDetector, useTapGesture } from 'react-native-gesture-handler';
 import React from 'react';
 import { View } from 'react-native';
-import { GestureDetector, useTapGesture } from 'react-native-gesture-handler';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-  interpolateColor,
-} from 'react-native-reanimated';
 
 export default function TapExample() {
   const colorProgress = useSharedValue(0);

--- a/apps/common-app/src/new_api/tests/nestedPressables/index.tsx
+++ b/apps/common-app/src/new_api/tests/nestedPressables/index.tsx
@@ -1,18 +1,9 @@
+import { COLORS, Feedback, commonStyles } from '../../../common';
+import { Pressable as RNPressable, StyleSheet, Text, View } from 'react-native';
 import React, { useRef } from 'react';
-import {
-  Pressable as RNPressable,
-  PressableStateCallbackType,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
+import type { FeedbackHandle } from '../../../common';
 import { Pressable } from 'react-native-gesture-handler';
-import {
-  COLORS,
-  commonStyles,
-  Feedback,
-  FeedbackHandle,
-} from '../../../common';
+import type { PressableStateCallbackType } from 'react-native';
 
 export default function Example() {
   const feedbackRefRNGH = useRef<FeedbackHandle>(null);

--- a/apps/common-app/src/new_api/tests/nestedRootView/index.tsx
+++ b/apps/common-app/src/new_api/tests/nestedRootView/index.tsx
@@ -1,22 +1,18 @@
 import * as React from 'react';
-import { useState, useRef } from 'react';
-import { StyleSheet, Modal, View, Text } from 'react-native';
-import {
-  GestureHandlerRootView,
-  RectButton,
-  GestureDetector,
-  usePanGesture,
-} from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import {
-  Feedback,
-  FeedbackHandle,
-  COLORS,
-  commonStyles,
-} from '../../../common';
+  GestureDetector,
+  GestureHandlerRootView,
+  RectButton,
+  usePanGesture,
+} from 'react-native-gesture-handler';
+import { Modal, StyleSheet, Text, View } from 'react-native';
+import { useRef, useState } from 'react';
+import type { FeedbackHandle } from '../../../common';
 
 interface DraggableBoxProps {
   minDist?: number;

--- a/apps/common-app/src/new_api/tests/pointerType/index.tsx
+++ b/apps/common-app/src/new_api/tests/pointerType/index.tsx
@@ -1,22 +1,18 @@
-import React, { useRef } from 'react';
-import { View } from 'react-native';
 import Animated, {
   interpolateColor,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import {
   GestureDetector,
   PointerType,
   useLongPressGesture,
 } from 'react-native-gesture-handler';
-import {
-  commonStyles,
-  COLORS,
-  Feedback,
-  FeedbackHandle,
-} from '../../../common';
+import React, { useRef } from 'react';
+import type { FeedbackHandle } from '../../../common';
+import { View } from 'react-native';
 
 const Colors = {
   Default: COLORS.NAVY,

--- a/apps/common-app/src/new_api/tests/pressable/androidRipple.tsx
+++ b/apps/common-app/src/new_api/tests/pressable/androidRipple.tsx
@@ -1,12 +1,8 @@
-import React, { useRef } from 'react';
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import { Platform, View } from 'react-native';
+import React, { useRef } from 'react';
+import type { FeedbackHandle } from '../../../common';
 import TestingBase from './testingBase';
-import {
-  COLORS,
-  commonStyles,
-  Feedback,
-  FeedbackHandle,
-} from '../../../common';
 
 export function RippleExample() {
   const feedbackRef = useRef<FeedbackHandle>(null);

--- a/apps/common-app/src/new_api/tests/pressable/delayedPress.tsx
+++ b/apps/common-app/src/new_api/tests/pressable/delayedPress.tsx
@@ -1,17 +1,13 @@
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import React, { useRef } from 'react';
-import { View } from 'react-native';
-import TestingBase from './testingBase';
 import {
   useSharedValue,
   withSequence,
   withSpring,
 } from 'react-native-reanimated';
-import {
-  COLORS,
-  commonStyles,
-  Feedback,
-  FeedbackHandle,
-} from '../../../common';
+import type { FeedbackHandle } from '../../../common';
+import TestingBase from './testingBase';
+import { View } from 'react-native';
 
 const signalerConfig = {
   stiffness: 500,

--- a/apps/common-app/src/new_api/tests/pressable/functionalStyles.tsx
+++ b/apps/common-app/src/new_api/tests/pressable/functionalStyles.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { PressableStateCallbackType, View } from 'react-native';
-import TestingBase from './testingBase';
 import { COLORS, commonStyles } from '../../../common';
+import type { PressableStateCallbackType } from 'react-native';
+import React from 'react';
+import TestingBase from './testingBase';
+import { View } from 'react-native';
 
 export function FunctionalStyleExample() {
   const functionalStyle = (state: PressableStateCallbackType) => {

--- a/apps/common-app/src/new_api/tests/pressable/hitSlop.tsx
+++ b/apps/common-app/src/new_api/tests/pressable/hitSlop.tsx
@@ -1,12 +1,8 @@
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import React, { useRef } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import type { FeedbackHandle } from '../../../common';
 import TestingBase from './testingBase';
-import {
-  COLORS,
-  commonStyles,
-  Feedback,
-  FeedbackHandle,
-} from '../../../common';
 
 const HIT_SLOP = 40;
 const PRESS_RETENTION_OFFSET = HIT_SLOP;

--- a/apps/common-app/src/new_api/tests/pressable/hoverDelay.tsx
+++ b/apps/common-app/src/new_api/tests/pressable/hoverDelay.tsx
@@ -1,12 +1,8 @@
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import React, { useRef } from 'react';
-import { View } from 'react-native';
+import type { FeedbackHandle } from '../../../common';
 import TestingBase from './testingBase';
-import {
-  COLORS,
-  commonStyles,
-  Feedback,
-  FeedbackHandle,
-} from '../../../common';
+import { View } from 'react-native';
 
 export function DelayHoverExample() {
   const feedbackRef = useRef<FeedbackHandle>(null);

--- a/apps/common-app/src/new_api/tests/pressable/index.tsx
+++ b/apps/common-app/src/new_api/tests/pressable/index.tsx
@@ -1,12 +1,12 @@
-import React, { ReactNode } from 'react';
-import { Text, View, StyleSheet } from 'react-native';
-import { ScrollView } from 'react-native-gesture-handler';
-
-import { HitSlopExample } from './hitSlop';
-import { RippleExample } from './androidRipple';
-import { FunctionalStyleExample } from './functionalStyles';
-import { DelayedPressExample } from './delayedPress';
+import { StyleSheet, Text, View } from 'react-native';
 import { DelayHoverExample } from './hoverDelay';
+import { DelayedPressExample } from './delayedPress';
+import { FunctionalStyleExample } from './functionalStyles';
+import { HitSlopExample } from './hitSlop';
+import React from 'react';
+import type { ReactNode } from 'react';
+import { RippleExample } from './androidRipple';
+import { ScrollView } from 'react-native-gesture-handler';
 import { commonStyles } from '../../../common';
 
 type TestingEntryProps = {

--- a/apps/common-app/src/new_api/tests/pressable/testingBase.tsx
+++ b/apps/common-app/src/new_api/tests/pressable/testingBase.tsx
@@ -1,15 +1,9 @@
-import { commonStyles } from '../../../common';
+import { Pressable, Text, View } from 'react-native';
+import type { PressableProps as GHPressableProps } from 'react-native-gesture-handler';
+import { Pressable as GesturizedPressable } from 'react-native-gesture-handler';
+import type { PressableProps as RNPressableProps } from 'react-native';
 import React from 'react';
-import {
-  Text,
-  View,
-  Pressable,
-  PressableProps as RNPressableProps,
-} from 'react-native';
-import {
-  Pressable as GesturizedPressable,
-  PressableProps as GHPressableProps,
-} from 'react-native-gesture-handler';
+import { commonStyles } from '../../../common';
 
 const TestingBase = (props: GHPressableProps & RNPressableProps) => (
   <>

--- a/apps/common-app/src/new_api/tests/reattaching/index.tsx
+++ b/apps/common-app/src/new_api/tests/reattaching/index.tsx
@@ -1,12 +1,8 @@
-import React, { useState, useRef } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import { GestureDetector, useTapGesture } from 'react-native-gesture-handler';
-import {
-  commonStyles,
-  COLORS,
-  Feedback,
-  FeedbackHandle,
-} from '../../../common';
+import React, { useRef, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import type { FeedbackHandle } from '../../../common';
 
 export default function TapExample() {
   const [isTopActive, setIsTopActive] = useState(false);

--- a/apps/common-app/src/new_api/tests/rectButton/index.tsx
+++ b/apps/common-app/src/new_api/tests/rectButton/index.tsx
@@ -1,12 +1,9 @@
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import React, { useRef } from 'react';
-import { StyleSheet, Text, View, StyleProp, ViewStyle } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import type { FeedbackHandle } from '../../../common';
 import { RectButton } from 'react-native-gesture-handler';
-import {
-  COLORS,
-  commonStyles,
-  Feedback,
-  FeedbackHandle,
-} from '../../../common';
 
 export default function RectButtonBorders() {
   const feedbackRef = useRef<FeedbackHandle>(null);

--- a/apps/common-app/src/new_api/tests/twoFingerPan/index.tsx
+++ b/apps/common-app/src/new_api/tests/twoFingerPan/index.tsx
@@ -1,12 +1,12 @@
-import { StyleSheet, View } from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
-
-import React, { useRef } from 'react';
+import { Feedback, commonStyles } from '../../../common';
 import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
-import { commonStyles, Feedback, FeedbackHandle } from '../../../common';
+import React, { useRef } from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { FeedbackHandle } from '../../../common';
 
 const BOX_SIZE = 270;
 

--- a/apps/common-app/src/new_api/tests/webStylesReset/index.tsx
+++ b/apps/common-app/src/new_api/tests/webStylesReset/index.tsx
@@ -1,22 +1,18 @@
-import React, { useRef, useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import {
-  GestureDetector,
-  Pressable,
-  usePanGesture,
-} from 'react-native-gesture-handler';
 import Animated, {
   interpolateColor,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { COLORS, Feedback, commonStyles } from '../../../common';
 import {
-  COLORS,
-  commonStyles,
-  Feedback,
-  FeedbackHandle,
-} from '../../../common';
+  GestureDetector,
+  Pressable,
+  usePanGesture,
+} from 'react-native-gesture-handler';
+import React, { useRef, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import type { FeedbackHandle } from '../../../common';
 
 const Colors = {
   enabled: COLORS.GREEN,

--- a/apps/expo-example/index.ts
+++ b/apps/expo-example/index.ts
@@ -1,7 +1,6 @@
 import '@expo/metro-runtime';
-import { registerRootComponent } from 'expo';
-
 import App from './App';
+import { registerRootComponent } from 'expo';
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,

--- a/apps/macos-example/index.ts
+++ b/apps/macos-example/index.ts
@@ -2,8 +2,8 @@
  * @format
  */
 
-import { AppRegistry } from 'react-native';
 import App from 'common-app';
+import { AppRegistry } from 'react-native';
 import { name as appName } from './app.json';
 
 AppRegistry.registerComponent(appName, () => App);

--- a/packages/react-native-gesture-handler/src/RNGestureHandlerModule.web.ts
+++ b/packages/react-native-gesture-handler/src/RNGestureHandlerModule.web.ts
@@ -1,12 +1,11 @@
-import React from 'react';
-
-import type { ActionType } from './ActionType';
-import { Gestures } from './web/Gestures';
 import type { Config, PropsRef } from './web/interfaces';
+import type { ActionType } from './ActionType';
+import { GestureHandlerWebDelegate } from './web/tools/GestureHandlerWebDelegate';
+import type { GestureRelations } from './v3/types';
+import { Gestures } from './web/Gestures';
 import InteractionManager from './web/tools/InteractionManager';
 import NodeManager from './web/tools/NodeManager';
-import { GestureHandlerWebDelegate } from './web/tools/GestureHandlerWebDelegate';
-import { GestureRelations } from './v3/types';
+import React from 'react';
 
 // init method is called inside attachGestureHandler function. However, this function may
 // fail when received view is not valid HTML element. On the other hand, dropGestureHandler

--- a/packages/react-native-gesture-handler/src/RNGestureHandlerModule.windows.ts
+++ b/packages/react-native-gesture-handler/src/RNGestureHandlerModule.windows.ts
@@ -1,17 +1,14 @@
-import React from 'react';
-
-import { ActionType } from './ActionType';
-
-// GestureHandlers
-import PanGestureHandler from './web/handlers/PanGestureHandler';
-import TapGestureHandler from './web/handlers/TapGestureHandler';
-import LongPressGestureHandler from './web/handlers/LongPressGestureHandler';
-import PinchGestureHandler from './web/handlers/PinchGestureHandler';
-import RotationGestureHandler from './web/handlers/RotationGestureHandler';
+import type { ActionType } from './ActionType';
+import type { Config } from './web/interfaces';
 import FlingGestureHandler from './web/handlers/FlingGestureHandler';
-import NativeViewGestureHandler from './web/handlers/NativeViewGestureHandler';
+import LongPressGestureHandler from './web/handlers/LongPressGestureHandler';
 import ManualGestureHandler from './web/handlers/ManualGestureHandler';
-import { Config } from './web/interfaces';
+import NativeViewGestureHandler from './web/handlers/NativeViewGestureHandler';
+import PanGestureHandler from './web/handlers/PanGestureHandler';
+import PinchGestureHandler from './web/handlers/PinchGestureHandler';
+import type React from 'react';
+import RotationGestureHandler from './web/handlers/RotationGestureHandler';
+import TapGestureHandler from './web/handlers/TapGestureHandler';
 
 export const Gestures = {
   NativeViewGestureHandler,

--- a/packages/react-native-gesture-handler/src/__tests__/Errors.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/Errors.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-import { render, cleanup } from '@testing-library/react-native';
 import {
   Gesture,
   GestureDetector,
@@ -7,7 +5,9 @@ import {
   InterceptingGestureDetector,
   useTapGesture,
 } from '../index';
-import { findNodeHandle, View } from 'react-native';
+import { View, findNodeHandle } from 'react-native';
+import { cleanup, render } from '@testing-library/react-native';
+import React from 'react';
 import { VirtualDetector } from '../v3/detectors/VirtualDetector/VirtualDetector';
 
 jest.mock('react-native-worklets', () =>

--- a/packages/react-native-gesture-handler/src/__tests__/Events.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/Events.test.tsx
@@ -1,19 +1,21 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 // Disabling lint for assymetric matchers, check proposal below
 // https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/56937
-import React from 'react';
-import { render, cleanup } from '@testing-library/react-native';
-import { Text } from 'react-native';
 import {
-  GestureHandlerRootView,
-  PanGestureHandler,
   Gesture,
   GestureDetector,
+  GestureHandlerRootView,
   State,
+} from '../index';
+import type {
   LegacyPanGesture,
   LegacyTapGesture,
+  PanGestureHandler,
 } from '../index';
+import { cleanup, render } from '@testing-library/react-native';
 import { fireGestureHandler, getByGestureTestId } from '../jestUtils';
+import React from 'react';
+import { Text } from 'react-native';
 
 beforeEach(cleanup);
 

--- a/packages/react-native-gesture-handler/src/__tests__/RelationsTraversal.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/RelationsTraversal.test.tsx
@@ -1,13 +1,14 @@
-import { tagMessage } from '../utils';
 import {
-  useExclusiveGestures,
   useCompetingGestures,
+  useExclusiveGestures,
   useSimultaneousGestures,
 } from '../v3/hooks/composition';
-import { useGesture } from '../v3/hooks/useGesture';
+import type { SingleGesture } from '../v3/types';
+import { SingleGestureName } from '../v3/types';
 import { configureRelations } from '../v3/detectors/utils';
-import { SingleGesture, SingleGestureName } from '../v3/types';
 import { renderHook } from '@testing-library/react-native';
+import { tagMessage } from '../utils';
+import { useGesture } from '../v3/hooks/useGesture';
 
 type AnySingleGesture = SingleGesture<unknown, unknown, unknown>;
 

--- a/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
@@ -1,11 +1,11 @@
-import { usePanGesture } from '../v3/hooks/gestures';
-import { render, renderHook } from '@testing-library/react-native';
-import { fireGestureHandler, getByGestureTestId } from '../jestUtils';
-import { State } from '../State';
-import GestureHandlerRootView from '../components/GestureHandlerRootView';
 import { RectButton, Touchable } from '../v3/components';
-import { act } from 'react';
+import { fireGestureHandler, getByGestureTestId } from '../jestUtils';
+import { render, renderHook } from '@testing-library/react-native';
+import GestureHandlerRootView from '../components/GestureHandlerRootView';
 import type { SingleGesture } from '../v3/types';
+import { State } from '../State';
+import { act } from 'react';
+import { usePanGesture } from '../v3/hooks/gestures';
 
 describe('[API v3] Hooks', () => {
   test('Pan gesture', () => {

--- a/packages/react-native-gesture-handler/src/__tests__/mocks.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/mocks.test.tsx
@@ -1,33 +1,28 @@
-import React from 'react';
-import { Text } from 'react-native';
-import { render, fireEvent } from '@testing-library/react-native';
-
 import {
-  LegacyRawButton,
   LegacyBaseButton,
-  LegacyRectButton,
   LegacyBorderlessButton,
   LegacyPureNativeButton,
+  LegacyRawButton,
+  LegacyRectButton,
 } from '../mocks/GestureButtons';
-
 import {
-  LegacyScrollView,
   LegacyFlatList,
+  LegacyRefreshControl,
+  LegacyScrollView,
   LegacySwitch,
   LegacyTextInput,
-  LegacyRefreshControl,
 } from '../mocks/gestureComponents';
-
 import {
   TouchableHighlight,
   TouchableNativeFeedback,
   TouchableOpacity,
   TouchableWithoutFeedback,
 } from '../mocks/Touchables';
-
-import LegacyPressable from '../mocks/Pressable';
-
+import { fireEvent, render } from '@testing-library/react-native';
 import GestureHandlerRootView from '../components/GestureHandlerRootView';
+import LegacyPressable from '../mocks/Pressable';
+import React from 'react';
+import { Text } from 'react-native';
 import { Touchable } from '../v3/components';
 
 describe('Jest mocks – legacy components render without crashing', () => {

--- a/packages/react-native-gesture-handler/src/components/GestureButtons.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureButtons.tsx
@@ -1,25 +1,23 @@
 import * as React from 'react';
 import { Animated, Platform, StyleSheet } from 'react-native';
-
-import createNativeWrapper from '../handlers/createNativeWrapper';
-import GestureHandlerButton from './GestureHandlerButton';
-import { State } from '../State';
-
-import {
+import type {
+  BaseButtonWithRefProps,
+  BorderlessButtonWithRefProps,
+  LegacyBaseButtonProps,
+  LegacyBorderlessButtonProps,
+  LegacyRawButtonProps,
+  LegacyRectButtonProps,
+  RectButtonWithRefProps,
+} from './GestureButtonsProps';
+import type {
   GestureEvent,
   HandlerStateChangeEvent,
 } from '../handlers/gestureHandlerCommon';
-import type { NativeViewGestureHandlerPayload } from '../handlers/GestureHandlerEventPayload';
-import type {
-  BaseButtonWithRefProps,
-  LegacyBaseButtonProps,
-  RectButtonWithRefProps,
-  LegacyRectButtonProps,
-  BorderlessButtonWithRefProps,
-  LegacyBorderlessButtonProps,
-  LegacyRawButtonProps,
-} from './GestureButtonsProps';
+import GestureHandlerButton from './GestureHandlerButton';
 import type { HostComponent } from 'react-native';
+import type { NativeViewGestureHandlerPayload } from '../handlers/GestureHandlerEventPayload';
+import { State } from '../State';
+import createNativeWrapper from '../handlers/createNativeWrapper';
 
 /**
  * @deprecated use `RawButton` instead

--- a/packages/react-native-gesture-handler/src/components/GestureButtonsProps.ts
+++ b/packages/react-native-gesture-handler/src/components/GestureButtonsProps.ts
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import {
+import type * as React from 'react';
+import type {
   AccessibilityProps,
   ColorValue,
   LayoutChangeEvent,

--- a/packages/react-native-gesture-handler/src/components/GestureComponents.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureComponents.tsx
@@ -1,31 +1,28 @@
 import * as React from 'react';
-import {
-  PropsWithChildren,
+import type {
   ForwardedRef,
-  RefAttributes,
+  PropsWithChildren,
   ReactElement,
+  RefAttributes,
 } from 'react';
 import {
-  ScrollView as RNScrollView,
-  ScrollViewProps as RNScrollViewProps,
-  Switch as RNSwitch,
-  SwitchProps as RNSwitchProps,
-  TextInput as RNTextInput,
-  TextInputProps as RNTextInputProps,
   DrawerLayoutAndroid as RNDrawerLayoutAndroid,
-  DrawerLayoutAndroidProps as RNDrawerLayoutAndroidProps,
   FlatList as RNFlatList,
-  FlatListProps as RNFlatListProps,
   RefreshControl as RNRefreshControl,
+  ScrollView as RNScrollView,
+  Switch as RNSwitch,
+  TextInput as RNTextInput,
 } from 'react-native';
-
+import type {
+  DrawerLayoutAndroidProps as RNDrawerLayoutAndroidProps,
+  FlatListProps as RNFlatListProps,
+  ScrollViewProps as RNScrollViewProps,
+  SwitchProps as RNSwitchProps,
+  TextInputProps as RNTextInputProps,
+} from 'react-native';
+import type { NativeViewGestureHandlerProps } from '../handlers/NativeViewGestureHandler';
 import createNativeWrapper from '../handlers/createNativeWrapper';
-
-import {
-  NativeViewGestureHandlerProps,
-  nativeViewProps,
-} from '../handlers/NativeViewGestureHandler';
-
+import { nativeViewProps } from '../handlers/NativeViewGestureHandler';
 import { toArray } from '../utils';
 
 /**

--- a/packages/react-native-gesture-handler/src/components/GestureComponents.web.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureComponents.web.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import {
   FlatList as RNFlatList,
+  ScrollView as RNScrollView,
   Switch as RNSwitch,
   TextInput as RNTextInput,
-  ScrollView as RNScrollView,
-  FlatListProps,
   View,
 } from 'react-native';
-
+import type { FlatListProps } from 'react-native';
 import createNativeWrapper from '../handlers/createNativeWrapper';
 
 /**

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -1,4 +1,4 @@
-import {
+import type {
   AccessibilityProps,
   ColorValue,
   HostComponent,

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { ColorValue, View, ViewProps } from 'react-native';
+import type { ColorValue, ViewProps } from 'react-native';
+import { View } from 'react-native';
 
 type ButtonProps = ViewProps & {
   ref?: React.Ref<React.ComponentRef<typeof View>>;

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerRootView.android.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerRootView.android.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { PropsWithChildren } from 'react';
-import { StyleSheet } from 'react-native';
 import GestureHandlerRootViewContext from '../GestureHandlerRootViewContext';
-import type { RootViewNativeProps } from '../specs/RNGestureHandlerRootViewNativeComponent';
 import GestureHandlerRootViewNativeComponent from '../specs/RNGestureHandlerRootViewNativeComponent';
+import type { PropsWithChildren } from 'react';
+import type { RootViewNativeProps } from '../specs/RNGestureHandlerRootViewNativeComponent';
+import { StyleSheet } from 'react-native';
 
 export interface GestureHandlerRootViewProps
   extends PropsWithChildren<RootViewNativeProps> {}

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerRootView.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerRootView.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { PropsWithChildren } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import GestureHandlerRootViewContext from '../GestureHandlerRootViewContext';
+import type { PropsWithChildren } from 'react';
 import type { RootViewNativeProps } from '../specs/RNGestureHandlerRootViewNativeComponent';
 
 export interface GestureHandlerRootViewProps

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerRootView.web.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerRootView.web.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { PropsWithChildren } from 'react';
-import { View, ViewProps, StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import GestureHandlerRootViewContext from '../GestureHandlerRootViewContext';
+import type { PropsWithChildren } from 'react';
+import type { ViewProps } from 'react-native';
 
 export interface GestureHandlerRootViewProps
   extends PropsWithChildren<ViewProps> {}

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -1,3 +1,15 @@
+import { INT32_MAX, isTestEnv } from '../../utils';
+import type {
+  Insets,
+  LayoutChangeEvent,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
+import type {
+  LegacyPressableProps,
+  PressableDimensions,
+  PressableEvent,
+} from './PressableProps';
 import React, {
   useCallback,
   useEffect,
@@ -5,37 +17,22 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { GestureObjects as Gesture } from '../../handlers/gestures/gestureObjects';
-import { GestureDetector } from '../../handlers/gestures/GestureDetector';
+import type { RelationPropName, RelationPropType } from '../utils';
+import { StateMachineEvent, getStatesConfig } from './stateDefinitions';
 import {
-  PressableEvent,
-  PressableDimensions,
-  LegacyPressableProps,
-} from './PressableProps';
-import {
-  Insets,
-  LayoutChangeEvent,
-  Platform,
-  StyleProp,
-  ViewStyle,
-} from 'react-native';
-import { ButtonComponent as NativeButton } from '../GestureHandlerButton';
-import {
-  gestureToPressableEvent,
   addInsets,
-  numberAsInset,
+  gestureToPressableEvent,
   gestureTouchToPressableEvent,
   isTouchWithinInset,
+  numberAsInset,
 } from './utils';
+import { GestureObjects as Gesture } from '../../handlers/gestures/gestureObjects';
+import { GestureDetector } from '../../handlers/gestures/GestureDetector';
+import { ButtonComponent as NativeButton } from '../GestureHandlerButton';
+import { Platform } from 'react-native';
 import { PressabilityDebugView } from '../../handlers/PressabilityDebugView';
-import { INT32_MAX, isTestEnv } from '../../utils';
-import {
-  applyRelationProp,
-  RelationPropName,
-  RelationPropType,
-} from '../utils';
-import { getStatesConfig, StateMachineEvent } from './stateDefinitions';
 import { PressableStateMachine } from './StateMachine';
+import { applyRelationProp } from '../utils';
 import { useIsScreenReaderEnabled } from '../../useIsScreenReaderEnabled';
 
 const DEFAULT_LONG_PRESS_DURATION = 500;

--- a/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
@@ -1,15 +1,15 @@
-import {
+import type {
   AccessibilityProps,
-  ViewProps,
   Insets,
-  StyleProp,
-  ViewStyle,
-  PressableStateCallbackType as RNPressableStateCallbackType,
   PressableAndroidRippleConfig as RNPressableAndroidRippleConfig,
+  PressableStateCallbackType as RNPressableStateCallbackType,
+  StyleProp,
   View,
+  ViewProps,
+  ViewStyle,
 } from 'react-native';
-import { RelationPropType } from '../utils';
-import { AnyGesture } from '../../v3/types';
+import type { AnyGesture } from '../../v3/types';
+import type { RelationPropType } from '../utils';
 
 export type PressableDimensions = { width: number; height: number };
 

--- a/packages/react-native-gesture-handler/src/components/Pressable/StateMachine.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/StateMachine.tsx
@@ -1,4 +1,4 @@
-import { PressableEvent } from './PressableProps';
+import type { PressableEvent } from './PressableProps';
 
 export interface StateDefinition {
   eventName: string;

--- a/packages/react-native-gesture-handler/src/components/Pressable/stateDefinitions.ts
+++ b/packages/react-native-gesture-handler/src/components/Pressable/stateDefinitions.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
-import { PressableEvent } from './PressableProps';
-import { StateDefinition } from './StateMachine';
+import type { PressableEvent } from './PressableProps';
+import type { StateDefinition } from './StateMachine';
 
 export enum StateMachineEvent {
   NATIVE_BEGIN = 'nativeBegin',

--- a/packages/react-native-gesture-handler/src/components/Pressable/utils.ts
+++ b/packages/react-native-gesture-handler/src/components/Pressable/utils.ts
@@ -1,20 +1,20 @@
-import { Insets } from 'react-native';
+import type {
+  GestureStateChangeEvent,
+  GestureTouchEvent,
+  TouchData,
+} from '../../handlers/gestureHandlerCommon';
+import type { HoverGestureEvent, LongPressGestureEvent } from '../../v3';
 import type {
   HoverGestureHandlerEventPayload,
   LongPressGestureHandlerEventPayload,
 } from '../../handlers/GestureHandlerEventPayload';
 import type {
-  TouchData,
-  GestureStateChangeEvent,
-  GestureTouchEvent,
-} from '../../handlers/gestureHandlerCommon';
-import type {
-  PressableDimensions,
   InnerPressableEvent,
+  PressableDimensions,
   PressableEvent,
 } from './PressableProps';
-import type { HoverGestureEvent, LongPressGestureEvent } from '../../v3';
 import type { HoverGestureActiveEvent } from '../../v3/hooks';
+import type { Insets } from 'react-native';
 
 const numberAsInset = (value: number): Insets => ({
   left: value,

--- a/packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx
@@ -2,31 +2,13 @@
 // It's cross-compatible with all platforms despite
 // `DrawerLayoutAndroid` only being available on android
 
-import React, {
-  ReactNode,
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useMemo,
-  useState,
-} from 'react';
-
-import {
-  StyleSheet,
-  Keyboard,
-  StatusBar,
-  I18nManager,
-  StatusBarAnimation,
-  StyleProp,
-  ViewStyle,
-  LayoutChangeEvent,
-  Platform,
-} from 'react-native';
-
+import type {
+  ActiveCursor,
+  HitSlop,
+  UserSelect,
+} from '../handlers/gestureHandlerCommon';
 import Animated, {
   Extrapolation,
-  SharedValue,
   interpolate,
   runOnJS,
   useAnimatedProps,
@@ -35,19 +17,33 @@ import Animated, {
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated';
-
 import {
-  UserSelect,
-  ActiveCursor,
-  MouseButton,
-  HitSlop,
-} from '../handlers/gestureHandlerCommon';
-import {
-  PanGestureActiveEvent,
-  usePanGesture,
-  useTapGesture,
-} from '../v3/hooks/gestures';
+  I18nManager,
+  Keyboard,
+  Platform,
+  StatusBar,
+  StyleSheet,
+} from 'react-native';
+import type {
+  LayoutChangeEvent,
+  StatusBarAnimation,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from 'react';
+import { usePanGesture, useTapGesture } from '../v3/hooks/gestures';
 import { GestureDetector } from '../v3/detectors';
+import { MouseButton } from '../handlers/gestureHandlerCommon';
+import type { PanGestureActiveEvent } from '../v3/hooks/gestures';
+import type { ReactNode } from 'react';
+import type { SharedValue } from 'react-native-reanimated';
 
 const DRAG_TOSS = 0.05;
 

--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
@@ -1,27 +1,26 @@
-import { useMemo, useCallback, useImperativeHandle, ForwardedRef } from 'react';
-import { LayoutChangeEvent, View, I18nManager, StyleSheet } from 'react-native';
 import Animated, {
-  useSharedValue,
-  interpolate,
-  runOnJS,
   ReduceMotion,
-  withSpring,
-  useAnimatedRef,
+  interpolate,
   measure,
+  runOnJS,
   runOnUI,
+  useAnimatedRef,
   useAnimatedStyle,
+  useSharedValue,
+  withSpring,
 } from 'react-native-reanimated';
-import {
-  SwipeableProps,
+import { I18nManager, StyleSheet, View } from 'react-native';
+import type {
   SwipeableMethods,
-  SwipeDirection,
+  SwipeableProps,
 } from './ReanimatedSwipeableProps';
-import {
-  PanGestureActiveEvent,
-  usePanGesture,
-  useTapGesture,
-} from '../../v3/hooks/gestures';
+import { useCallback, useImperativeHandle, useMemo } from 'react';
+import { usePanGesture, useTapGesture } from '../../v3/hooks/gestures';
+import type { ForwardedRef } from 'react';
 import { GestureDetector } from '../../v3/detectors';
+import type { LayoutChangeEvent } from 'react-native';
+import type { PanGestureActiveEvent } from '../../v3/hooks/gestures';
+import { SwipeDirection } from './ReanimatedSwipeableProps';
 
 const DRAG_TOSS = 0.05;
 

--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeableProps.ts
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeableProps.ts
@@ -1,8 +1,8 @@
-import React from 'react';
-import { SharedValue } from 'react-native-reanimated';
-import { StyleProp, ViewStyle } from 'react-native';
-import { HitSlop } from '../../handlers/gestureHandlerCommon';
-import { AnyGesture } from '../../v3/types';
+import type { StyleProp, ViewStyle } from 'react-native';
+import type { AnyGesture } from '../../v3/types';
+import type { HitSlop } from '../../handlers/gestureHandlerCommon';
+import type React from 'react';
+import type { SharedValue } from 'react-native-reanimated';
 
 export enum SwipeDirection {
   LEFT = 'left',

--- a/packages/react-native-gesture-handler/src/components/Text.tsx
+++ b/packages/react-native-gesture-handler/src/components/Text.tsx
@@ -1,12 +1,9 @@
-import React, { ComponentRef, Ref, useEffect, useMemo, useRef } from 'react';
-import {
-  Platform,
-  Text as RNText,
-  TextProps as RNTextProps,
-} from 'react-native';
-
+import type { ComponentRef, Ref } from 'react';
+import { Platform, Text as RNText } from 'react-native';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { GestureObjects as Gesture } from '../handlers/gestures/gestureObjects';
 import { GestureDetector } from '../handlers/gestures/GestureDetector';
+import type { TextProps as RNTextProps } from 'react-native';
 
 type TextProps = RNTextProps & {
   ref?: Ref<ComponentRef<typeof RNText> | null>;

--- a/packages/react-native-gesture-handler/src/components/touchables/GenericTouchable.tsx
+++ b/packages/react-native-gesture-handler/src/components/touchables/GenericTouchable.tsx
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import { Component } from 'react';
 import { Animated, Platform } from 'react-native';
-
-import { State } from '../../State';
-import { LegacyBaseButton } from '../GestureButtons';
-
-import {
+import type {
   GestureEvent,
   HandlerStateChangeEvent,
 } from '../../handlers/gestureHandlerCommon';
-import type { NativeViewGestureHandlerPayload } from '../../handlers/GestureHandlerEventPayload';
+import { Component } from 'react';
 import type { GenericTouchableProps } from './GenericTouchableProps';
+import { LegacyBaseButton } from '../GestureButtons';
+import type { NativeViewGestureHandlerPayload } from '../../handlers/GestureHandlerEventPayload';
+import { State } from '../../State';
 
 /**
  * Each touchable is a states' machine which preforms transitions.

--- a/packages/react-native-gesture-handler/src/components/touchables/GenericTouchableProps.ts
+++ b/packages/react-native-gesture-handler/src/components/touchables/GenericTouchableProps.ts
@@ -1,11 +1,11 @@
 import type {
-  StyleProp,
-  ViewStyle,
-  TouchableWithoutFeedbackProps,
   Insets,
+  StyleProp,
+  TouchableWithoutFeedbackProps,
+  ViewStyle,
 } from 'react-native';
+import type { ExtraButtonProps } from './ExtraButtonProps';
 import type { UserSelect } from '../../handlers/gestureHandlerCommon';
-import { ExtraButtonProps } from './ExtraButtonProps';
 
 export interface GenericTouchableProps
   extends Omit<TouchableWithoutFeedbackProps, 'hitSlop'> {

--- a/packages/react-native-gesture-handler/src/components/touchables/TouchableHighlight.tsx
+++ b/packages/react-native-gesture-handler/src/components/touchables/TouchableHighlight.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import { Component } from 'react';
-import GenericTouchable, { TOUCHABLE_STATE } from './GenericTouchable';
-import type { GenericTouchableProps } from './GenericTouchableProps';
-import {
-  StyleSheet,
-  View,
-  TouchableHighlightProps as RNTouchableHighlightProps,
+import type {
   ColorValue,
+  TouchableHighlightProps as RNTouchableHighlightProps,
   ViewProps,
 } from 'react-native';
+import GenericTouchable, { TOUCHABLE_STATE } from './GenericTouchable';
+import { StyleSheet, View } from 'react-native';
+import { Component } from 'react';
+import type { GenericTouchableProps } from './GenericTouchableProps';
 
 interface State {
   extraChildStyle: null | {

--- a/packages/react-native-gesture-handler/src/components/touchables/TouchableNativeFeedback.android.tsx
+++ b/packages/react-native-gesture-handler/src/components/touchables/TouchableNativeFeedback.android.tsx
@@ -1,11 +1,12 @@
-import { Platform, ColorValue } from 'react-native';
 import * as React from 'react';
+import type {
+  TouchableNativeFeedbackExtraProps,
+  TouchableNativeFeedbackProps,
+} from './TouchableNativeFeedbackProps';
+import type { ColorValue } from 'react-native';
 import { Component } from 'react';
 import GenericTouchable from './GenericTouchable';
-import {
-  TouchableNativeFeedbackProps,
-  TouchableNativeFeedbackExtraProps,
-} from './TouchableNativeFeedbackProps';
+import { Platform } from 'react-native';
 
 /**
  * @deprecated TouchableNativeFeedback will be removed in the future version of Gesture Handler. Use Pressable instead.

--- a/packages/react-native-gesture-handler/src/components/touchables/TouchableNativeFeedbackProps.tsx
+++ b/packages/react-native-gesture-handler/src/components/touchables/TouchableNativeFeedbackProps.tsx
@@ -1,6 +1,6 @@
-import type { TouchableNativeFeedbackProps as RNTouchableNativeFeedbackProps } from 'react-native';
+import type { ExtraButtonProps } from './ExtraButtonProps';
 import type { GenericTouchableProps } from './GenericTouchableProps';
-import { ExtraButtonProps } from './ExtraButtonProps';
+import type { TouchableNativeFeedbackProps as RNTouchableNativeFeedbackProps } from 'react-native';
 
 export type TouchableNativeFeedbackExtraProps = ExtraButtonProps;
 /**

--- a/packages/react-native-gesture-handler/src/components/touchables/TouchableOpacity.tsx
+++ b/packages/react-native-gesture-handler/src/components/touchables/TouchableOpacity.tsx
@@ -1,14 +1,9 @@
-import {
-  Animated,
-  Easing,
-  StyleSheet,
-  View,
-  TouchableOpacityProps as RNTouchableOpacityProps,
-} from 'react-native';
-import GenericTouchable, { TOUCHABLE_STATE } from './GenericTouchable';
-import type { GenericTouchableProps } from './GenericTouchableProps';
 import * as React from 'react';
+import { Animated, Easing, StyleSheet, View } from 'react-native';
+import GenericTouchable, { TOUCHABLE_STATE } from './GenericTouchable';
 import { Component } from 'react';
+import type { GenericTouchableProps } from './GenericTouchableProps';
+import type { TouchableOpacityProps as RNTouchableOpacityProps } from 'react-native';
 
 /**
  * @deprecated TouchableOpacity will be removed in the future version of Gesture Handler. Use Pressable instead.

--- a/packages/react-native-gesture-handler/src/components/touchables/TouchableWithoutFeedback.tsx
+++ b/packages/react-native-gesture-handler/src/components/touchables/TouchableWithoutFeedback.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { PropsWithChildren } from 'react';
 import GenericTouchable from './GenericTouchable';
 import type { GenericTouchableProps } from './GenericTouchableProps';
+import type { PropsWithChildren } from 'react';
 
 /**
  * @deprecated TouchableWithoutFeedback will be removed in the future version of Gesture Handler. Use Pressable instead.

--- a/packages/react-native-gesture-handler/src/components/utils.ts
+++ b/packages/react-native-gesture-handler/src/components/utils.ts
@@ -1,4 +1,4 @@
-import { BaseGesture, GestureRef } from '../handlers/gestures/gesture';
+import type { BaseGesture, GestureRef } from '../handlers/gestures/gesture';
 
 export type RelationPropName =
   | 'simultaneousWithExternalGesture'

--- a/packages/react-native-gesture-handler/src/findNodeHandle.web.ts
+++ b/packages/react-native-gesture-handler/src/findNodeHandle.web.ts
@@ -1,5 +1,5 @@
-import { FlatList } from 'react-native';
 import type { GestureHandlerRef, SVGRef } from './web/interfaces';
+import { FlatList } from 'react-native';
 import { isRNSVGElement } from './web/utils';
 
 export default function findNodeHandle(

--- a/packages/react-native-gesture-handler/src/handlers/FlingGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/FlingGestureHandler.ts
@@ -1,9 +1,7 @@
+import type { BaseGestureHandlerProps } from './gestureHandlerCommon';
 import type { FlingGestureHandlerEventPayload } from './GestureHandlerEventPayload';
+import { baseGestureHandlerProps } from './gestureHandlerCommon';
 import createHandler from './createHandler';
-import {
-  BaseGestureHandlerProps,
-  baseGestureHandlerProps,
-} from './gestureHandlerCommon';
 
 export const flingGestureHandlerProps = [
   'numberOfPointers',

--- a/packages/react-native-gesture-handler/src/handlers/ForceTouchGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/ForceTouchGestureHandler.ts
@@ -1,12 +1,11 @@
-import React, { PropsWithChildren } from 'react';
-import { tagMessage } from '../utils';
-import PlatformConstants from '../PlatformConstants';
-import createHandler from './createHandler';
-import {
-  BaseGestureHandlerProps,
-  baseGestureHandlerProps,
-} from './gestureHandlerCommon';
+import type { BaseGestureHandlerProps } from './gestureHandlerCommon';
 import type { ForceTouchGestureHandlerEventPayload } from './GestureHandlerEventPayload';
+import PlatformConstants from '../PlatformConstants';
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+import { baseGestureHandlerProps } from './gestureHandlerCommon';
+import createHandler from './createHandler';
+import { tagMessage } from '../utils';
 
 export const forceTouchGestureHandlerProps = [
   'minForce',

--- a/packages/react-native-gesture-handler/src/handlers/GestureHandlerEventPayload.ts
+++ b/packages/react-native-gesture-handler/src/handlers/GestureHandlerEventPayload.ts
@@ -1,4 +1,4 @@
-import { StylusData } from './gestureHandlerCommon';
+import type { StylusData } from './gestureHandlerCommon';
 
 export type FlingGestureHandlerEventPayload = {
   x: number;

--- a/packages/react-native-gesture-handler/src/handlers/LongPressGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/LongPressGestureHandler.ts
@@ -1,9 +1,7 @@
-import { LongPressGestureHandlerEventPayload } from './GestureHandlerEventPayload';
+import type { BaseGestureHandlerProps } from './gestureHandlerCommon';
+import type { LongPressGestureHandlerEventPayload } from './GestureHandlerEventPayload';
+import { baseGestureHandlerProps } from './gestureHandlerCommon';
 import createHandler from './createHandler';
-import {
-  BaseGestureHandlerProps,
-  baseGestureHandlerProps,
-} from './gestureHandlerCommon';
 
 export const longPressGestureHandlerProps = [
   'minDurationMs',

--- a/packages/react-native-gesture-handler/src/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/NativeViewGestureHandler.ts
@@ -1,9 +1,7 @@
+import type { BaseGestureHandlerProps } from './gestureHandlerCommon';
 import type { NativeViewGestureHandlerPayload } from './GestureHandlerEventPayload';
+import { baseGestureHandlerProps } from './gestureHandlerCommon';
 import createHandler from './createHandler';
-import {
-  BaseGestureHandlerProps,
-  baseGestureHandlerProps,
-} from './gestureHandlerCommon';
 
 export const nativeViewGestureHandlerProps = [
   'shouldActivateOnStart',

--- a/packages/react-native-gesture-handler/src/handlers/PanGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/PanGestureHandler.ts
@@ -1,9 +1,7 @@
+import type { BaseGestureHandlerProps } from './gestureHandlerCommon';
 import type { PanGestureHandlerEventPayload } from './GestureHandlerEventPayload';
+import { baseGestureHandlerProps } from './gestureHandlerCommon';
 import createHandler from './createHandler';
-import {
-  BaseGestureHandlerProps,
-  baseGestureHandlerProps,
-} from './gestureHandlerCommon';
 
 export const panGestureHandlerProps = [
   'activeOffsetY',

--- a/packages/react-native-gesture-handler/src/handlers/PinchGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/PinchGestureHandler.ts
@@ -1,9 +1,7 @@
-import { PinchGestureHandlerEventPayload } from './GestureHandlerEventPayload';
+import type { BaseGestureHandlerProps } from './gestureHandlerCommon';
+import type { PinchGestureHandlerEventPayload } from './GestureHandlerEventPayload';
+import { baseGestureHandlerProps } from './gestureHandlerCommon';
 import createHandler from './createHandler';
-import {
-  BaseGestureHandlerProps,
-  baseGestureHandlerProps,
-} from './gestureHandlerCommon';
 
 /**
  * @deprecated PinchGestureHandler will be removed in the future version of Gesture Handler. Use `Gesture.Pinch()` instead.

--- a/packages/react-native-gesture-handler/src/handlers/RotationGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/RotationGestureHandler.ts
@@ -1,9 +1,7 @@
-import { RotationGestureHandlerEventPayload } from './GestureHandlerEventPayload';
+import type { BaseGestureHandlerProps } from './gestureHandlerCommon';
+import type { RotationGestureHandlerEventPayload } from './GestureHandlerEventPayload';
+import { baseGestureHandlerProps } from './gestureHandlerCommon';
 import createHandler from './createHandler';
-import {
-  BaseGestureHandlerProps,
-  baseGestureHandlerProps,
-} from './gestureHandlerCommon';
 
 /**
  * @deprecated RotationGestureHandler will be removed in the future version of Gesture Handler. Use `Gesture.Rotation()` instead.

--- a/packages/react-native-gesture-handler/src/handlers/TapGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/TapGestureHandler.ts
@@ -1,9 +1,7 @@
+import type { BaseGestureHandlerProps } from './gestureHandlerCommon';
 import type { TapGestureHandlerEventPayload } from './GestureHandlerEventPayload';
+import { baseGestureHandlerProps } from './gestureHandlerCommon';
 import createHandler from './createHandler';
-import {
-  BaseGestureHandlerProps,
-  baseGestureHandlerProps,
-} from './gestureHandlerCommon';
 
 export const tapGestureHandlerProps = [
   'maxDurationMs',

--- a/packages/react-native-gesture-handler/src/handlers/createHandler.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/createHandler.tsx
@@ -1,34 +1,30 @@
 import * as React from 'react';
-import {
-  Platform,
-  DeviceEventEmitter,
-  EmitterSubscription,
-} from 'react-native';
-import { customDirectEventTypes } from './customDirectEventTypes';
-import RNGestureHandlerModule from '../RNGestureHandlerModule';
-import { State } from '../State';
+import type {
+  BaseGestureHandlerProps,
+  GestureEvent,
+  HandlerStateChangeEvent,
+} from './gestureHandlerCommon';
+import { DeviceEventEmitter, Platform } from 'react-native';
+import { deepEqual, isTestEnv, tagMessage } from '../utils';
+import { filterConfig, scheduleFlushOperations } from './utils';
 import {
   handlerIDToTag,
   registerOldGestureHandler,
   unregisterOldGestureHandler,
 } from './handlersRegistry';
-import { getNextHandlerTag } from './getNextHandlerTag';
-
-import {
-  BaseGestureHandlerProps,
-  GestureEvent,
-  HandlerStateChangeEvent,
-} from './gestureHandlerCommon';
-import { filterConfig, scheduleFlushOperations } from './utils';
-import findNodeHandle from '../findNodeHandle';
-import { ValueOf } from '../typeUtils';
-import { deepEqual, isTestEnv, tagMessage } from '../utils';
 import { ActionType } from '../ActionType';
-import { PressabilityDebugView } from './PressabilityDebugView';
+import type { EmitterSubscription } from 'react-native';
 import GestureHandlerRootViewContext from '../GestureHandlerRootViewContext';
-import { ghQueueMicrotask } from '../ghQueueMicrotask';
 import { MountRegistry } from '../mountRegistry';
-import { ReactElement } from 'react';
+import { PressabilityDebugView } from './PressabilityDebugView';
+import RNGestureHandlerModule from '../RNGestureHandlerModule';
+import type { ReactElement } from 'react';
+import { State } from '../State';
+import type { ValueOf } from '../typeUtils';
+import { customDirectEventTypes } from './customDirectEventTypes';
+import findNodeHandle from '../findNodeHandle';
+import { getNextHandlerTag } from './getNextHandlerTag';
+import { ghQueueMicrotask } from '../ghQueueMicrotask';
 
 customDirectEventTypes.topGestureHandlerEvent = {
   registrationName: 'onGestureHandlerEvent',

--- a/packages/react-native-gesture-handler/src/handlers/createNativeWrapper.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/createNativeWrapper.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import { useImperativeHandle, useRef } from 'react';
-
 import {
   NativeViewGestureHandler,
-  NativeViewGestureHandlerProps,
   nativeViewProps,
 } from './NativeViewGestureHandler';
+import { useImperativeHandle, useRef } from 'react';
+import type { NativeViewGestureHandlerProps } from './NativeViewGestureHandler';
 
 /*
  * This array should consist of:

--- a/packages/react-native-gesture-handler/src/handlers/gestureHandlerCommon.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestureHandlerCommon.ts
@@ -2,12 +2,11 @@
 // Without those types, we'd introduce breaking change, forcing users to prefix every handler type specification with typeof
 // e.g. React.createRef<TapGestureHandler> -> React.createRef<typeof TapGestureHandler>.
 // See https://www.typescriptlang.org/docs/handbook/classes.html#constructor-functions for reference.
-import * as React from 'react';
-
-import { State } from '../State';
-import { TouchEventType } from '../TouchEventType';
-import { ValueOf } from '../typeUtils';
-import { PointerType } from '../PointerType';
+import type * as React from 'react';
+import type { PointerType } from '../PointerType';
+import type { State } from '../State';
+import type { TouchEventType } from '../TouchEventType';
+import type { ValueOf } from '../typeUtils';
 
 const commonProps = [
   'id',

--- a/packages/react-native-gesture-handler/src/handlers/gestureHandlerTypesCompat.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestureHandlerTypesCompat.ts
@@ -1,33 +1,33 @@
 import type {
-  LegacyBaseButtonProps,
-  LegacyBorderlessButtonProps,
-  LegacyRawButtonProps,
-  LegacyRectButtonProps,
-} from '../components/GestureButtonsProps';
-import {
+  FlingGestureHandlerEventPayload,
+  ForceTouchGestureHandlerEventPayload,
+  LongPressGestureHandlerEventPayload,
+  NativeViewGestureHandlerPayload,
+  PanGestureHandlerEventPayload,
+  PinchGestureHandlerEventPayload,
+  RotationGestureHandlerEventPayload,
+  TapGestureHandlerEventPayload,
+} from './GestureHandlerEventPayload';
+import type {
   GestureEvent,
   GestureEventPayload,
   HandlerStateChangeEvent,
   HandlerStateChangeEventPayload,
 } from './gestureHandlerCommon';
-import type { FlingGestureHandlerProps } from './FlingGestureHandler';
 import type {
-  FlingGestureHandlerEventPayload,
-  ForceTouchGestureHandlerEventPayload,
-  LongPressGestureHandlerEventPayload,
-  PanGestureHandlerEventPayload,
-  PinchGestureHandlerEventPayload,
-  RotationGestureHandlerEventPayload,
-  TapGestureHandlerEventPayload,
-  NativeViewGestureHandlerPayload,
-} from './GestureHandlerEventPayload';
+  LegacyBaseButtonProps,
+  LegacyBorderlessButtonProps,
+  LegacyRawButtonProps,
+  LegacyRectButtonProps,
+} from '../components/GestureButtonsProps';
+import type { FlingGestureHandlerProps } from './FlingGestureHandler';
 import type { ForceTouchGestureHandlerProps } from './ForceTouchGestureHandler';
 import type { LongPressGestureHandlerProps } from './LongPressGestureHandler';
+import type { NativeViewGestureHandlerProps } from './NativeViewGestureHandler';
 import type { PanGestureHandlerProps } from './PanGestureHandler';
 import type { PinchGestureHandlerProps } from './PinchGestureHandler';
 import type { RotationGestureHandlerProps } from './RotationGestureHandler';
 import type { TapGestureHandlerProps } from './TapGestureHandler';
-import type { NativeViewGestureHandlerProps } from './NativeViewGestureHandler';
 
 // Events
 export type GestureHandlerGestureEventNativeEvent = GestureEventPayload;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/Wrap.web.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/Wrap.web.tsx
@@ -1,7 +1,7 @@
-import React, { forwardRef } from 'react';
 import type { LegacyRef, PropsWithChildren } from 'react';
-import { tagMessage } from '../../../utils';
+import React, { forwardRef } from 'react';
 import { isRNSVGNode } from '../../../web/utils';
+import { tagMessage } from '../../../utils';
 
 export const Wrap = forwardRef<HTMLDivElement, PropsWithChildren<{}>>(
   ({ children }, ref) => {

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/attachHandlers.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/attachHandlers.ts
@@ -1,21 +1,21 @@
-import React from 'react';
-import { GestureType, HandlerCallbacks } from '../gesture';
-import { registerHandler } from '../../handlersRegistry';
-import RNGestureHandlerModule from '../../../RNGestureHandlerModule';
-import { filterConfig, scheduleFlushOperations } from '../../utils';
-import { ComposedGesture } from '../gestureComposition';
-import { ActionType } from '../../../ActionType';
-import { Platform } from 'react-native';
-import type RNGestureHandlerModuleWeb from '../../../RNGestureHandlerModule.web';
-import { ghQueueMicrotask } from '../../../ghQueueMicrotask';
-import { AttachedGestureState } from './types';
 import {
-  extractGestureRelations,
-  checkGestureCallbacksForWorklets,
   ALLOWED_PROPS,
+  checkGestureCallbacksForWorklets,
+  extractGestureRelations,
 } from './utils';
+import type { GestureType, HandlerCallbacks } from '../gesture';
+import { filterConfig, scheduleFlushOperations } from '../../utils';
+import { ActionType } from '../../../ActionType';
+import type { AttachedGestureState } from './types';
+import type { ComposedGesture } from '../gestureComposition';
 import { MountRegistry } from '../../../mountRegistry';
-import { PropsRef } from '../../../web/interfaces';
+import { Platform } from 'react-native';
+import type { PropsRef } from '../../../web/interfaces';
+import RNGestureHandlerModule from '../../../RNGestureHandlerModule';
+import type RNGestureHandlerModuleWeb from '../../../RNGestureHandlerModule.web';
+import type React from 'react';
+import { ghQueueMicrotask } from '../../../ghQueueMicrotask';
+import { registerHandler } from '../../handlersRegistry';
 
 interface AttachHandlersConfig {
   preparedGesture: AttachedGestureState;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/dropHandlers.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/dropHandlers.ts
@@ -1,8 +1,8 @@
-import { unregisterHandler } from '../../handlersRegistry';
+import type { AttachedGestureState } from './types';
+import { MountRegistry } from '../../../mountRegistry';
 import RNGestureHandlerModule from '../../../RNGestureHandlerModule';
 import { scheduleFlushOperations } from '../../utils';
-import { AttachedGestureState } from './types';
-import { MountRegistry } from '../../../mountRegistry';
+import { unregisterHandler } from '../../handlersRegistry';
 
 export function dropHandlers(preparedGesture: AttachedGestureState) {
   for (const handler of preparedGesture.attachedGestures) {

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/index.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/index.tsx
@@ -1,20 +1,20 @@
 /* eslint-disable react/no-unused-prop-types */
+import { AnimatedWrap, Wrap } from './Wrap';
+import type { AttachedGestureState, GestureDetectorState } from './types';
 import React, { useEffect, useMemo, useRef } from 'react';
-import findNodeHandle from '../../../findNodeHandle';
-import { GestureType } from '../gesture';
-import { UserSelect, TouchAction } from '../../gestureHandlerCommon';
-import { ComposedGesture } from '../gestureComposition';
-import { AttachedGestureState, GestureDetectorState } from './types';
-import { useAnimatedGesture } from './useAnimatedGesture';
+import type { TouchAction, UserSelect } from '../../gestureHandlerCommon';
+import type { ComposedGesture } from '../gestureComposition';
+import type { GestureType } from '../gesture';
 import { attachHandlers } from './attachHandlers';
-import { needsToReattach } from './needsToReattach';
 import { dropHandlers } from './dropHandlers';
-import { useWebEventHandlers } from './utils';
-import { Wrap, AnimatedWrap } from './Wrap';
+import findNodeHandle from '../../../findNodeHandle';
+import { needsToReattach } from './needsToReattach';
+import { useAnimatedGesture } from './useAnimatedGesture';
 import { useDetectorUpdater } from './useDetectorUpdater';
-import { useViewRefHandler } from './useViewRefHandler';
-import { useMountReactions } from './useMountReactions';
 import { useIsomorphicLayoutEffect } from '../../../useIsomorphicLayoutEffect';
+import { useMountReactions } from './useMountReactions';
+import { useViewRefHandler } from './useViewRefHandler';
+import { useWebEventHandlers } from './utils';
 
 function propagateDetectorConfig(
   props: GestureDetectorProps,

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/needsToReattach.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/needsToReattach.ts
@@ -1,5 +1,5 @@
-import { GestureType } from '../gesture';
-import { AttachedGestureState } from './types';
+import type { AttachedGestureState } from './types';
+import type { GestureType } from '../gesture';
 
 // Checks whether the gesture should be reattached to the view, this will happen when:
 // - The number of gestures in the preparedGesture is different than the number of gestures in the gesture

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/types.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/types.ts
@@ -1,5 +1,5 @@
-import { SharedValue } from '../../../v3/types';
-import { GestureType, HandlerCallbacks } from '../gesture';
+import type { GestureType, HandlerCallbacks } from '../gesture';
+import type { SharedValue } from '../../../v3/types';
 
 export interface AttachedGestureState {
   // Array of gestures that should be attached to the view under that gesture detector

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/updateHandlers.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/updateHandlers.ts
@@ -1,15 +1,15 @@
-import { GestureType, HandlerCallbacks } from '../gesture';
-import { registerHandler } from '../../handlersRegistry';
-import RNGestureHandlerModule from '../../../RNGestureHandlerModule';
-import { filterConfig, scheduleFlushOperations } from '../../utils';
-import { ComposedGesture } from '../gestureComposition';
-import { ghQueueMicrotask } from '../../../ghQueueMicrotask';
-import { AttachedGestureState } from './types';
 import {
-  extractGestureRelations,
-  checkGestureCallbacksForWorklets,
   ALLOWED_PROPS,
+  checkGestureCallbacksForWorklets,
+  extractGestureRelations,
 } from './utils';
+import type { GestureType, HandlerCallbacks } from '../gesture';
+import { filterConfig, scheduleFlushOperations } from '../../utils';
+import type { AttachedGestureState } from './types';
+import type { ComposedGesture } from '../gestureComposition';
+import RNGestureHandlerModule from '../../../RNGestureHandlerModule';
+import { ghQueueMicrotask } from '../../../ghQueueMicrotask';
+import { registerHandler } from '../../handlersRegistry';
 
 export function updateHandlers(
   preparedGesture: AttachedGestureState,

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useAnimatedGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useAnimatedGesture.ts
@@ -1,18 +1,17 @@
-import { HandlerCallbacks, CALLBACK_TYPE } from '../gesture';
-import { Reanimated } from '../reanimatedWrapper';
-import {
+import type {
+  GestureStateChangeEvent,
   GestureTouchEvent,
   GestureUpdateEvent,
-  GestureStateChangeEvent,
 } from '../../gestureHandlerCommon';
-import {
-  GestureStateManager,
-  GestureStateManagerType,
-} from '../gestureStateManager';
+import type { AttachedGestureState } from './types';
+import { CALLBACK_TYPE } from '../gesture';
+import { GestureStateManager } from '../gestureStateManager';
+import type { GestureStateManagerType } from '../gestureStateManager';
+import type { HandlerCallbacks } from '../gesture';
+import { Reanimated } from '../reanimatedWrapper';
 import { State } from '../../../State';
 import { TouchEventType } from '../../../TouchEventType';
 import { tagMessage } from '../../../utils';
-import { AttachedGestureState } from './types';
 
 function getHandler(
   type: CALLBACK_TYPE,

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useDetectorUpdater.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useDetectorUpdater.ts
@@ -1,15 +1,15 @@
-import React, { useCallback } from 'react';
-import { GestureType } from '../gesture';
-import { ComposedGesture } from '../gestureComposition';
-
-import { AttachedGestureState, GestureDetectorState } from './types';
-import { attachHandlers } from './attachHandlers';
-import { updateHandlers } from './updateHandlers';
-import { needsToReattach } from './needsToReattach';
-import { dropHandlers } from './dropHandlers';
+import type { AttachedGestureState, GestureDetectorState } from './types';
 import { useForceRender, validateDetectorChildren } from './utils';
+import type { ComposedGesture } from '../gestureComposition';
+import type { GestureType } from '../gesture';
+import type { PropsRef } from '../../../web/interfaces';
+import type React from 'react';
+import { attachHandlers } from './attachHandlers';
+import { dropHandlers } from './dropHandlers';
 import findNodeHandle from '../../../findNodeHandle';
-import { PropsRef } from '../../../web/interfaces';
+import { needsToReattach } from './needsToReattach';
+import { updateHandlers } from './updateHandlers';
+import { useCallback } from 'react';
 
 // Returns a function that's responsible for updating the attached gestures
 // If the view has changed, it will reattach the handlers to the new view

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useMountReactions.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useMountReactions.ts
@@ -1,8 +1,8 @@
-import { transformIntoHandlerTags } from '../../utils';
+import type { AttachedGestureState } from './types';
+import type { GestureRef } from '../gesture';
 import { MountRegistry } from '../../../mountRegistry';
-import { AttachedGestureState } from './types';
+import { transformIntoHandlerTags } from '../../utils';
 import { useEffect } from 'react';
-import { GestureRef } from '../gesture';
 
 function shouldUpdateDetector(
   relation: GestureRef[] | undefined,

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useViewRefHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useViewRefHandler.ts
@@ -1,9 +1,9 @@
-import { tagMessage } from '../../../utils';
-import { getShadowNodeFromRef } from '../../../getShadowNodeFromRef';
-
-import { GestureDetectorState } from './types';
-import React, { useCallback } from 'react';
+import type { GestureDetectorState } from './types';
+import type React from 'react';
 import findNodeHandle from '../../../findNodeHandle';
+import { getShadowNodeFromRef } from '../../../getShadowNodeFromRef';
+import { tagMessage } from '../../../utils';
+import { useCallback } from 'react';
 
 declare const global: {
   _isViewFlatteningDisabled: (node: unknown) => boolean | null; // JSI function

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/utils.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/utils.ts
@@ -1,28 +1,27 @@
-import { Platform } from 'react-native';
-
-import { isTestEnv, tagMessage } from '../../../utils';
-import { GestureRef, BaseGesture, GestureType } from '../gesture';
-
-import { flingGestureHandlerProps } from '../../FlingGestureHandler';
-import { forceTouchGestureHandlerProps } from '../../ForceTouchGestureHandler';
-import { longPressGestureHandlerProps } from '../../LongPressGestureHandler';
-import {
-  panGestureHandlerProps,
-  panGestureHandlerCustomNativeProps,
-} from '../../PanGestureHandler';
-import { tapGestureHandlerProps } from '../../TapGestureHandler';
-import { hoverGestureHandlerProps } from '../hoverGesture';
-import { nativeViewGestureHandlerProps } from '../../NativeViewGestureHandler';
-import { baseGestureHandlerWithDetectorProps } from '../../gestureHandlerCommon';
-import { RNRenderer } from '../../../RNRenderer';
-import { useCallback, useRef, useState } from 'react';
-import { Reanimated } from '../reanimatedWrapper';
-import { onGestureHandlerEvent } from '../eventReceiver';
-import {
+import type {
   GestureHandlerNativeEvent,
   PropsRef,
   ResultEvent,
 } from '../../../web/interfaces';
+import type { GestureRef, GestureType } from '../gesture';
+import { isTestEnv, tagMessage } from '../../../utils';
+import {
+  panGestureHandlerCustomNativeProps,
+  panGestureHandlerProps,
+} from '../../PanGestureHandler';
+import { useCallback, useRef, useState } from 'react';
+import { BaseGesture } from '../gesture';
+import { Platform } from 'react-native';
+import { RNRenderer } from '../../../RNRenderer';
+import { Reanimated } from '../reanimatedWrapper';
+import { baseGestureHandlerWithDetectorProps } from '../../gestureHandlerCommon';
+import { flingGestureHandlerProps } from '../../FlingGestureHandler';
+import { forceTouchGestureHandlerProps } from '../../ForceTouchGestureHandler';
+import { hoverGestureHandlerProps } from '../hoverGesture';
+import { longPressGestureHandlerProps } from '../../LongPressGestureHandler';
+import { nativeViewGestureHandlerProps } from '../../NativeViewGestureHandler';
+import { onGestureHandlerEvent } from '../eventReceiver';
+import { tapGestureHandlerProps } from '../../TapGestureHandler';
 
 export const ALLOWED_PROPS = [
   ...baseGestureHandlerWithDetectorProps,

--- a/packages/react-native-gesture-handler/src/handlers/gestures/eventReceiver.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/eventReceiver.ts
@@ -1,17 +1,16 @@
-import { DeviceEventEmitter, EmitterSubscription } from 'react-native';
-import { State } from '../../State';
-import { TouchEventType } from '../../TouchEventType';
-import {
+import type {
+  GestureStateChangeEvent,
   GestureTouchEvent,
   GestureUpdateEvent,
-  GestureStateChangeEvent,
 } from '../gestureHandlerCommon';
 import { findHandler, findOldGestureHandler } from '../handlersRegistry';
-import { BaseGesture } from './gesture';
-import {
-  GestureStateManager,
-  GestureStateManagerType,
-} from './gestureStateManager';
+import type { BaseGesture } from './gesture';
+import { DeviceEventEmitter } from 'react-native';
+import type { EmitterSubscription } from 'react-native';
+import { GestureStateManager } from './gestureStateManager';
+import type { GestureStateManagerType } from './gestureStateManager';
+import { State } from '../../State';
+import { TouchEventType } from '../../TouchEventType';
 
 let gestureHandlerEventSubscription: EmitterSubscription | null = null;
 let gestureHandlerStateChangeEventSubscription: EmitterSubscription | null =

--- a/packages/react-native-gesture-handler/src/handlers/gestures/flingGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/flingGesture.ts
@@ -1,5 +1,6 @@
-import { BaseGesture, BaseGestureConfig } from './gesture';
-import { FlingGestureConfig } from '../FlingGestureHandler';
+import { BaseGesture } from './gesture';
+import type { BaseGestureConfig } from './gesture';
+import type { FlingGestureConfig } from '../FlingGestureHandler';
 import type { FlingGestureHandlerEventPayload } from '../GestureHandlerEventPayload';
 
 export class FlingGesture extends BaseGesture<FlingGestureHandlerEventPayload> {

--- a/packages/react-native-gesture-handler/src/handlers/gestures/forceTouchGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/forceTouchGesture.ts
@@ -1,7 +1,8 @@
-import { BaseGestureConfig, ContinousBaseGesture } from './gesture';
-import { ForceTouchGestureConfig } from '../ForceTouchGestureHandler';
+import type { BaseGestureConfig } from './gesture';
+import { ContinousBaseGesture } from './gesture';
+import type { ForceTouchGestureConfig } from '../ForceTouchGestureHandler';
 import type { ForceTouchGestureHandlerEventPayload } from '../GestureHandlerEventPayload';
-import { GestureUpdateEvent } from '../gestureHandlerCommon';
+import type { GestureUpdateEvent } from '../gestureHandlerCommon';
 
 /**
  * @deprecated ForceTouch gesture is deprecated and will be removed in the future.

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
@@ -1,25 +1,25 @@
-import {
-  HitSlop,
-  CommonGestureConfig,
-  GestureTouchEvent,
-  GestureStateChangeEvent,
-  GestureUpdateEvent,
+import type {
   ActiveCursor,
+  CommonGestureConfig,
+  GestureStateChangeEvent,
+  GestureTouchEvent,
+  GestureUpdateEvent,
+  HitSlop,
   MouseButton,
 } from '../gestureHandlerCommon';
-import { getNextHandlerTag } from '../getNextHandlerTag';
-import { GestureStateManagerType } from './gestureStateManager';
 import type {
   FlingGestureHandlerEventPayload,
   ForceTouchGestureHandlerEventPayload,
+  HoverGestureHandlerEventPayload,
   LongPressGestureHandlerEventPayload,
+  NativeViewGestureHandlerPayload,
   PanGestureHandlerEventPayload,
   PinchGestureHandlerEventPayload,
   RotationGestureHandlerEventPayload,
   TapGestureHandlerEventPayload,
-  NativeViewGestureHandlerPayload,
-  HoverGestureHandlerEventPayload,
 } from '../GestureHandlerEventPayload';
+import type { GestureStateManagerType } from './gestureStateManager';
+import { getNextHandlerTag } from '../getNextHandlerTag';
 import { isRemoteDebuggingEnabled } from '../../utils';
 
 export type GestureType =

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureComposition.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureComposition.ts
@@ -1,4 +1,5 @@
-import { BaseGesture, Gesture, GestureRef, GestureType } from './gesture';
+import { BaseGesture, Gesture } from './gesture';
+import type { GestureRef, GestureType } from './gesture';
 
 function extendRelation(
   currentRelation: GestureRef[] | undefined,

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureObjects.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureObjects.ts
@@ -1,19 +1,19 @@
-import { FlingGesture } from './flingGesture';
-import { ForceTouchGesture } from './forceTouchGesture';
-import { Gesture } from './gesture';
 import {
   ComposedGesture,
   ExclusiveGesture,
   SimultaneousGesture,
 } from './gestureComposition';
+import { FlingGesture } from './flingGesture';
+import { ForceTouchGesture } from './forceTouchGesture';
+import type { Gesture } from './gesture';
+import { HoverGesture } from './hoverGesture';
 import { LongPressGesture } from './longPressGesture';
+import { ManualGesture } from './manualGesture';
+import { NativeGesture } from './nativeGesture';
 import { PanGesture } from './panGesture';
 import { PinchGesture } from './pinchGesture';
 import { RotationGesture } from './rotationGesture';
 import { TapGesture } from './tapGesture';
-import { NativeGesture } from './nativeGesture';
-import { ManualGesture } from './manualGesture';
-import { HoverGesture } from './hoverGesture';
 
 /**
  * `Gesture` is the object that allows you to create and compose gestures.

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureStateManager.web.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureStateManager.web.ts
@@ -1,6 +1,6 @@
-import { State } from '../../State';
+import type { GestureStateManagerType } from './gestureStateManager';
 import NodeManager from '../../web/tools/NodeManager';
-import { GestureStateManagerType } from './gestureStateManager';
+import { State } from '../../State';
 
 export const GestureStateManager = {
   create(handlerTag: number): GestureStateManagerType {

--- a/packages/react-native-gesture-handler/src/handlers/gestures/hoverGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/hoverGesture.ts
@@ -1,5 +1,6 @@
-import { BaseGestureConfig, ContinousBaseGesture } from './gesture';
-import { GestureUpdateEvent } from '../gestureHandlerCommon';
+import type { BaseGestureConfig } from './gesture';
+import { ContinousBaseGesture } from './gesture';
+import type { GestureUpdateEvent } from '../gestureHandlerCommon';
 import type { HoverGestureHandlerEventPayload } from '../GestureHandlerEventPayload';
 
 export type HoverGestureChangeEventPayload = {

--- a/packages/react-native-gesture-handler/src/handlers/gestures/longPressGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/longPressGesture.ts
@@ -1,5 +1,6 @@
-import { BaseGesture, BaseGestureConfig } from './gesture';
-import { LongPressGestureConfig } from '../LongPressGestureHandler';
+import { BaseGesture } from './gesture';
+import type { BaseGestureConfig } from './gesture';
+import type { LongPressGestureConfig } from '../LongPressGestureHandler';
 import type { LongPressGestureHandlerEventPayload } from '../GestureHandlerEventPayload';
 
 export class LongPressGesture extends BaseGesture<LongPressGestureHandlerEventPayload> {

--- a/packages/react-native-gesture-handler/src/handlers/gestures/manualGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/manualGesture.ts
@@ -1,5 +1,5 @@
-import { GestureUpdateEvent } from '../gestureHandlerCommon';
 import { ContinousBaseGesture } from './gesture';
+import type { GestureUpdateEvent } from '../gestureHandlerCommon';
 
 function changeEventCalculator(
   current: GestureUpdateEvent<Record<string, never>>,

--- a/packages/react-native-gesture-handler/src/handlers/gestures/nativeGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/nativeGesture.ts
@@ -1,5 +1,6 @@
-import { BaseGestureConfig, BaseGesture } from './gesture';
-import { NativeViewGestureConfig } from '../NativeViewGestureHandler';
+import { BaseGesture } from './gesture';
+import type { BaseGestureConfig } from './gesture';
+import type { NativeViewGestureConfig } from '../NativeViewGestureHandler';
 import type { NativeViewGestureHandlerPayload } from '../GestureHandlerEventPayload';
 
 export class NativeGesture extends BaseGesture<NativeViewGestureHandlerPayload> {

--- a/packages/react-native-gesture-handler/src/handlers/gestures/panGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/panGesture.ts
@@ -1,6 +1,7 @@
-import { BaseGestureConfig, ContinousBaseGesture } from './gesture';
-import { GestureUpdateEvent } from '../gestureHandlerCommon';
-import { PanGestureConfig } from '../PanGestureHandler';
+import type { BaseGestureConfig } from './gesture';
+import { ContinousBaseGesture } from './gesture';
+import type { GestureUpdateEvent } from '../gestureHandlerCommon';
+import type { PanGestureConfig } from '../PanGestureHandler';
 import type { PanGestureHandlerEventPayload } from '../GestureHandlerEventPayload';
 
 export type PanGestureChangeEventPayload = {

--- a/packages/react-native-gesture-handler/src/handlers/gestures/pinchGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/pinchGesture.ts
@@ -1,6 +1,6 @@
 import { ContinousBaseGesture } from './gesture';
+import type { GestureUpdateEvent } from '../gestureHandlerCommon';
 import type { PinchGestureHandlerEventPayload } from '../GestureHandlerEventPayload';
-import { GestureUpdateEvent } from '../gestureHandlerCommon';
 
 export type PinchGestureChangeEventPayload = {
   scaleChange: number;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/reanimatedWrapper.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/reanimatedWrapper.ts
@@ -1,11 +1,11 @@
-import { ComponentClass } from 'react';
-import { tagMessage } from '../../utils';
-import {
+import type {
   GestureCallbacks,
   GestureUpdateEventWithHandlerData,
   SharedValue,
 } from '../../v3/types';
+import type { ComponentClass } from 'react';
 import { NativeProxy } from '../../v3/NativeProxy';
+import { tagMessage } from '../../utils';
 
 export type ReanimatedContext<THandlerData> = {
   lastUpdateEvent: GestureUpdateEventWithHandlerData<THandlerData> | undefined;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/rotationGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/rotationGesture.ts
@@ -1,6 +1,6 @@
 import { ContinousBaseGesture } from './gesture';
+import type { GestureUpdateEvent } from '../gestureHandlerCommon';
 import type { RotationGestureHandlerEventPayload } from '../GestureHandlerEventPayload';
-import { GestureUpdateEvent } from '../gestureHandlerCommon';
 
 type RotationGestureChangeEventPayload = {
   rotationChange: number;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/tapGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/tapGesture.ts
@@ -1,5 +1,6 @@
-import { BaseGestureConfig, BaseGesture } from './gesture';
-import { TapGestureConfig } from '../TapGestureHandler';
+import { BaseGesture } from './gesture';
+import type { BaseGestureConfig } from './gesture';
+import type { TapGestureConfig } from '../TapGestureHandler';
 import type { TapGestureHandlerEventPayload } from '../GestureHandlerEventPayload';
 
 export class TapGesture extends BaseGesture<TapGestureHandlerEventPayload> {

--- a/packages/react-native-gesture-handler/src/handlers/handlersRegistry.ts
+++ b/packages/react-native-gesture-handler/src/handlers/handlersRegistry.ts
@@ -1,7 +1,10 @@
+import type {
+  GestureEvent,
+  HandlerStateChangeEvent,
+} from './gestureHandlerCommon';
+import type { GestureType } from './gestures/gesture';
+import type { SingleGesture } from '../v3/types';
 import { isTestEnv } from '../utils';
-import { GestureType } from './gestures/gesture';
-import { GestureEvent, HandlerStateChangeEvent } from './gestureHandlerCommon';
-import { SingleGesture } from '../v3/types';
 
 export const handlerIDToTag: Record<string, number> = {};
 

--- a/packages/react-native-gesture-handler/src/handlers/utils.ts
+++ b/packages/react-native-gesture-handler/src/handlers/utils.ts
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import type * as React from 'react';
 import { Platform, findNodeHandle as findNodeHandleRN } from 'react-native';
-import { handlerIDToTag } from './handlersRegistry';
-import { toArray } from '../utils';
 import RNGestureHandlerModule from '../RNGestureHandlerModule';
 import { ghQueueMicrotask } from '../ghQueueMicrotask';
+import { handlerIDToTag } from './handlersRegistry';
+import { toArray } from '../utils';
 
 function isConfigParam(param: unknown, name: string) {
   // param !== Object(param) returns false if `param` is a function

--- a/packages/react-native-gesture-handler/src/jestUtils/jestUtils.ts
+++ b/packages/react-native-gesture-handler/src/jestUtils/jestUtils.ts
@@ -1,33 +1,8 @@
-import invariant from 'invariant';
-import { DeviceEventEmitter } from 'react-native';
-import { ReactTestInstance } from 'react-test-renderer';
-import {
-  FlingGestureHandler,
-  flingHandlerName,
-} from '../handlers/FlingGestureHandler';
-import {
-  ForceTouchGestureHandler,
-  forceTouchHandlerName,
-} from '../handlers/ForceTouchGestureHandler';
-import {
+import type {
   BaseGestureHandlerProps,
   GestureEvent,
   HandlerStateChangeEvent,
 } from '../handlers/gestureHandlerCommon';
-import { FlingGesture } from '../handlers/gestures/flingGesture';
-import { ForceTouchGesture } from '../handlers/gestures/forceTouchGesture';
-import { BaseGesture, GestureType } from '../handlers/gestures/gesture';
-import { LongPressGesture } from '../handlers/gestures/longPressGesture';
-import { NativeGesture } from '../handlers/gestures/nativeGesture';
-import { PanGesture } from '../handlers/gestures/panGesture';
-import { PinchGesture } from '../handlers/gestures/pinchGesture';
-import { RotationGesture } from '../handlers/gestures/rotationGesture';
-import { TapGesture } from '../handlers/gestures/tapGesture';
-import { findHandlerByTestID } from '../handlers/handlersRegistry';
-import {
-  LongPressGestureHandler,
-  longPressHandlerName,
-} from '../handlers/LongPressGestureHandler';
 import type {
   FlingGestureHandlerEventPayload,
   ForceTouchGestureHandlerEventPayload,
@@ -38,30 +13,40 @@ import type {
   RotationGestureHandlerEventPayload,
   TapGestureHandlerEventPayload,
 } from '../handlers/GestureHandlerEventPayload';
-import {
-  NativeViewGestureHandler,
-  nativeViewHandlerName,
-} from '../handlers/NativeViewGestureHandler';
-import {
-  PanGestureHandler,
-  panHandlerName,
-} from '../handlers/PanGestureHandler';
-import {
-  PinchGestureHandler,
-  pinchHandlerName,
-} from '../handlers/PinchGestureHandler';
-import {
-  RotationGestureHandler,
-  rotationHandlerName,
-} from '../handlers/RotationGestureHandler';
-import {
-  TapGestureHandler,
-  tapHandlerName,
-} from '../handlers/TapGestureHandler';
-import { State } from '../State';
 import { hasProperty, withPrevAndCurrent } from '../utils';
+import { BaseGesture } from '../handlers/gestures/gesture';
+import { DeviceEventEmitter } from 'react-native';
+import type { FlingGesture } from '../handlers/gestures/flingGesture';
+import type { FlingGestureHandler } from '../handlers/FlingGestureHandler';
+import type { ForceTouchGesture } from '../handlers/gestures/forceTouchGesture';
+import type { ForceTouchGestureHandler } from '../handlers/ForceTouchGestureHandler';
+import type { GestureType } from '../handlers/gestures/gesture';
+import type { LongPressGesture } from '../handlers/gestures/longPressGesture';
+import type { LongPressGestureHandler } from '../handlers/LongPressGestureHandler';
+import type { NativeGesture } from '../handlers/gestures/nativeGesture';
+import type { NativeViewGestureHandler } from '../handlers/NativeViewGestureHandler';
+import type { PanGesture } from '../handlers/gestures/panGesture';
+import type { PanGestureHandler } from '../handlers/PanGestureHandler';
+import type { PinchGesture } from '../handlers/gestures/pinchGesture';
+import type { PinchGestureHandler } from '../handlers/PinchGestureHandler';
+import type { ReactTestInstance } from 'react-test-renderer';
+import type { RotationGesture } from '../handlers/gestures/rotationGesture';
+import type { RotationGestureHandler } from '../handlers/RotationGestureHandler';
 import type { SingleGesture } from '../v3/types';
+import { State } from '../State';
+import type { TapGesture } from '../handlers/gestures/tapGesture';
+import type { TapGestureHandler } from '../handlers/TapGestureHandler';
+import { findHandlerByTestID } from '../handlers/handlersRegistry';
+import { flingHandlerName } from '../handlers/FlingGestureHandler';
+import { forceTouchHandlerName } from '../handlers/ForceTouchGestureHandler';
+import invariant from 'invariant';
+import { longPressHandlerName } from '../handlers/LongPressGestureHandler';
 import { maybeUnpackValue } from '../v3/hooks/utils';
+import { nativeViewHandlerName } from '../handlers/NativeViewGestureHandler';
+import { panHandlerName } from '../handlers/PanGestureHandler';
+import { pinchHandlerName } from '../handlers/PinchGestureHandler';
+import { rotationHandlerName } from '../handlers/RotationGestureHandler';
+import { tapHandlerName } from '../handlers/TapGestureHandler';
 
 // Load fireEvent conditionally, so RNGH may be used in setups without testing-library
 let fireEvent = (

--- a/packages/react-native-gesture-handler/src/mocks/GestureButtons.tsx
+++ b/packages/react-native-gesture-handler/src/mocks/GestureButtons.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { TouchableNativeFeedback, View } from 'react-native';
+import React from 'react';
 
 const RawButton = ({ enabled, children, ...rest }: any) => (
   <TouchableNativeFeedback disabled={enabled === false} {...rest}>

--- a/packages/react-native-gesture-handler/src/mountRegistry.ts
+++ b/packages/react-native-gesture-handler/src/mountRegistry.ts
@@ -1,4 +1,4 @@
-import { GestureType } from './handlers/gestures/gesture';
+import type { GestureType } from './handlers/gestures/gesture';
 
 interface ReactComponentWithHandlerTag extends React.Component {
   handlerTag: number;

--- a/packages/react-native-gesture-handler/src/specs/NativeRNGestureHandlerModule.ts
+++ b/packages/react-native-gesture-handler/src/specs/NativeRNGestureHandlerModule.ts
@@ -1,5 +1,6 @@
-import { TurboModuleRegistry, TurboModule } from 'react-native';
-import { Double } from 'react-native/Libraries/Types/CodegenTypes';
+import type { Double } from 'react-native/Libraries/Types/CodegenTypes';
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
   // This method returns a boolean only to force the codegen to generate

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
@@ -1,10 +1,10 @@
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import type { ColorValue, ViewProps } from 'react-native';
 import type {
+  Float,
   Int32,
   WithDefault,
-  Float,
 } from 'react-native/Libraries/Types/CodegenTypes';
-import type { ViewProps, ColorValue } from 'react-native';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 // @ts-ignore - Redefining pointerEvents with WithDefault for codegen, conflicts with ViewProps type but codegen needs it
 interface NativeProps extends ViewProps {

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerDetectorNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerDetectorNativeComponent.ts
@@ -1,12 +1,12 @@
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type {
-  Int32,
   DirectEventHandler,
-  UnsafeMixed,
   Double,
+  Int32,
+  UnsafeMixed,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
 import type { ViewProps } from 'react-native';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 type GestureHandlerEvent = Readonly<{
   handlerTag: Int32;

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerRootViewNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerRootViewNativeComponent.ts
@@ -1,6 +1,6 @@
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
 import type { ViewProps } from 'react-native';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 // Publicly accessible type, moduleId is set internally
 export interface RootViewNativeProps extends ViewProps {

--- a/packages/react-native-gesture-handler/src/v3/NativeProxy.ts
+++ b/packages/react-native-gesture-handler/src/v3/NativeProxy.ts
@@ -1,10 +1,10 @@
-import { scheduleOperationToBeFlushed } from '../handlers/utils';
-import RNGestureHandlerModule from '../RNGestureHandlerModule';
-import {
+import type {
   BaseGestureConfig,
   GestureRelations,
   SingleGestureName,
 } from './types';
+import RNGestureHandlerModule from '../RNGestureHandlerModule';
+import { scheduleOperationToBeFlushed } from '../handlers/utils';
 
 // Destructure functions that can be called on the UI thread to have
 // a raw HostFunction reference

--- a/packages/react-native-gesture-handler/src/v3/NativeProxy.web.ts
+++ b/packages/react-native-gesture-handler/src/v3/NativeProxy.web.ts
@@ -1,9 +1,9 @@
-import RNGestureHandlerModule from '../RNGestureHandlerModule';
-import {
+import type {
   BaseGestureConfig,
   GestureRelations,
   SingleGestureName,
 } from './types';
+import RNGestureHandlerModule from '../RNGestureHandlerModule';
 
 export const NativeProxy = {
   createGestureHandler: <T extends Record<string, unknown>>(

--- a/packages/react-native-gesture-handler/src/v3/components/GestureButtons.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/GestureButtons.tsx
@@ -1,16 +1,15 @@
-import React, { useRef } from 'react';
-import { Platform, StyleSheet, Animated } from 'react-native';
-import createNativeWrapper from '../createNativeWrapper';
-import GestureHandlerButton from '../../components/GestureHandlerButton';
+import { Animated, Platform, StyleSheet } from 'react-native';
 import type {
   BaseButtonProps,
   BorderlessButtonProps,
   RawButtonProps,
   RectButtonProps,
 } from './GestureButtonsProps';
-
+import React, { useRef } from 'react';
 import type { GestureEvent } from '../types';
+import GestureHandlerButton from '../../components/GestureHandlerButton';
 import type { NativeHandlerData } from '../hooks/gestures/native/NativeTypes';
+import createNativeWrapper from '../createNativeWrapper';
 
 type CallbackEventType = GestureEvent<NativeHandlerData>;
 

--- a/packages/react-native-gesture-handler/src/v3/components/GestureButtonsProps.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/GestureButtonsProps.ts
@@ -1,8 +1,7 @@
-import { StyleProp, ViewStyle } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+import type { ButtonProps } from '../../components/GestureHandlerButton';
+import type GestureHandlerButton from '../../components/GestureHandlerButton';
 import type { NativeWrapperProperties } from '../types/NativeWrapperType';
-import GestureHandlerButton, {
-  ButtonProps,
-} from '../../components/GestureHandlerButton';
 
 /**
  * @deprecated `RawButtonProps` is deprecated, use `ClickableProps` instead

--- a/packages/react-native-gesture-handler/src/v3/components/GestureComponents.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/GestureComponents.tsx
@@ -1,23 +1,24 @@
-import React, { PropsWithChildren, ReactElement, useState } from 'react';
+import type { PropsWithChildren, ReactElement } from 'react';
 import {
-  ScrollView as RNScrollView,
-  ScrollViewProps as RNScrollViewProps,
-  Switch as RNSwitch,
-  SwitchProps as RNSwitchProps,
-  TextInput as RNTextInput,
-  TextInputProps as RNTextInputProps,
   FlatList as RNFlatList,
-  FlatListProps as RNFlatListProps,
   RefreshControl as RNRefreshControl,
-  RefreshControlProps as RNRefreshControlProps,
+  ScrollView as RNScrollView,
+  Switch as RNSwitch,
+  TextInput as RNTextInput,
 } from 'react-native';
-
-import createNativeWrapper from '../createNativeWrapper';
-
-import type { NativeWrapperProperties } from '../types/NativeWrapperType';
-import { NativeWrapperProps } from '../hooks/utils';
+import type {
+  FlatListProps as RNFlatListProps,
+  RefreshControlProps as RNRefreshControlProps,
+  ScrollViewProps as RNScrollViewProps,
+  SwitchProps as RNSwitchProps,
+  TextInputProps as RNTextInputProps,
+} from 'react-native';
+import React, { useState } from 'react';
 import { GestureDetectorType } from '../detectors';
 import type { NativeGesture } from '../hooks/gestures/native/NativeTypes';
+import type { NativeWrapperProperties } from '../types/NativeWrapperType';
+import { NativeWrapperProps } from '../hooks/utils';
+import createNativeWrapper from '../createNativeWrapper';
 import { ghQueueMicrotask } from '../../ghQueueMicrotask';
 
 export const RefreshControl = createNativeWrapper<

--- a/packages/react-native-gesture-handler/src/v3/components/GestureComponents.web.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/GestureComponents.web.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import {
   FlatList as RNFlatList,
+  ScrollView as RNScrollView,
   Switch as RNSwitch,
   TextInput as RNTextInput,
-  ScrollView as RNScrollView,
-  FlatListProps,
   View,
 } from 'react-native';
-
+import type { FlatListProps } from 'react-native';
 import createNativeWrapper from '../createNativeWrapper';
 
 export const ScrollView = createNativeWrapper(RNScrollView, {

--- a/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
@@ -1,3 +1,15 @@
+import { INT32_MAX, isTestEnv } from '../../utils';
+import type {
+  Insets,
+  LayoutChangeEvent,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
+import type {
+  PressableDimensions,
+  PressableEvent,
+  PressableProps,
+} from '../../components/Pressable/PressableProps';
 import React, {
   useCallback,
   useEffect,
@@ -6,29 +18,16 @@ import React, {
   useState,
 } from 'react';
 import {
-  PressableDimensions,
-  PressableEvent,
-  PressableProps,
-} from '../../components/Pressable/PressableProps';
-import {
-  Insets,
-  LayoutChangeEvent,
-  Platform,
-  StyleProp,
-  ViewStyle,
-} from 'react-native';
+  StateMachineEvent,
+  getStatesConfig,
+} from '../../components/Pressable/stateDefinitions';
 import {
   addInsets,
-  numberAsInset,
+  gestureToPressableEvent,
   gestureTouchToPressableEvent,
   isTouchWithinInset,
-  gestureToPressableEvent,
+  numberAsInset,
 } from '../../components/Pressable/utils';
-import {
-  getStatesConfig,
-  StateMachineEvent,
-} from '../../components/Pressable/stateDefinitions';
-import { PressableStateMachine } from '../../components/Pressable/StateMachine';
 import {
   useHoverGesture,
   useLongPressGesture,
@@ -36,10 +35,10 @@ import {
   useSimultaneousGestures,
 } from '../hooks';
 import { GestureDetector } from '../detectors';
-import { PureNativeButton } from './GestureButtons';
-
+import { Platform } from 'react-native';
 import { PressabilityDebugView } from '../../handlers/PressabilityDebugView';
-import { INT32_MAX, isTestEnv } from '../../utils';
+import { PressableStateMachine } from '../../components/Pressable/StateMachine';
+import { PureNativeButton } from './GestureButtons';
 import { useIsScreenReaderEnabled } from '../../useIsScreenReaderEnabled';
 
 const DEFAULT_LONG_PRESS_DURATION = 500;

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -1,9 +1,8 @@
+import type { CallbackEventType, TouchableProps } from './TouchableProps';
 import React, { useCallback, useRef } from 'react';
+import type { ButtonProps } from '../../../components/GestureHandlerButton';
+import GestureHandlerButton from '../../../components/GestureHandlerButton';
 import { Platform } from 'react-native';
-import GestureHandlerButton, {
-  ButtonProps,
-} from '../../../components/GestureHandlerButton';
-import { CallbackEventType, TouchableProps } from './TouchableProps';
 import createNativeWrapper from '../../createNativeWrapper';
 
 const TouchableButton = createNativeWrapper<

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
@@ -1,8 +1,8 @@
-import type { PressableAndroidRippleConfig as RNPressableAndroidRippleConfig } from 'react-native';
+import type { BaseButtonProps, RawButtonProps } from '../GestureButtonsProps';
 import type { ButtonProps } from '../../../components/GestureHandlerButton';
 import type { GestureEvent } from '../../types';
 import type { NativeHandlerData } from '../../hooks/gestures/native/NativeTypes';
-import { BaseButtonProps, RawButtonProps } from '../GestureButtonsProps';
+import type { PressableAndroidRippleConfig as RNPressableAndroidRippleConfig } from 'react-native';
 
 export type CallbackEventType = GestureEvent<NativeHandlerData>;
 

--- a/packages/react-native-gesture-handler/src/v3/createNativeWrapper.tsx
+++ b/packages/react-native-gesture-handler/src/v3/createNativeWrapper.tsx
@@ -1,14 +1,13 @@
-import React, { useEffect } from 'react';
-
-import { NativeWrapperProps } from './hooks/utils';
-import { useNativeGesture } from './hooks/gestures';
-import { NativeDetector } from './detectors/NativeDetector';
+import { GestureDetectorType, InterceptingGestureDetector } from './detectors';
 import type {
   NativeWrapperProperties,
   WrapperSpecificProperties,
 } from './types/NativeWrapperType';
-import { GestureDetectorType, InterceptingGestureDetector } from './detectors';
+import React, { useEffect } from 'react';
+import { NativeDetector } from './detectors/NativeDetector';
+import { NativeWrapperProps } from './hooks/utils';
 import { VirtualDetector } from './detectors/VirtualDetector/VirtualDetector';
+import { useNativeGesture } from './hooks/gestures';
 
 export default function createNativeWrapper<TRef = unknown, TProps = unknown>(
   Component: React.ComponentType<TProps>,

--- a/packages/react-native-gesture-handler/src/v3/detectors/GestureDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/GestureDetector.tsx
@@ -1,11 +1,9 @@
-import { NativeDetectorProps } from './common';
 import { BaseGesture } from '../../handlers/gestures/gesture';
-import { NativeDetector } from './NativeDetector';
 import { ComposedGesture } from '../../handlers/gestures/gestureComposition';
-import {
-  GestureDetectorProps as LegacyGestureDetectorProps,
-  GestureDetector as LegacyGestureDetector,
-} from '../../handlers/gestures/GestureDetector';
+import { GestureDetector as LegacyGestureDetector } from '../../handlers/gestures/GestureDetector';
+import type { GestureDetectorProps as LegacyGestureDetectorProps } from '../../handlers/gestures/GestureDetector';
+import { NativeDetector } from './NativeDetector';
+import type { NativeDetectorProps } from './common';
 import { useEnsureGestureHandlerRootView } from './useEnsureGestureHandlerRootView';
 
 export function GestureDetector<

--- a/packages/react-native-gesture-handler/src/v3/detectors/HostGestureDetector.web.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/HostGestureDetector.web.tsx
@@ -1,10 +1,14 @@
-import React, { Ref, RefObject, useEffect, useMemo, useRef } from 'react';
-import RNGestureHandlerModule from '../../RNGestureHandlerModule.web';
+import React, { useEffect, useMemo, useRef } from 'react';
+import type { Ref, RefObject } from 'react';
+import type {
+  TouchAction,
+  UserSelect,
+} from '../../handlers/gestureHandlerCommon';
 import { ActionType } from '../../ActionType';
-import { PropsRef } from '../../web/interfaces';
+import type { PropsRef } from '../../web/interfaces';
+import RNGestureHandlerModule from '../../RNGestureHandlerModule.web';
 import { View } from 'react-native';
 import { tagMessage } from '../../utils';
-import { TouchAction, UserSelect } from '../../handlers/gestureHandlerCommon';
 
 export interface GestureHandlerDetectorProps extends PropsRef {
   handlerTags: number[];

--- a/packages/react-native-gesture-handler/src/v3/detectors/NativeDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/NativeDetector.tsx
@@ -1,14 +1,11 @@
+import { AnimatedNativeDetector, nativeDetectorStyles } from './common';
 import React, { useMemo } from 'react';
-import HostGestureDetector from './HostGestureDetector';
 import { configureRelations, ensureNativeDetectorComponent } from './utils';
-import { isComposedGesture } from '../hooks/utils/relationUtils';
-import {
-  AnimatedNativeDetector,
-  NativeDetectorProps,
-  nativeDetectorStyles,
-} from './common';
-import { ReanimatedNativeDetector } from './ReanimatedNativeDetector';
+import HostGestureDetector from './HostGestureDetector';
+import type { NativeDetectorProps } from './common';
 import { Platform } from 'react-native';
+import { ReanimatedNativeDetector } from './ReanimatedNativeDetector';
+import { isComposedGesture } from '../hooks/utils/relationUtils';
 
 export function NativeDetector<
   TConfig,

--- a/packages/react-native-gesture-handler/src/v3/detectors/ReanimatedNativeDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/ReanimatedNativeDetector.tsx
@@ -1,11 +1,9 @@
-import { useEffect, useMemo, useRef } from 'react';
-import {
-  NativeEventsManager,
-  Reanimated,
-} from '../../handlers/gestures/reanimatedWrapper';
 import HostGestureDetector, {
   type RNGestureHandlerDetectorNativeComponentProps,
 } from './HostGestureDetector';
+import { useEffect, useMemo, useRef } from 'react';
+import type { NativeEventsManager } from '../../handlers/gestures/reanimatedWrapper';
+import { Reanimated } from '../../handlers/gestures/reanimatedWrapper';
 import { findNodeHandle } from 'react-native';
 
 let NativeEventsManagerImpl = Reanimated?.NativeEventsManager;

--- a/packages/react-native-gesture-handler/src/v3/detectors/ReanimatedNativeDetector.web.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/ReanimatedNativeDetector.web.tsx
@@ -1,5 +1,5 @@
-import { Reanimated } from '../../handlers/gestures/reanimatedWrapper';
 import HostGestureDetector from './HostGestureDetector';
+import { Reanimated } from '../../handlers/gestures/reanimatedWrapper';
 
 export const ReanimatedNativeDetector =
   Reanimated?.default.createAnimatedComponent(HostGestureDetector);

--- a/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/InterceptingGestureDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/InterceptingGestureDetector.tsx
@@ -1,31 +1,28 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import HostGestureDetector from '../HostGestureDetector';
-import {
-  VirtualChild,
-  GestureHandlerEventWithHandlerData,
+import { AnimatedNativeDetector, nativeDetectorStyles } from '../common';
+import type {
   DetectorCallbacks,
+  GestureHandlerEventWithHandlerData,
+  VirtualChild,
 } from '../../types';
 import {
   InterceptingDetectorContext,
-  InterceptingDetectorContextValue,
   InterceptingDetectorMode,
 } from './useInterceptingDetectorContext';
-import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
-import { configureRelations, ensureNativeDetectorComponent } from '../utils';
-import { isComposedGesture } from '../../hooks/utils/relationUtils';
-import {
-  AnimatedNativeDetector,
-  InterceptingGestureDetectorProps,
-  nativeDetectorStyles,
-} from '../common';
-import { tagMessage } from '../../../utils';
-import { useEnsureGestureHandlerRootView } from '../useEnsureGestureHandlerRootView';
-import { ReanimatedNativeDetector } from '../ReanimatedNativeDetector';
-import { Platform } from 'react-native';
-import {
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import type {
   TouchAction,
   UserSelect,
 } from '../../../handlers/gestureHandlerCommon';
+import { configureRelations, ensureNativeDetectorComponent } from '../utils';
+import HostGestureDetector from '../HostGestureDetector';
+import type { InterceptingDetectorContextValue } from './useInterceptingDetectorContext';
+import type { InterceptingGestureDetectorProps } from '../common';
+import { Platform } from 'react-native';
+import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
+import { ReanimatedNativeDetector } from '../ReanimatedNativeDetector';
+import { isComposedGesture } from '../../hooks/utils/relationUtils';
+import { tagMessage } from '../../../utils';
+import { useEnsureGestureHandlerRootView } from '../useEnsureGestureHandlerRootView';
 
 interface StrippedVirtualChildren {
   viewTag: number;

--- a/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/VirtualDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/VirtualDetector.tsx
@@ -1,15 +1,15 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { Wrap } from '../../../handlers/gestures/GestureDetector/Wrap';
-import { findNodeHandle, Platform } from 'react-native';
+import type { DetectorCallbacks, VirtualChild } from '../../types';
 import {
   InterceptingDetectorMode,
   useInterceptingDetectorContext,
 } from './useInterceptingDetectorContext';
-import { isComposedGesture } from '../../hooks/utils/relationUtils';
-import { VirtualDetectorProps } from '../common';
+import { Platform, findNodeHandle } from 'react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { VirtualDetectorProps } from '../common';
+import { Wrap } from '../../../handlers/gestures/GestureDetector/Wrap';
 import { configureRelations } from '../utils';
+import { isComposedGesture } from '../../hooks/utils/relationUtils';
 import { tagMessage } from '../../../utils';
-import { DetectorCallbacks, VirtualChild } from '../../types';
 
 function useRequiredInterceptingDetectorContext() {
   const context = useInterceptingDetectorContext();

--- a/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/useInterceptingDetectorContext.ts
+++ b/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/useInterceptingDetectorContext.ts
@@ -1,5 +1,5 @@
 import { createContext, use } from 'react';
-import { VirtualChild } from '../../types';
+import type { VirtualChild } from '../../types';
 
 export enum InterceptingDetectorMode {
   DEFAULT,

--- a/packages/react-native-gesture-handler/src/v3/detectors/common.ts
+++ b/packages/react-native-gesture-handler/src/v3/detectors/common.ts
@@ -1,9 +1,12 @@
-import React from 'react';
-import { Gesture } from '../types';
 import { Animated, StyleSheet } from 'react-native';
+import type {
+  TouchAction,
+  UserSelect,
+} from '../../handlers/gestureHandlerCommon';
+import type { Gesture } from '../types';
 import HostGestureDetector from './HostGestureDetector';
-import { GestureDetectorProps as LegacyDetectorProps } from '../../handlers/gestures/GestureDetector';
-import { TouchAction, UserSelect } from '../../handlers/gestureHandlerCommon';
+import type { GestureDetectorProps as LegacyDetectorProps } from '../../handlers/gestures/GestureDetector';
+import type React from 'react';
 
 export enum GestureDetectorType {
   Native,

--- a/packages/react-native-gesture-handler/src/v3/detectors/useEnsureGestureHandlerRootView.ts
+++ b/packages/react-native-gesture-handler/src/v3/detectors/useEnsureGestureHandlerRootView.ts
@@ -1,6 +1,6 @@
-import { use } from 'react';
-import { Platform } from 'react-native';
 import GestureHandlerRootViewContext from '../../GestureHandlerRootViewContext';
+import { Platform } from 'react-native';
+import { use } from 'react';
 
 export function useEnsureGestureHandlerRootView() {
   const rootViewContext = use(GestureHandlerRootViewContext);

--- a/packages/react-native-gesture-handler/src/v3/detectors/utils.ts
+++ b/packages/react-native-gesture-handler/src/v3/detectors/utils.ts
@@ -4,13 +4,14 @@
 // For `waitFor` we need array as order of the gestures matters.
 // For `simultaneousHandlers` we use Set as the order doesn't matter.
 
-import { tagMessage } from '../../utils';
 import {
   isComposedGesture,
   prepareRelations,
 } from '../hooks/utils/relationUtils';
+import { ComposedGestureName } from '../types';
+import type { Gesture } from '../types';
 import { NativeProxy } from '../NativeProxy';
-import { ComposedGestureName, Gesture } from '../types';
+import { tagMessage } from '../../utils';
 
 // The tree consists of ComposedGestures and NativeGestures. NativeGestures are always leaf nodes.
 export const traverseAndConfigureRelations = (

--- a/packages/react-native-gesture-handler/src/v3/gestureStateManager.web.ts
+++ b/packages/react-native-gesture-handler/src/v3/gestureStateManager.web.ts
@@ -1,8 +1,8 @@
-import { tagMessage } from '../utils';
-import IGestureHandler from '../web/handlers/IGestureHandler';
 import GestureHandlerOrchestrator from '../web/tools/GestureHandlerOrchestrator';
+import type { GestureStateManagerType } from './gestureStateManager';
+import type IGestureHandler from '../web/handlers/IGestureHandler';
 import NodeManager from '../web/tools/NodeManager';
-import { GestureStateManagerType } from './gestureStateManager';
+import { tagMessage } from '../utils';
 
 function ensureHandlerAttached(handler: IGestureHandler) {
   if (!handler.attached) {

--- a/packages/react-native-gesture-handler/src/v3/hooks/callbacks/eventHandler.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/callbacks/eventHandler.ts
@@ -1,13 +1,4 @@
-import {
-  flattenAndFilterEvent,
-  isEventForHandlerWithTag,
-  maybeExtractNativeEvent,
-  runCallback,
-  touchEventTypeToCallbackType,
-} from '../utils';
-import { tagMessage } from '../../../utils';
-import { ReanimatedContext } from '../../../handlers/gestures/reanimatedWrapper';
-import {
+import type {
   ChangeCalculatorType,
   GestureCallbacks,
   GestureEvent,
@@ -15,11 +6,20 @@ import {
   GestureStateChangeEventWithHandlerData,
   GestureUpdateEventWithHandlerData,
 } from '../../types';
+import {
+  flattenAndFilterEvent,
+  isEventForHandlerWithTag,
+  maybeExtractNativeEvent,
+  runCallback,
+  touchEventTypeToCallbackType,
+} from '../utils';
+import { isStateChangeEvent, isTouchEvent } from '../utils/eventUtils';
 import { CALLBACK_TYPE } from '../../../handlers/gestures/gesture';
+import type { GestureTouchEvent } from '../../../handlers/gestureHandlerCommon';
+import type { ReanimatedContext } from '../../../handlers/gestures/reanimatedWrapper';
 import { State } from '../../../State';
 import { TouchEventType } from '../../../TouchEventType';
-import { GestureTouchEvent } from '../../../handlers/gestureHandlerCommon';
-import { isStateChangeEvent, isTouchEvent } from '../utils/eventUtils';
+import { tagMessage } from '../../../utils';
 
 function handleStateChangeEvent<
   THandlerData,

--- a/packages/react-native-gesture-handler/src/v3/hooks/callbacks/stateChangeHandler.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/callbacks/stateChangeHandler.ts
@@ -1,7 +1,4 @@
-import { ReanimatedContext } from '../../../handlers/gestures/reanimatedWrapper';
-import { CALLBACK_TYPE } from '../../../handlers/gestures/gesture';
-import { State } from '../../../State';
-import {
+import type {
   GestureCallbacks,
   GestureStateChangeEventWithHandlerData,
   StateChangeEventWithHandlerData,
@@ -12,6 +9,9 @@ import {
   maybeExtractNativeEvent,
   runCallback,
 } from '../utils';
+import { CALLBACK_TYPE } from '../../../handlers/gestures/gesture';
+import type { ReanimatedContext } from '../../../handlers/gestures/reanimatedWrapper';
+import { State } from '../../../State';
 
 export function getStateChangeHandler<
   THandlerData,

--- a/packages/react-native-gesture-handler/src/v3/hooks/callbacks/touchEventHandler.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/callbacks/touchEventHandler.ts
@@ -1,12 +1,12 @@
-import { GestureCallbacks, TouchEvent } from '../../types';
+import type { GestureCallbacks, TouchEvent } from '../../types';
 import {
   isEventForHandlerWithTag,
   maybeExtractNativeEvent,
   runCallback,
   touchEventTypeToCallbackType,
 } from '../utils';
+import type { GestureTouchEvent } from '../../../handlers/gestureHandlerCommon';
 import { TouchEventType } from '../../../TouchEventType';
-import { GestureTouchEvent } from '../../../handlers/gestureHandlerCommon';
 
 export function getTouchEventHandler<
   THandlerData,

--- a/packages/react-native-gesture-handler/src/v3/hooks/callbacks/updateHandler.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/callbacks/updateHandler.ts
@@ -1,7 +1,4 @@
-import { CALLBACK_TYPE } from '../../../handlers/gestures/gesture';
-import { tagMessage } from '../../../utils';
-import { ReanimatedContext } from '../../../handlers/gestures/reanimatedWrapper';
-import {
+import type {
   ChangeCalculatorType,
   GestureCallbacks,
   GestureUpdateEventWithHandlerData,
@@ -13,6 +10,9 @@ import {
   maybeExtractNativeEvent,
   runCallback,
 } from '../utils';
+import { CALLBACK_TYPE } from '../../../handlers/gestures/gesture';
+import type { ReanimatedContext } from '../../../handlers/gestures/reanimatedWrapper';
+import { tagMessage } from '../../../utils';
 
 export function getUpdateHandler<
   THandlerData,

--- a/packages/react-native-gesture-handler/src/v3/hooks/callbacks/useGestureEventHandler.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/callbacks/useGestureEventHandler.ts
@@ -1,11 +1,11 @@
-import { ReanimatedContext } from '../../../handlers/gestures/reanimatedWrapper';
-import {
+import type {
   BaseGestureConfig,
   GestureCallbacks,
   GestureHandlerEventWithHandlerData,
 } from '../../types';
-import { useMemo } from 'react';
+import type { ReanimatedContext } from '../../../handlers/gestures/reanimatedWrapper';
 import { eventHandler } from './eventHandler';
+import { useMemo } from 'react';
 
 export function useGestureEventHandler<
   TConfig,

--- a/packages/react-native-gesture-handler/src/v3/hooks/callbacks/useReanimatedEventHandler.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/callbacks/useReanimatedEventHandler.ts
@@ -1,15 +1,13 @@
-import { useMemo } from 'react';
-import {
-  Reanimated,
-  ReanimatedHandler,
-} from '../../../handlers/gestures/reanimatedWrapper';
-import {
+import type {
   ChangeCalculatorType,
   GestureCallbacks,
   GestureEvent,
   UnpackedGestureHandlerEventWithHandlerData,
 } from '../../types';
+import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
+import type { ReanimatedHandler } from '../../../handlers/gestures/reanimatedWrapper';
 import { eventHandler } from './eventHandler';
+import { useMemo } from 'react';
 
 const workletNOOP = () => {
   'worklet';

--- a/packages/react-native-gesture-handler/src/v3/hooks/composition/useCompetingGestures.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/composition/useCompetingGestures.ts
@@ -1,4 +1,5 @@
-import { AnyGesture, ComposedGestureName } from '../../types';
+import type { AnyGesture } from '../../types';
+import { ComposedGestureName } from '../../types';
 import { useComposedGesture } from './useComposedGesture';
 
 export function useCompetingGestures(...gestures: AnyGesture[]) {

--- a/packages/react-native-gesture-handler/src/v3/hooks/composition/useComposedGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/composition/useComposedGesture.ts
@@ -1,13 +1,13 @@
-import {
-  ComposedGesture,
-  ComposedGestureName,
+import type {
   AnyGesture,
+  ComposedGesture,
   ComposedGestureConfig,
+  ComposedGestureName,
   GestureHandlerEventWithHandlerData,
 } from '../../types';
-import { tagMessage } from '../../../utils';
-import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
 import { containsDuplicates, isComposedGesture } from '../utils';
+import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
+import { tagMessage } from '../../../utils';
 
 // TODO: Simplify repeated relations (Simultaneous with Simultaneous, Exclusive with Exclusive, etc.)
 export function useComposedGesture(

--- a/packages/react-native-gesture-handler/src/v3/hooks/composition/useExclusiveGestures.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/composition/useExclusiveGestures.ts
@@ -1,4 +1,5 @@
-import { AnyGesture, ComposedGestureName } from '../../types';
+import type { AnyGesture } from '../../types';
+import { ComposedGestureName } from '../../types';
 import { useComposedGesture } from './useComposedGesture';
 
 export function useExclusiveGestures(...gestures: AnyGesture[]) {

--- a/packages/react-native-gesture-handler/src/v3/hooks/composition/useSimultaneousGestures.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/composition/useSimultaneousGestures.ts
@@ -1,4 +1,5 @@
-import { AnyGesture, ComposedGestureName } from '../../types';
+import type { AnyGesture } from '../../types';
+import { ComposedGestureName } from '../../types';
 import { useComposedGesture } from './useComposedGesture';
 
 export function useSimultaneousGestures(...gestures: AnyGesture[]) {

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/FlingTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/FlingTypes.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BaseDiscreteGestureConfig,
   ExcludeInternalConfigProps,
   GestureEvent,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/useFlingGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/useFlingGesture.ts
@@ -1,12 +1,12 @@
-import { SingleGestureName } from '../../../types';
-import { useGesture } from '../../useGesture';
-import { useClonedAndRemappedConfig } from '../../utils';
-import {
+import type {
   FlingGesture,
   FlingGestureConfig,
   FlingGestureProperties,
   FlingHandlerData,
 } from './FlingTypes';
+import { SingleGestureName } from '../../../types';
+import { useClonedAndRemappedConfig } from '../../utils';
+import { useGesture } from '../../useGesture';
 
 export function useFlingGesture(config: FlingGestureConfig): FlingGesture {
   const flingConfig = useClonedAndRemappedConfig<

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/hover/HoverTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/hover/HoverTypes.ts
@@ -1,12 +1,12 @@
-import { StylusData } from '../../../../handlers/gestureHandlerCommon';
-import { HoverEffect } from '../../../../handlers/gestures/hoverGesture';
-import {
+import type {
   BaseGestureConfig,
   ExcludeInternalConfigProps,
   GestureEvent,
   SingleGesture,
   WithSharedValue,
 } from '../../../types';
+import type { HoverEffect } from '../../../../handlers/gestures/hoverGesture';
+import type { StylusData } from '../../../../handlers/gestureHandlerCommon';
 
 export type HoverGestureExternalProperties = {
   /**

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/hover/useHoverGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/hover/useHoverGesture.ts
@@ -1,10 +1,5 @@
-import { GestureEvent, HandlerData, SingleGestureName } from '../../../types';
-import { useGesture } from '../../useGesture';
-import {
-  useClonedAndRemappedConfig,
-  getChangeEventCalculator,
-} from '../../utils';
-import {
+import type { GestureEvent, HandlerData } from '../../../types';
+import type {
   HoverExtendedHandlerData,
   HoverGesture,
   HoverGestureConfig,
@@ -13,6 +8,12 @@ import {
   HoverGestureProperties,
   HoverHandlerData,
 } from './HoverTypes';
+import {
+  getChangeEventCalculator,
+  useClonedAndRemappedConfig,
+} from '../../utils';
+import { SingleGestureName } from '../../../types';
+import { useGesture } from '../../useGesture';
 
 function diffCalculator(
   current: HandlerData<HoverExtendedHandlerData>,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/index.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/index.ts
@@ -1,56 +1,56 @@
 import type {
-  FlingGestureEvent,
-  FlingGestureActiveEvent,
   FlingGesture,
+  FlingGestureActiveEvent,
   FlingGestureConfig,
+  FlingGestureEvent,
 } from './fling/FlingTypes';
 import type {
-  HoverGestureEvent,
   HoverGesture,
   HoverGestureActiveEvent,
   HoverGestureConfig,
+  HoverGestureEvent,
 } from './hover/HoverTypes';
 import type {
-  LongPressGestureEvent,
-  LongPressGestureActiveEvent,
   LongPressGesture,
+  LongPressGestureActiveEvent,
   LongPressGestureConfig,
+  LongPressGestureEvent,
 } from './longPress/LongPressTypes';
 import type {
-  ManualGestureEvent,
-  ManualGestureActiveEvent,
   ManualGesture,
+  ManualGestureActiveEvent,
   ManualGestureConfig,
+  ManualGestureEvent,
 } from './manual/ManualTypes';
 import type {
-  NativeGestureEvent,
-  NativeGestureActiveEvent,
   NativeGesture,
+  NativeGestureActiveEvent,
   NativeGestureConfig,
+  NativeGestureEvent,
 } from './native/NativeTypes';
 import type {
-  PanGestureEvent,
   PanGesture,
   PanGestureActiveEvent,
   PanGestureConfig,
+  PanGestureEvent,
 } from './pan/PanTypes';
 import type {
-  PinchGestureEvent,
   PinchGesture,
   PinchGestureActiveEvent,
   PinchGestureConfig,
+  PinchGestureEvent,
 } from './pinch/PinchTypes';
 import type {
-  RotationGestureEvent,
-  RotationGestureActiveEvent,
   RotationGesture,
+  RotationGestureActiveEvent,
   RotationGestureConfig,
+  RotationGestureEvent,
 } from './rotation/RotationTypes';
 import type {
-  TapGestureEvent,
   TapGesture,
   TapGestureActiveEvent,
   TapGestureConfig,
+  TapGestureEvent,
 } from './tap/TapTypes';
 
 export type {

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/longPress/LongPressTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/longPress/LongPressTypes.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BaseDiscreteGestureConfig,
   ExcludeInternalConfigProps,
   GestureEvent,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/longPress/useLongPressGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/longPress/useLongPressGesture.ts
@@ -1,7 +1,4 @@
-import { SingleGestureName } from '../../../types';
-import { useGesture } from '../../useGesture';
-import { useClonedAndRemappedConfig } from '../../utils';
-import {
+import type {
   LongPressGesture,
   LongPressGestureConfig,
   LongPressGestureInternalConfig,
@@ -9,6 +6,9 @@ import {
   LongPressGestureProperties,
   LongPressHandlerData,
 } from './LongPressTypes';
+import { SingleGestureName } from '../../../types';
+import { useClonedAndRemappedConfig } from '../../utils';
+import { useGesture } from '../../useGesture';
 
 const LongPressPropsMapping = new Map<
   keyof LongPressGestureProperties,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/manual/ManualTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/manual/ManualTypes.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BaseGestureConfig,
   ExcludeInternalConfigProps,
   GestureEvent,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/manual/useManualGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/manual/useManualGesture.ts
@@ -1,12 +1,12 @@
-import { SingleGestureName } from '../../../types';
-import { useGesture } from '../../useGesture';
-import { useClonedAndRemappedConfig } from '../../utils';
-import {
-  ManualGestureProperties,
-  ManualHandlerData,
+import type {
   ManualGesture,
   ManualGestureConfig,
+  ManualGestureProperties,
+  ManualHandlerData,
 } from './ManualTypes';
+import { SingleGestureName } from '../../../types';
+import { useClonedAndRemappedConfig } from '../../utils';
+import { useGesture } from '../../useGesture';
 
 export function useManualGesture(config: ManualGestureConfig): ManualGesture {
   const manualConfig = useClonedAndRemappedConfig<

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/NativeTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/NativeTypes.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BaseGestureConfig,
   ExcludeInternalConfigProps,
   GestureEvent,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/useNativeGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/useNativeGesture.ts
@@ -1,12 +1,12 @@
-import { SingleGestureName } from '../../../types';
-import { useGesture } from '../../useGesture';
-import { useClonedAndRemappedConfig } from '../../utils';
-import {
+import type {
   NativeGesture,
   NativeGestureConfig,
   NativeGestureProperties,
   NativeHandlerData,
 } from './NativeTypes';
+import { SingleGestureName } from '../../../types';
+import { useClonedAndRemappedConfig } from '../../utils';
+import { useGesture } from '../../useGesture';
 
 export function useNativeGesture(config: NativeGestureConfig): NativeGesture {
   const nativeConfig = useClonedAndRemappedConfig<

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/PanTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/PanTypes.ts
@@ -1,11 +1,11 @@
-import { StylusData } from '../../../../handlers/gestureHandlerCommon';
-import {
+import type {
   BaseGestureConfig,
   ExcludeInternalConfigProps,
   GestureEvent,
   SingleGesture,
   WithSharedValue,
 } from '../../../types';
+import type { StylusData } from '../../../../handlers/gestureHandlerCommon';
 
 type CommonPanGestureProperties = {
   /**

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/usePanGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/usePanGesture.ts
@@ -1,16 +1,9 @@
-import {
+import type {
   GestureEvent,
   HandlerData,
-  SingleGestureName,
   WithSharedValue,
 } from '../../../types';
-import { useGesture } from '../../useGesture';
-import {
-  getChangeEventCalculator,
-  maybeUnpackValue,
-  useClonedAndRemappedConfig,
-} from '../../utils';
-import {
+import type {
   OffsetProps,
   PanExtendedHandlerData,
   PanGesture,
@@ -20,6 +13,13 @@ import {
   PanGestureProperties,
   PanHandlerData,
 } from './PanTypes';
+import {
+  getChangeEventCalculator,
+  maybeUnpackValue,
+  useClonedAndRemappedConfig,
+} from '../../utils';
+import { SingleGestureName } from '../../../types';
+import { useGesture } from '../../useGesture';
 
 const PanPropsMapping = new Map<
   keyof PanGestureProperties,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/pinch/PinchTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/pinch/PinchTypes.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BaseGestureConfig,
   ExcludeInternalConfigProps,
   GestureEvent,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/pinch/usePinchGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/pinch/usePinchGesture.ts
@@ -1,10 +1,5 @@
-import { GestureEvent, HandlerData, SingleGestureName } from '../../../types';
-import { useGesture } from '../../useGesture';
-import {
-  useClonedAndRemappedConfig,
-  getChangeEventCalculator,
-} from '../../utils';
-import {
+import type { GestureEvent, HandlerData } from '../../../types';
+import type {
   PinchExtendedHandlerData,
   PinchGesture,
   PinchGestureConfig,
@@ -12,6 +7,12 @@ import {
   PinchGestureProperties,
   PinchHandlerData,
 } from './PinchTypes';
+import {
+  getChangeEventCalculator,
+  useClonedAndRemappedConfig,
+} from '../../utils';
+import { SingleGestureName } from '../../../types';
+import { useGesture } from '../../useGesture';
 
 function diffCalculator(
   current: HandlerData<PinchExtendedHandlerData>,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/rotation/RotationTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/rotation/RotationTypes.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BaseGestureConfig,
   ExcludeInternalConfigProps,
   GestureEvent,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/rotation/useRotationGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/rotation/useRotationGesture.ts
@@ -1,10 +1,5 @@
-import { GestureEvent, HandlerData, SingleGestureName } from '../../../types';
-import { useGesture } from '../../useGesture';
-import {
-  useClonedAndRemappedConfig,
-  getChangeEventCalculator,
-} from '../../utils';
-import {
+import type { GestureEvent, HandlerData } from '../../../types';
+import type {
   RotationExtendedHandlerData,
   RotationGesture,
   RotationGestureConfig,
@@ -12,6 +7,12 @@ import {
   RotationGestureProperties,
   RotationHandlerData,
 } from './RotationTypes';
+import {
+  getChangeEventCalculator,
+  useClonedAndRemappedConfig,
+} from '../../utils';
+import { SingleGestureName } from '../../../types';
+import { useGesture } from '../../useGesture';
 
 function diffCalculator(
   current: HandlerData<RotationExtendedHandlerData>,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/TapTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/TapTypes.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BaseDiscreteGestureConfig,
   DiscreteSingleGesture,
   ExcludeInternalConfigProps,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/useTapGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/useTapGesture.ts
@@ -1,13 +1,13 @@
-import { SingleGestureName } from '../../../types';
-import { useGesture } from '../../useGesture';
-import { useClonedAndRemappedConfig } from '../../utils';
-import {
-  TapGestureProperties,
-  TapGestureInternalProperties,
-  TapHandlerData,
-  TapGestureConfig,
+import type {
   TapGesture,
+  TapGestureConfig,
+  TapGestureInternalProperties,
+  TapGestureProperties,
+  TapHandlerData,
 } from './TapTypes';
+import { SingleGestureName } from '../../../types';
+import { useClonedAndRemappedConfig } from '../../utils';
+import { useGesture } from '../../useGesture';
 
 const TapPropsMapping = new Map<
   keyof TapGestureProperties,

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -1,21 +1,25 @@
-import { useEffect, useMemo, useRef } from 'react';
-import { getNextHandlerTag } from '../../handlers/getNextHandlerTag';
-import { useGestureCallbacks } from './useGestureCallbacks';
+import type {
+  BaseGestureConfig,
+  SingleGesture,
+  SingleGestureName,
+} from '../types';
 import {
-  prepareConfig,
-  prepareRelations,
   bindSharedValues,
-  unbindSharedValues,
+  prepareConfig,
   prepareConfigForNativeSide,
+  prepareRelations,
+  unbindSharedValues,
 } from './utils';
-import { tagMessage } from '../../utils';
-import { BaseGestureConfig, SingleGesture, SingleGestureName } from '../types';
-import { scheduleFlushOperations } from '../../handlers/utils';
 import {
   registerGesture,
   unregisterGesture,
 } from '../../handlers/handlersRegistry';
+import { useEffect, useMemo, useRef } from 'react';
 import { NativeProxy } from '../NativeProxy';
+import { getNextHandlerTag } from '../../handlers/getNextHandlerTag';
+import { scheduleFlushOperations } from '../../handlers/utils';
+import { tagMessage } from '../../utils';
+import { useGestureCallbacks } from './useGestureCallbacks';
 
 export function useGesture<
   TConfig,

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGestureCallbacks.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGestureCallbacks.ts
@@ -1,5 +1,4 @@
-import { useGestureEventHandler } from './callbacks/useGestureEventHandler';
-import {
+import type {
   AnimatedEvent,
   BaseGestureConfig,
   GestureUpdateEventWithHandlerData,
@@ -9,9 +8,10 @@ import {
   isNativeAnimatedEvent,
   useMemoizedGestureCallbacks,
 } from './utils';
-import { useReanimatedEventHandler } from './callbacks/useReanimatedEventHandler';
-import { tagMessage } from '../../utils';
 import { Reanimated } from '../../handlers/gestures/reanimatedWrapper';
+import { tagMessage } from '../../utils';
+import { useGestureEventHandler } from './callbacks/useGestureEventHandler';
+import { useReanimatedEventHandler } from './callbacks/useReanimatedEventHandler';
 
 function guardJSAnimatedEvent(handler: (...args: unknown[]) => void) {
   return (...args: unknown[]) => {

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
@@ -1,18 +1,18 @@
-import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
-import { tagMessage } from '../../../utils';
-import {
+import type {
   BaseGestureConfig,
   ExcludeInternalConfigProps,
   SingleGestureName,
 } from '../../types';
-import { hasWorkletEventHandlers, maybeUnpackValue } from './reanimatedUtils';
-import { isNativeAnimatedEvent, shouldHandleTouchEvents } from './eventUtils';
 import {
-  allowedNativeProps,
   EMPTY_WHITE_LIST,
   PropsToFilter,
   PropsWhiteLists,
+  allowedNativeProps,
 } from './propsWhiteList';
+import { hasWorkletEventHandlers, maybeUnpackValue } from './reanimatedUtils';
+import { isNativeAnimatedEvent, shouldHandleTouchEvents } from './eventUtils';
+import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
+import { tagMessage } from '../../../utils';
 import { useMemo } from 'react';
 
 export function prepareConfig<

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/eventHandlersUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/eventHandlersUtils.ts
@@ -1,13 +1,13 @@
-import { useMemo } from 'react';
-import { TouchEventType } from '../../../TouchEventType';
-import { CALLBACK_TYPE } from '../../../handlers/gestures/gesture';
-import {
+import type {
   GestureCallbacks,
   GestureEventCallback,
   GestureEventCallbackWithDidSucceed,
   GestureTouchEventCallback,
   UnpackedGestureHandlerEvent,
 } from '../../types';
+import { CALLBACK_TYPE } from '../../../handlers/gestures/gesture';
+import { TouchEventType } from '../../../TouchEventType';
+import { useMemo } from 'react';
 
 export function useMemoizedGestureCallbacks<
   THandlerData,

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/eventUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/eventUtils.ts
@@ -1,15 +1,15 @@
-import { NativeSyntheticEvent } from 'react-native';
-import {
+import type {
   AnimatedEvent,
   BaseGestureConfig,
   ChangeCalculatorType,
   DiffCalculatorType,
+  GestureEvent,
   GestureHandlerEventWithHandlerData,
   GestureStateChangeEventWithHandlerData,
   GestureUpdateEventWithHandlerData,
-  GestureEvent,
 } from '../../types';
-import { GestureTouchEvent } from '../../../handlers/gestureHandlerCommon';
+import type { GestureTouchEvent } from '../../../handlers/gestureHandlerCommon';
+import type { NativeSyntheticEvent } from 'react-native';
 import { tagMessage } from '../../../utils';
 
 function isNativeEvent<THandlerData, TExtendedHandlerData extends THandlerData>(

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
@@ -1,18 +1,18 @@
-import {
+import type {
   BaseGestureConfig,
   CommonGestureConfig,
   ExternalRelations,
   GestureCallbacks,
   HandlersPropsWhiteList,
   InternalConfigProps,
-  SingleGestureName,
 } from '../../types';
-import { NativeWrapperProperties } from '../../types/NativeWrapperType';
 import { FlingNativeProperties } from '../gestures/fling/FlingTypes';
 import { HoverNativeProperties } from '../gestures/hover/HoverTypes';
 import { LongPressNativeProperties } from '../gestures/longPress/LongPressTypes';
 import { NativeHandlerNativeProperties } from '../gestures/native/NativeTypes';
+import type { NativeWrapperProperties } from '../../types/NativeWrapperType';
 import { PanNativeProperties } from '../gestures/pan/PanTypes';
+import { SingleGestureName } from '../../types';
 import { TapNativeProperties } from '../gestures/tap/TapTypes';
 
 const CommonConfig = new Set<keyof CommonGestureConfig>([

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/reanimatedUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/reanimatedUtils.ts
@@ -1,12 +1,12 @@
-import { NativeProxy } from '../../NativeProxy';
-import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
-import {
+import type {
   BaseGestureConfig,
   GestureCallbacks,
   SharedValue,
   SharedValueOrT,
 } from '../../types';
 import { HandlerCallbacks } from './propsWhiteList';
+import { NativeProxy } from '../../NativeProxy';
+import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
 
 // Variant of djb2 hash function.
 // Taken from https://gist.github.com/eplawless/52813b1d8ad9af510d85?permalink_comment_id=3367765#gistcomment-3367765

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/relationUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/relationUtils.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ComposedGesture,
   ExternalRelations,
   Gesture,

--- a/packages/react-native-gesture-handler/src/v3/types/ConfigTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/ConfigTypes.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ActiveCursor,
   GestureTouchEvent,
   HitSlop,
@@ -6,12 +6,12 @@ import {
   TouchAction,
   UserSelect,
 } from '../../handlers/gestureHandlerCommon';
-import {
+import type {
   AnimatedEvent,
   ChangeCalculatorType,
   GestureEvent,
 } from './EventTypes';
-import { WithSharedValue } from './ReanimatedTypes';
+import type { WithSharedValue } from './ReanimatedTypes';
 
 export type GestureEventCallback<THandlerData> = (
   event: GestureEvent<THandlerData>

--- a/packages/react-native-gesture-handler/src/v3/types/DetectorTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/DetectorTypes.ts
@@ -1,9 +1,12 @@
-import {
+import type {
   AnimatedEvent,
-  GestureUpdateEventWithHandlerData,
   GestureHandlerEventWithHandlerData,
+  GestureUpdateEventWithHandlerData,
 } from './EventTypes';
-import { TouchAction, UserSelect } from '../../handlers/gestureHandlerCommon';
+import type {
+  TouchAction,
+  UserSelect,
+} from '../../handlers/gestureHandlerCommon';
 
 export type DetectorCallbacks<
   THandlerData,

--- a/packages/react-native-gesture-handler/src/v3/types/EventTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/EventTypes.ts
@@ -1,7 +1,7 @@
-import { Animated, NativeSyntheticEvent } from 'react-native';
-import { GestureTouchEvent } from '../../handlers/gestureHandlerCommon';
-import { PointerType } from '../../PointerType';
-import { State } from '../../State';
+import type { Animated, NativeSyntheticEvent } from 'react-native';
+import type { GestureTouchEvent } from '../../handlers/gestureHandlerCommon';
+import type { PointerType } from '../../PointerType';
+import type { State } from '../../State';
 
 type EventPayload = {
   handlerTag: number;

--- a/packages/react-native-gesture-handler/src/v3/types/GestureTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/GestureTypes.ts
@@ -1,12 +1,12 @@
-import { DetectorCallbacks } from './DetectorTypes';
-import {
+import type {
   CommonGestureConfig,
   ComposedGestureConfig,
   GestureCallbacks,
   GestureRelations,
   InternalConfigProps,
 } from './ConfigTypes';
-import { FilterNeverProperties } from './UtilityTypes';
+import type { DetectorCallbacks } from './DetectorTypes';
+import type { FilterNeverProperties } from './UtilityTypes';
 
 // Unfortunately, this type cannot be moved into ConfigTypes.ts because of circular dependency
 export type ExternalRelations = {

--- a/packages/react-native-gesture-handler/src/v3/types/NativeWrapperType.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/NativeWrapperType.ts
@@ -1,9 +1,13 @@
-import { CommonGestureConfig, ExternalRelations, GestureCallbacks } from '.';
+import type {
+  CommonGestureConfig,
+  ExternalRelations,
+  GestureCallbacks,
+} from '.';
 
-import {
+import type {
+  NativeGesture,
   NativeGestureNativeProperties,
   NativeHandlerData,
-  NativeGesture,
 } from '../hooks/gestures/native/NativeTypes';
 
 export type WrapperSpecificProperties<T = unknown> = {

--- a/packages/react-native-gesture-handler/src/v3/types/UtilityTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/UtilityTypes.ts
@@ -1,10 +1,10 @@
-import { PanGestureNativeProperties } from '../hooks/gestures/pan/PanTypes';
-import { FlingGestureNativeProperties } from '../hooks/gestures/fling/FlingTypes';
-import { HoverGestureNativeProperties } from '../hooks/gestures/hover/HoverTypes';
-import { LongPressGestureNativeProperties } from '../hooks/gestures/longPress/LongPressTypes';
-import { NativeGestureNativeProperties } from '../hooks/gestures/native/NativeTypes';
-import { TapGestureNativeConfig } from '../hooks/gestures/tap/TapTypes';
-import { InternalConfigProps } from './ConfigTypes';
+import type { FlingGestureNativeProperties } from '../hooks/gestures/fling/FlingTypes';
+import type { HoverGestureNativeProperties } from '../hooks/gestures/hover/HoverTypes';
+import type { InternalConfigProps } from './ConfigTypes';
+import type { LongPressGestureNativeProperties } from '../hooks/gestures/longPress/LongPressTypes';
+import type { NativeGestureNativeProperties } from '../hooks/gestures/native/NativeTypes';
+import type { PanGestureNativeProperties } from '../hooks/gestures/pan/PanTypes';
+import type { TapGestureNativeConfig } from '../hooks/gestures/tap/TapTypes';
 
 export type HandlersPropsWhiteList =
   | Set<keyof PanGestureNativeProperties>

--- a/packages/react-native-gesture-handler/src/web/Gestures.ts
+++ b/packages/react-native-gesture-handler/src/web/Gestures.ts
@@ -1,13 +1,13 @@
 // Gesture Handlers
-import PanGestureHandler from './handlers/PanGestureHandler';
-import TapGestureHandler from './handlers/TapGestureHandler';
+import FlingGestureHandler from './handlers/FlingGestureHandler';
+import HoverGestureHandler from './handlers/HoverGestureHandler';
 import LongPressGestureHandler from './handlers/LongPressGestureHandler';
+import ManualGestureHandler from './handlers/ManualGestureHandler';
+import NativeViewGestureHandler from './handlers/NativeViewGestureHandler';
+import PanGestureHandler from './handlers/PanGestureHandler';
 import PinchGestureHandler from './handlers/PinchGestureHandler';
 import RotationGestureHandler from './handlers/RotationGestureHandler';
-import FlingGestureHandler from './handlers/FlingGestureHandler';
-import NativeViewGestureHandler from './handlers/NativeViewGestureHandler';
-import ManualGestureHandler from './handlers/ManualGestureHandler';
-import HoverGestureHandler from './handlers/HoverGestureHandler';
+import TapGestureHandler from './handlers/TapGestureHandler';
 
 export const Gestures = {
   NativeViewGestureHandler,

--- a/packages/react-native-gesture-handler/src/web/detectors/RotationGestureDetector.ts
+++ b/packages/react-native-gesture-handler/src/web/detectors/RotationGestureDetector.ts
@@ -1,5 +1,6 @@
-import { AdaptedEvent, EventTypes } from '../interfaces';
-import PointerTracker from '../tools/PointerTracker';
+import type { AdaptedEvent } from '../interfaces';
+import { EventTypes } from '../interfaces';
+import type PointerTracker from '../tools/PointerTracker';
 
 export interface RotationGestureListener {
   onRotationBegin: (detector: RotationGestureDetector) => boolean;

--- a/packages/react-native-gesture-handler/src/web/detectors/ScaleGestureDetector.ts
+++ b/packages/react-native-gesture-handler/src/web/detectors/ScaleGestureDetector.ts
@@ -1,7 +1,7 @@
+import type { AdaptedEvent } from '../interfaces';
 import { DEFAULT_TOUCH_SLOP } from '../constants';
-import { AdaptedEvent, EventTypes } from '../interfaces';
-
-import PointerTracker from '../tools/PointerTracker';
+import { EventTypes } from '../interfaces';
+import type PointerTracker from '../tools/PointerTracker';
 
 export interface ScaleGestureListener {
   onScaleBegin: (detector: ScaleGestureDetector) => boolean;

--- a/packages/react-native-gesture-handler/src/web/handlers/FlingGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/FlingGestureHandler.ts
@@ -1,13 +1,12 @@
-import { State } from '../../State';
+import type { AdaptedEvent, Config } from '../interfaces';
 import { DiagonalDirections, Directions } from '../../Directions';
-import { AdaptedEvent, Config } from '../interfaces';
-
 import GestureHandler from './GestureHandler';
+import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
+import type IGestureHandler from './IGestureHandler';
+import { SingleGestureName } from '../../v3/types';
+import { State } from '../../State';
 import Vector from '../tools/Vector';
 import { coneToDeviation } from '../utils';
-import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
-import IGestureHandler from './IGestureHandler';
-import { SingleGestureName } from '../../v3/types';
 
 const DEFAULT_MAX_DURATION_MS = 800;
 const DEFAULT_MIN_VELOCITY = 700;

--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -1,37 +1,38 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { State } from '../../State';
-import {
-  Config,
-  AdaptedEvent,
-  PropsRef,
-  ResultEvent,
-  PointerData,
-  EventTypes,
-  HitSlop,
-  GestureHandlerNativeEvent,
-} from '../interfaces';
-import EventManager from '../tools/EventManager';
-import GestureHandlerOrchestrator from '../tools/GestureHandlerOrchestrator';
-import InteractionManager from '../tools/InteractionManager';
-import PointerTracker, { TrackerElement } from '../tools/PointerTracker';
-import IGestureHandler from './IGestureHandler';
-import {
+import { ActionType, usesNativeOrVirtualDetector } from '../../ActionType';
+import type {
   ActiveCursor,
+  GestureTouchEvent,
   TouchAction,
   UserSelect,
-  GestureTouchEvent,
-  MouseButton,
 } from '../../handlers/gestureHandlerCommon';
-import { PointerType } from '../../PointerType';
-import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
-import { ActionType, usesNativeOrVirtualDetector } from '../../ActionType';
-import { tagMessage } from '../../utils';
-import {
+import type {
+  AdaptedEvent,
+  Config,
+  GestureHandlerNativeEvent,
+  HitSlop,
+  PointerData,
+  PropsRef,
+  ResultEvent,
+} from '../interfaces';
+import type {
   GestureStateChangeEventWithHandlerData,
   GestureUpdateEventWithHandlerData,
   SingleGestureName,
 } from '../../v3/types';
+import type EventManager from '../tools/EventManager';
+import { EventTypes } from '../interfaces';
+import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
+import GestureHandlerOrchestrator from '../tools/GestureHandlerOrchestrator';
+import type IGestureHandler from './IGestureHandler';
+import InteractionManager from '../tools/InteractionManager';
+import { MouseButton } from '../../handlers/gestureHandlerCommon';
+import PointerTracker from '../tools/PointerTracker';
+import { PointerType } from '../../PointerType';
+import { State } from '../../State';
 import { TouchEventType } from '../../TouchEventType';
+import type { TrackerElement } from '../tools/PointerTracker';
+import { tagMessage } from '../../utils';
 
 export default abstract class GestureHandler implements IGestureHandler {
   private _name!: SingleGestureName;

--- a/packages/react-native-gesture-handler/src/web/handlers/HoverGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/HoverGestureHandler.ts
@@ -1,11 +1,11 @@
-import { State } from '../../State';
-import { AdaptedEvent } from '../interfaces';
-import GestureHandlerOrchestrator from '../tools/GestureHandlerOrchestrator';
+import type { AdaptedEvent } from '../interfaces';
 import GestureHandler from './GestureHandler';
-import { StylusData } from '../../handlers/gestureHandlerCommon';
-import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
-import IGestureHandler from './IGestureHandler';
+import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
+import GestureHandlerOrchestrator from '../tools/GestureHandlerOrchestrator';
+import type IGestureHandler from './IGestureHandler';
 import { SingleGestureName } from '../../v3/types';
+import { State } from '../../State';
+import type { StylusData } from '../../handlers/gestureHandlerCommon';
 
 export default class HoverGestureHandler extends GestureHandler {
   private stylusData: StylusData | undefined;

--- a/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
@@ -1,16 +1,16 @@
-import type { PointerType } from '../../PointerType';
 import type {
   ActiveCursor,
   MouseButton,
   TouchAction,
   UserSelect,
 } from '../../handlers/gestureHandlerCommon';
-import type { State } from '../../State';
 import type { Config } from '../interfaces';
 import type EventManager from '../tools/EventManager';
 import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 import type PointerTracker from '../tools/PointerTracker';
-import { SingleGestureName } from '../../v3/types';
+import type { PointerType } from '../../PointerType';
+import type { SingleGestureName } from '../../v3/types';
+import type { State } from '../../State';
 
 export default interface IGestureHandler {
   attached: boolean;

--- a/packages/react-native-gesture-handler/src/web/handlers/LongPressGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/LongPressGestureHandler.ts
@@ -1,11 +1,10 @@
-import { ActionType } from '../../ActionType';
-import { State } from '../../State';
-import { SingleGestureName } from '../../v3/types';
-import { AdaptedEvent, Config, PropsRef } from '../interfaces';
-import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
-
+import type { AdaptedEvent, Config, PropsRef } from '../interfaces';
+import type { ActionType } from '../../ActionType';
 import GestureHandler from './GestureHandler';
-import IGestureHandler from './IGestureHandler';
+import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
+import type IGestureHandler from './IGestureHandler';
+import { SingleGestureName } from '../../v3/types';
+import { State } from '../../State';
 
 const DEFAULT_MIN_DURATION_MS = 500;
 const DEFAULT_MAX_DIST_DP = 10;

--- a/packages/react-native-gesture-handler/src/web/handlers/ManualGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/ManualGestureHandler.ts
@@ -1,8 +1,8 @@
-import { SingleGestureName } from '../../v3/types';
-import { AdaptedEvent } from '../interfaces';
-import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
+import type { AdaptedEvent } from '../interfaces';
 import GestureHandler from './GestureHandler';
-import IGestureHandler from './IGestureHandler';
+import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
+import type IGestureHandler from './IGestureHandler';
+import { SingleGestureName } from '../../v3/types';
 
 export default class ManualGestureHandler extends GestureHandler {
   public constructor(

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -1,13 +1,12 @@
-import { Platform } from 'react-native';
-import { State } from '../../State';
+import type { AdaptedEvent, Config, PropsRef } from '../interfaces';
+import type { ActionType } from '../../ActionType';
 import { DEFAULT_TOUCH_SLOP } from '../constants';
-import { AdaptedEvent, Config, PropsRef } from '../interfaces';
-
 import GestureHandler from './GestureHandler';
-import { ActionType } from '../../ActionType';
-import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
-import IGestureHandler from './IGestureHandler';
+import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
+import type IGestureHandler from './IGestureHandler';
+import { Platform } from 'react-native';
 import { SingleGestureName } from '../../v3/types';
+import { State } from '../../State';
 export default class NativeViewGestureHandler extends GestureHandler {
   private buttonRole!: boolean;
 

--- a/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
@@ -1,12 +1,12 @@
-import { State } from '../../State';
+import type { AdaptedEvent, Config } from '../interfaces';
 import { DEFAULT_TOUCH_SLOP } from '../constants';
-import { AdaptedEvent, Config, WheelDevice } from '../interfaces';
-import { StylusData } from '../../handlers/gestureHandlerCommon';
-
 import GestureHandler from './GestureHandler';
-import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
-import IGestureHandler from './IGestureHandler';
+import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
+import type IGestureHandler from './IGestureHandler';
 import { SingleGestureName } from '../../v3/types';
+import { State } from '../../State';
+import type { StylusData } from '../../handlers/gestureHandlerCommon';
+import { WheelDevice } from '../interfaces';
 
 const DEFAULT_MIN_POINTERS = 1;
 const DEFAULT_MAX_POINTERS = 10;

--- a/packages/react-native-gesture-handler/src/web/handlers/PinchGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PinchGestureHandler.ts
@@ -1,15 +1,13 @@
-import { State } from '../../State';
+import type { AdaptedEvent, PropsRef } from '../interfaces';
+import type { ActionType } from '../../ActionType';
 import { DEFAULT_TOUCH_SLOP } from '../constants';
-import { AdaptedEvent, PropsRef } from '../interfaces';
-
 import GestureHandler from './GestureHandler';
-import ScaleGestureDetector, {
-  ScaleGestureListener,
-} from '../detectors/ScaleGestureDetector';
-import { ActionType } from '../../ActionType';
-import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
-import IGestureHandler from './IGestureHandler';
+import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
+import type IGestureHandler from './IGestureHandler';
+import ScaleGestureDetector from '../detectors/ScaleGestureDetector';
+import type { ScaleGestureListener } from '../detectors/ScaleGestureDetector';
 import { SingleGestureName } from '../../v3/types';
+import { State } from '../../State';
 
 export default class PinchGestureHandler extends GestureHandler {
   private scale = 1;

--- a/packages/react-native-gesture-handler/src/web/handlers/RotationGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/RotationGestureHandler.ts
@@ -1,14 +1,12 @@
-import { State } from '../../State';
-import { AdaptedEvent, PropsRef } from '../interfaces';
-
+import type { AdaptedEvent, PropsRef } from '../interfaces';
+import type { ActionType } from '../../ActionType';
 import GestureHandler from './GestureHandler';
-import RotationGestureDetector, {
-  RotationGestureListener,
-} from '../detectors/RotationGestureDetector';
-import { ActionType } from '../../ActionType';
-import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
-import IGestureHandler from './IGestureHandler';
+import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
+import type IGestureHandler from './IGestureHandler';
+import RotationGestureDetector from '../detectors/RotationGestureDetector';
+import type { RotationGestureListener } from '../detectors/RotationGestureDetector';
 import { SingleGestureName } from '../../v3/types';
+import { State } from '../../State';
 
 const ROTATION_RECOGNITION_THRESHOLD = Math.PI / 36;
 

--- a/packages/react-native-gesture-handler/src/web/handlers/TapGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/TapGestureHandler.ts
@@ -1,10 +1,10 @@
-import { State } from '../../State';
-import { SingleGestureName } from '../../v3/types';
-import { AdaptedEvent, Config, EventTypes } from '../interfaces';
-import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
-
+import type { AdaptedEvent, Config } from '../interfaces';
+import { EventTypes } from '../interfaces';
 import GestureHandler from './GestureHandler';
-import IGestureHandler from './IGestureHandler';
+import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
+import type IGestureHandler from './IGestureHandler';
+import { SingleGestureName } from '../../v3/types';
+import { State } from '../../State';
 
 const DEFAULT_MAX_DURATION_MS = 500;
 const DEFAULT_MAX_DELAY_MS = 500;

--- a/packages/react-native-gesture-handler/src/web/interfaces.ts
+++ b/packages/react-native-gesture-handler/src/web/interfaces.ts
@@ -1,18 +1,18 @@
-import {
-  UserSelect,
+import type {
   ActiveCursor,
-  MouseButton,
-  TouchAction,
-  StylusData,
   GestureTouchEvent,
+  MouseButton,
+  StylusData,
+  TouchAction,
+  UserSelect,
 } from '../handlers/gestureHandlerCommon';
-import { Directions } from '../Directions';
-import { PointerType } from '../PointerType';
-import {
+import type {
   GestureStateChangeEventWithHandlerData,
   GestureUpdateEventWithHandlerData,
 } from '../v3/types';
-import { State } from '../State';
+import type { Directions } from '../Directions';
+import type { PointerType } from '../PointerType';
+import type { State } from '../State';
 
 export interface HitSlop {
   left?: number | undefined;

--- a/packages/react-native-gesture-handler/src/web/tools/EventManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/EventManager.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { AdaptedEvent, EventTypes } from '../interfaces';
+import type { AdaptedEvent, EventTypes } from '../interfaces';
 
 type PointerEventCallback = (event: AdaptedEvent) => void;
 

--- a/packages/react-native-gesture-handler/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/GestureHandlerOrchestrator.ts
@@ -1,8 +1,7 @@
-import { PointerType } from '../../PointerType';
-import { State } from '../../State';
-
 import type IGestureHandler from '../handlers/IGestureHandler';
 import PointerTracker from './PointerTracker';
+import { PointerType } from '../../PointerType';
+import { State } from '../../State';
 
 export default class GestureHandlerOrchestrator {
   private static _instance: GestureHandlerOrchestrator;

--- a/packages/react-native-gesture-handler/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/GestureHandlerWebDelegate.ts
@@ -1,18 +1,18 @@
-import findNodeHandle from '../../findNodeHandle';
-import type IGestureHandler from '../handlers/IGestureHandler';
-import {
+import type {
   GestureHandlerDelegate,
   MeasureResult,
 } from './GestureHandlerDelegate';
-import PointerEventManager from './PointerEventManager';
-import { State } from '../../State';
-import { isPointerInBounds, getEffectiveBoundingRect } from '../utils';
-import EventManager from './EventManager';
-import { MouseButton } from '../../handlers/gestureHandlerCommon';
+import { getEffectiveBoundingRect, isPointerInBounds } from '../utils';
+import type EventManager from './EventManager';
+import type IGestureHandler from '../handlers/IGestureHandler';
 import KeyboardEventManager from './KeyboardEventManager';
-import WheelEventManager from './WheelEventManager';
-import { tagMessage } from '../../utils';
+import { MouseButton } from '../../handlers/gestureHandlerCommon';
+import PointerEventManager from './PointerEventManager';
 import { SingleGestureName } from '../../v3/types';
+import { State } from '../../State';
+import WheelEventManager from './WheelEventManager';
+import findNodeHandle from '../../findNodeHandle';
+import { tagMessage } from '../../utils';
 
 interface DefaultViewStyles {
   userSelect: string;

--- a/packages/react-native-gesture-handler/src/web/tools/InteractionManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/InteractionManager.ts
@@ -1,6 +1,7 @@
-import { GestureRelations, SingleGestureName } from '../../v3/types';
+import type { Config, Handler } from '../interfaces';
+import type { GestureRelations } from '../../v3/types';
 import type IGestureHandler from '../handlers/IGestureHandler';
-import { Config, Handler } from '../interfaces';
+import { SingleGestureName } from '../../v3/types';
 
 export default class InteractionManager {
   private static _instance: InteractionManager;

--- a/packages/react-native-gesture-handler/src/web/tools/KeyboardEventManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/KeyboardEventManager.ts
@@ -1,5 +1,6 @@
-import { AdaptedEvent, EventTypes } from '../interfaces';
+import type { AdaptedEvent } from '../interfaces';
 import EventManager from './EventManager';
+import { EventTypes } from '../interfaces';
 import { PointerType } from '../../PointerType';
 
 export default class KeyboardEventManager extends EventManager<HTMLElement> {

--- a/packages/react-native-gesture-handler/src/web/tools/NodeManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/NodeManager.ts
@@ -1,6 +1,6 @@
-import { ValueOf } from '../../typeUtils';
-import { Gestures } from '../Gestures';
+import type { Gestures } from '../Gestures';
 import type IGestureHandler from '../handlers/IGestureHandler';
+import type { ValueOf } from '../../typeUtils';
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export default abstract class NodeManager {

--- a/packages/react-native-gesture-handler/src/web/tools/PointerEventManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/PointerEventManager.ts
@@ -1,12 +1,13 @@
-import EventManager from './EventManager';
-import { AdaptedEvent, EventTypes, Point } from '../interfaces';
+import type { AdaptedEvent, Point } from '../interfaces';
 import {
   PointerTypeMapping,
   calculateViewScale,
-  tryExtractStylusData,
-  isPointerInBounds,
   getEffectiveBoundingRect,
+  isPointerInBounds,
+  tryExtractStylusData,
 } from '../utils';
+import EventManager from './EventManager';
+import { EventTypes } from '../interfaces';
 import { PointerType } from '../../PointerType';
 
 const POINTER_CAPTURE_EXCLUDE_LIST = new Set<string>(['SELECT', 'INPUT']);

--- a/packages/react-native-gesture-handler/src/web/tools/PointerTracker.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/PointerTracker.ts
@@ -1,4 +1,4 @@
-import { AdaptedEvent, Point } from '../interfaces';
+import type { AdaptedEvent, Point } from '../interfaces';
 import VelocityTracker from './VelocityTracker';
 
 export interface TrackerElement {

--- a/packages/react-native-gesture-handler/src/web/tools/Vector.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/Vector.ts
@@ -1,6 +1,6 @@
 import { DiagonalDirections, Directions } from '../../Directions';
 import { MINIMAL_RECOGNIZABLE_MAGNITUDE } from '../constants';
-import PointerTracker from './PointerTracker';
+import type PointerTracker from './PointerTracker';
 
 export default class Vector {
   private readonly x;

--- a/packages/react-native-gesture-handler/src/web/tools/VelocityTracker.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/VelocityTracker.ts
@@ -1,4 +1,4 @@
-import { AdaptedEvent } from '../interfaces';
+import type { AdaptedEvent } from '../interfaces';
 import CircularBuffer from './CircularBuffer';
 import LeastSquareSolver from './LeastSquareSolver';
 

--- a/packages/react-native-gesture-handler/src/web/tools/WheelEventManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/WheelEventManager.ts
@@ -1,5 +1,6 @@
+import type { AdaptedEvent } from '../interfaces';
 import EventManager from './EventManager';
-import { AdaptedEvent, EventTypes } from '../interfaces';
+import { EventTypes } from '../interfaces';
 import { PointerType } from '../../PointerType';
 
 export default class WheelEventManager extends EventManager<HTMLElement> {

--- a/packages/react-native-gesture-handler/src/web/utils.ts
+++ b/packages/react-native-gesture-handler/src/web/utils.ts
@@ -1,6 +1,6 @@
-import { PointerType } from '../PointerType';
 import type { GestureHandlerRef, Point, SVGRef } from './interfaces';
-import { StylusData } from '../handlers/gestureHandlerCommon';
+import { PointerType } from '../PointerType';
+import type { StylusData } from '../handlers/gestureHandlerCommon';
 
 // For display: contents elements (like the gesture detector wrapper), getBoundingClientRect
 // returns all zeros since the element has no box. Compute the bounding box from children instead.


### PR DESCRIPTION
## Description

This PR aims to add new eslint rules, that:

- Require sorted imports
- Require `type` when importing only types

As there would be too many changes, I've decided to split this into two PRs. This one will be base, similarly as in monorepo migration.

- https://github.com/software-mansion/react-native-gesture-handler/pull/4088
- https://github.com/software-mansion/react-native-gesture-handler/pull/4089

## Test plan

- `yarn lint-js`
- `yarn ts-check`

<img width="1069" height="482" alt="image" src="https://github.com/user-attachments/assets/5f4e79f6-ae0a-4ec4-9073-b23f89a0f569" />

