### PR TITLE
[General] Fix gestures becoming unresponsive after a fast refresh

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/callbacks/useReanimatedEventHandler.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/callbacks/useReanimatedEventHandler.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import type { ReanimatedHandler } from '../../../handlers/gestures/reanimatedWrapper';
 import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
@@ -9,6 +9,12 @@ import type {
   UnpackedGestureHandlerEventWithHandlerData,
 } from '../../types';
 import { eventHandler } from './eventHandler';
+
+const REANIMATED_EVENT_NAMES = [
+  'onGestureHandlerReanimatedEvent',
+  'onGestureHandlerReanimatedStateChange',
+  'onGestureHandlerReanimatedTouchEvent',
+];
 
 const workletNOOP = () => {
   'worklet';
@@ -59,14 +65,24 @@ export function useReanimatedEventHandler<
     );
   };
 
+  // Fast Refresh invalidates `useMemo` caches but preserves `useRef`, so the
+  // `handlerTag` computed with `useMemo([])` in `useGesture` can regenerate
+  // on FR. Without forcing a rebuild, the registered worklet keeps the old
+  // `handlerTag` in its closure and `isEventForHandlerWithTag` rejects every
+  // event emitted by the freshly-created native handler.
+  const prevHandlerTagRef = useRef(handlerTag);
+  const handlerTagChanged = prevHandlerTagRef.current !== handlerTag;
+
+  // Write after commit so interrupted or re-invoked renders don't desync the
+  // ref from what was actually committed.
+  useEffect(() => {
+    prevHandlerTagRef.current = handlerTag;
+  }, [handlerTag]);
+
   const reanimatedEvent = Reanimated?.useEvent(
     callback,
-    [
-      'onGestureHandlerReanimatedEvent',
-      'onGestureHandlerReanimatedStateChange',
-      'onGestureHandlerReanimatedTouchEvent',
-    ],
-    !!reanimatedHandler?.doDependenciesDiffer
+    REANIMATED_EVENT_NAMES,
+    handlerTagChanged || !!reanimatedHandler?.doDependenciesDiffer
   );
 
   return reanimatedEvent;


### PR DESCRIPTION
## Description

Fast refresh was able to make gestures unresponsive - Gesture Handler uses `useMemo` to store the handler tag, which gets invalidated on the fast refresh. Reanimated's `useHandler`/`useEvent` preserves their internal state, and the worklet event handler didn't rebuild. This caused a gesture with a new tag to use the event handler built for the previous tag, which was ignoring all incoming events.

This PR fixes this by tracking handler tag changes and rebuilding the event handler when it changes.

Supersedes https://github.com/software-mansion/react-native-gesture-handler/pull/3997

## Test plan

<details>
<summary>File1.tsx</summary>

```jsx
import React from 'react';
import { View } from 'react-native';
import { GestureDetector, useTapGesture } from 'react-native-gesture-handler';

function Test() {
  const gesture = useTapGesture({
    onActivate: () => {
      console.log('onActivate');
    },
  });

  const COMMENT_THIS = 2;

  return (
    <GestureDetector gesture={gesture}>
      <View style={{ width: 100, height: 100, backgroundColor: 'red' }} />
    </GestureDetector>
  );
}

export default Test;
```

</details>

<details>
<summary>File2.tsx</summary>

```jsx
import React from 'react';
import { GestureHandlerRootView } from 'react-native-gesture-handler';

import Test from './File1';

function Example() {
  return (
    <GestureHandlerRootView>
      <Test />
    </GestureHandlerRootView>
  );
}

export default Example;
```

</details>

1. Navigate to `File2`
2. Verify that tap works
3. Comment `COMMENT_THIS` and save `File1`
4. Check whether the tap works