### PR TITLE
[General] Remove `onActiveStateChange` from `Touchable`

### DIFF
--- a/packages/docs-gesture-handler/docs/components/touchable.mdx
+++ b/packages/docs-gesture-handler/docs/components/touchable.mdx
@@ -285,14 +285,6 @@ onLongPress?: () => void;
 Triggered when the button gets pressed for at least [`delayLongPress`](#delaylongpress) milliseconds.
 
 
-### onActiveStateChange
-
-```ts
-onActiveStateChange?: (active: boolean) => void;
-```
-
-Triggered when the button transitions between active and inactive states. It passes the current active state as a boolean variable to the method as the first parameter.
-
 ### delayLongPress
 
 ```ts

--- a/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
@@ -107,31 +107,6 @@ describe('[API v3] Components', () => {
       expect(pressFn).not.toHaveBeenCalled();
     });
 
-    test('calls onActiveStateChange with correct values', () => {
-      const activeStateFn = jest.fn();
-
-      const Example = () => (
-        <GestureHandlerRootView>
-          <Touchable testID="touchable" onActiveStateChange={activeStateFn} />
-        </GestureHandlerRootView>
-      );
-
-      render(<Example />);
-      const gesture = getByGestureTestId('touchable');
-
-      act(() => {
-        fireGestureHandler(gesture, [
-          { oldState: State.UNDETERMINED, state: State.BEGAN },
-          { oldState: State.BEGAN, state: State.ACTIVE },
-          { oldState: State.ACTIVE, state: State.END },
-        ]);
-      });
-
-      expect(activeStateFn).toHaveBeenCalledTimes(2);
-      expect(activeStateFn).toHaveBeenNthCalledWith(1, true);
-      expect(activeStateFn).toHaveBeenNthCalledWith(2, false);
-    });
-
     test('calls onLongPress after delayLongPress and suppresses onPress', () => {
       jest.useFakeTimers();
 

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -32,7 +32,6 @@ export const Touchable = (props: TouchableProps) => {
     onPress,
     onPressIn,
     onPressOut,
-    onActiveStateChange,
     children,
     disabled = false,
     ref,
@@ -71,27 +70,20 @@ export const Touchable = (props: TouchableProps) => {
     [startLongPressTimer, onPressIn]
   );
 
-  const onActivate = useCallback(
-    (e: CallbackEventType) => {
-      onActiveStateChange?.(true);
-
-      if (!e.pointerInside && longPressTimeout.current !== undefined) {
-        clearTimeout(longPressTimeout.current);
-        longPressTimeout.current = undefined;
-      }
-    },
-    [onActiveStateChange]
-  );
+  const onActivate = useCallback((e: CallbackEventType) => {
+    if (!e.pointerInside && longPressTimeout.current !== undefined) {
+      clearTimeout(longPressTimeout.current);
+      longPressTimeout.current = undefined;
+    }
+  }, []);
 
   const onDeactivate = useCallback(
     (e: EndCallbackEventType) => {
-      onActiveStateChange?.(false);
-
       if (!e.canceled && !longPressDetected.current) {
         onPress?.(e.pointerInside);
       }
     },
-    [onActiveStateChange, onPress]
+    [onPress]
   );
 
   const onFinalize = useCallback(

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
@@ -18,7 +18,7 @@ type PressableAndroidRippleConfig = {
 type RippleProps = 'rippleColor' | 'rippleRadius' | 'borderless' | 'foreground';
 
 export type TouchableProps = Omit<ButtonProps, RippleProps | 'enabled'> &
-  Omit<BaseButtonProps, keyof RawButtonProps> & {
+  Omit<BaseButtonProps, keyof RawButtonProps | 'onActiveStateChange'> & {
     /**
      * Configuration for the ripple effect on Android.
      */


### PR DESCRIPTION
## Description

Removes `onActiveStateChange` from the `Touchable` component. With `onPressIn` and `onPressOut`, this callback seems redundant and confusing since the state transitions regarding the button are inconsistent between platforms.

## Test plan

Static checks
