### PR TITLE
[iOS] Fix button events with `numberOfPointers: 0`

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -685,10 +685,11 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
     } else {
       [self rngh_sendActionsForControlEvents:UIControlEventTouchUpOutside withEvent:event];
     }
+
+    _suppressSuperControlActionDispatch = YES;
   }
 
   _isTouchInsideBounds = NO;
-  _suppressSuperControlActionDispatch = YES;
 }
 
 - (BOOL)shouldHandleTouch:(RNGHUIView *)view atPoint:(CGPoint)point

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -41,6 +41,7 @@
  */
 @implementation RNGestureHandlerButton {
   BOOL _isTouchInsideBounds;
+  BOOL _suppressSuperControlActionDispatch;
   CALayer *_underlayLayer;
   CGFloat _underlayCornerRadii[8]; // [tlH, tlV, trH, trV, blH, blV, brH, brV] outer radii in points
   UIEdgeInsets _underlayBorderInsets; // border widths for padding-box inset
@@ -591,9 +592,52 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
   return [super beginTrackingWithTouch:touch withEvent:event];
 }
 
+// Mirrors `sendActionsForControlEvents:` but preserves the real `UIEvent`
+// so target-actions with a `forEvent:` parameter receive the touches.
+// The public `sendActionsForControlEvents:` passes a nil event, which would
+// make handlers reading `event.allTouches.count` observe 0 pointers.
+- (void)rngh_sendActionsForControlEvents:(UIControlEvents)controlEvents withEvent:(UIEvent *)event
+{
+  for (id target in [self allTargets]) {
+    for (NSString *actionName in [self actionsForTarget:target forControlEvent:controlEvents]) {
+      [self sendAction:NSSelectorFromString(actionName) to:target forEvent:event];
+    }
+  }
+}
+
+// UIControl's default `touchesMoved:` / `touchesEnded:` invoke
+// `{continue|end}TrackingWithTouch:` and THEN dispatch their own Drag* / Up*
+// actions via `sendAction:to:forEvent:` using Apple's 70-point retention-offset
+// hit-test. That double-fires our handlers (once from our manual dispatch in
+// the tracking hooks, once from UIControl's retention-offset path). We swallow
+// UIControl's dispatch via this override; the flag is armed by our tracking
+// hooks only after our own dispatch has already run.
+- (void)sendAction:(SEL)action to:(id)target forEvent:(UIEvent *)event
+{
+  if (_suppressSuperControlActionDispatch) {
+    return;
+  }
+  [super sendAction:action to:target forEvent:event];
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [super touchesMoved:touches withEvent:event];
+  _suppressSuperControlActionDispatch = NO;
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [super touchesEnded:touches withEvent:event];
+  _suppressSuperControlActionDispatch = NO;
+}
+
 - (BOOL)continueTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event
 {
-  // DO NOT call super. We are entirely taking over the drag event generation.
+  // We take over drag event generation to enforce strict hitslop bounds
+  // (bypassing Apple's retention offset). After our dispatch, set the
+  // suppress flag so UIControl's default post-tracking dispatch in
+  // `touchesMoved:` gets swallowed by our `sendAction:to:forEvent:` override.
 
   CGPoint location = [touch locationInView:self];
   CGRect hitFrame = UIEdgeInsetsInsetRect(self.bounds, self.hitTestEdgeInsets);
@@ -601,25 +645,27 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
 
   if (currentlyInside) {
     if (!_isTouchInsideBounds) {
-      [self sendActionsForControlEvents:UIControlEventTouchDragEnter];
+      [self rngh_sendActionsForControlEvents:UIControlEventTouchDragEnter withEvent:event];
       _isTouchInsideBounds = YES;
     }
 
     // Targets may call `cancelTrackingWithEvent:` in response to DragEnter.
     if (self.tracking) {
-      [self sendActionsForControlEvents:UIControlEventTouchDragInside];
+      [self rngh_sendActionsForControlEvents:UIControlEventTouchDragInside withEvent:event];
     }
   } else {
     if (_isTouchInsideBounds) {
-      [self sendActionsForControlEvents:UIControlEventTouchDragExit];
+      [self rngh_sendActionsForControlEvents:UIControlEventTouchDragExit withEvent:event];
       _isTouchInsideBounds = NO;
     }
 
     // Targets may call `cancelTrackingWithEvent:` in response to DragExit.
     if (self.tracking) {
-      [self sendActionsForControlEvents:UIControlEventTouchDragOutside];
+      [self rngh_sendActionsForControlEvents:UIControlEventTouchDragOutside withEvent:event];
     }
   }
+
+  _suppressSuperControlActionDispatch = YES;
 
   // If `cancelTrackingWithEvent` was called, `self.tracking` will be NO.
   return self.tracking;
@@ -627,20 +673,22 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
 
 - (void)endTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event
 {
-  // Also bypass super here so that the final "up" event respects the
-  // strict bounds, rather than Apple's 70-point.
+  // Same rationale as `continueTrackingWithTouch:` — we dispatch the final
+  // Up* event ourselves using strict hitslop bounds, then set the suppress
+  // flag so UIControl's default dispatch in `touchesEnded:` gets swallowed.
 
   if (touch != nil) {
     CGPoint location = [touch locationInView:self];
     CGRect hitFrame = UIEdgeInsetsInsetRect(self.bounds, self.hitTestEdgeInsets);
     if (CGRectContainsPoint(hitFrame, location)) {
-      [self sendActionsForControlEvents:UIControlEventTouchUpInside];
+      [self rngh_sendActionsForControlEvents:UIControlEventTouchUpInside withEvent:event];
     } else {
-      [self sendActionsForControlEvents:UIControlEventTouchUpOutside];
+      [self rngh_sendActionsForControlEvents:UIControlEventTouchUpOutside withEvent:event];
     }
   }
 
   _isTouchInsideBounds = NO;
+  _suppressSuperControlActionDispatch = YES;
 }
 
 - (BOOL)shouldHandleTouch:(RNGHUIView *)view atPoint:(CGPoint)point


### PR DESCRIPTION
## Description

After https://github.com/software-mansion/react-native-gesture-handler/pull/4038, the button started emitting duplicated events with `numberOfPointers: 0` when moving a pointer. This PR addresses that issue.

## Test plan

Add `onUpdate={console.log}` to the `Touchable` implementation, drag over any `Touchable` component, and inspect the logs. Before:
```
 LOG  onUpdate {"handlerTag":50,"pointerType":0,"numberOfPointers":1,"pointerInside":1}
 LOG  onUpdate {"handlerTag":50,"pointerType":0,"numberOfPointers":0,"pointerInside":1}
 LOG  onUpdate {"handlerTag":50,"pointerType":0,"numberOfPointers":1,"pointerInside":1}
 LOG  onUpdate {"handlerTag":50,"pointerType":0,"numberOfPointers":0,"pointerInside":1}
 LOG  onUpdate {"handlerTag":50,"pointerType":0,"numberOfPointers":1,"pointerInside":1}
 LOG  onUpdate {"handlerTag":50,"pointerType":0,"numberOfPointers":0,"pointerInside":1}
 LOG  onUpdate {"handlerTag":50,"pointerType":0,"numberOfPointers":1,"pointerInside":1}
```

After:
```
 LOG  onUpdate {"handlerTag":50,"pointerType":0,"numberOfPointers":1,"pointerInside":1}
 LOG  onUpdate {"handlerTag":50,"pointerType":0,"numberOfPointers":1,"pointerInside":1}
 LOG  onUpdate {"handlerTag":50,"pointerType":0,"numberOfPointers":1,"pointerInside":1}
 LOG  onUpdate {"handlerTag":50,"pointerType":0,"numberOfPointers":1,"pointerInside":1}
```
