### PR TITLE
[General] Don't emit duplicate events for `NativeViewGestureHandler`

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -31,6 +31,10 @@ class NativeViewGestureHandler : GestureHandler() {
 
   private var hook: NativeViewGestureHandlerHook = defaultHook
 
+  private data class ActiveUpdateSnapshot(val pointerInside: Boolean, val numberOfPointers: Int, val pointerType: Int)
+
+  private var lastActiveUpdate: ActiveUpdateSnapshot? = null
+
   init {
     shouldCancelWhenOutside = true
   }
@@ -163,6 +167,21 @@ class NativeViewGestureHandler : GestureHandler() {
 
   override fun onReset() {
     this.hook = defaultHook
+    lastActiveUpdate = null
+  }
+
+  override fun dispatchHandlerUpdate(event: MotionEvent) {
+    val snapshot = ActiveUpdateSnapshot(isWithinBounds, numberOfPointers, pointerType)
+    if (snapshot == lastActiveUpdate) {
+      return
+    }
+    lastActiveUpdate = snapshot
+    super.dispatchHandlerUpdate(event)
+  }
+
+  override fun dispatchStateChange(newState: Int, prevState: Int) {
+    lastActiveUpdate = null
+    super.dispatchStateChange(newState, prevState)
   }
 
   override fun wantsToAttachDirectlyToView() = true

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -113,6 +113,7 @@
 @implementation RNNativeViewGestureHandler {
   BOOL _shouldActivateOnStart;
   BOOL _disallowInterruption;
+  RNGestureHandlerEventExtraData *_lastActiveExtraData;
 }
 
 - (instancetype)initWithTag:(NSNumber *)tag
@@ -180,6 +181,16 @@
   [super unbindFromView];
 }
 
+- (void)sendActiveStateEventIfChangedForView:(UIView *)sender extraData:(RNGestureHandlerEventExtraData *)extraData
+{
+  if ([_lastActiveExtraData.data isEqualToDictionary:extraData.data]) {
+    return;
+  }
+
+  _lastActiveExtraData = extraData;
+  [self sendEventsInState:RNGestureHandlerStateActive forViewWithTag:sender.reactTag withExtraData:extraData];
+}
+
 - (void)handleTouchDown:(UIView *)sender forEvent:(UIEvent *)event
 {
   [self setCurrentPointerTypeForEvent:event];
@@ -202,11 +213,11 @@
                                                        withNumberOfTouches:event.allTouches.count
                                                            withPointerType:_pointerType]];
 
-  [self sendEventsInState:RNGestureHandlerStateActive
-           forViewWithTag:sender.reactTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES
-                                                       withNumberOfTouches:event.allTouches.count
-                                                           withPointerType:_pointerType]];
+  _lastActiveExtraData = nil;
+  [self sendActiveStateEventIfChangedForView:sender
+                                   extraData:[RNGestureHandlerEventExtraData forPointerInside:YES
+                                                                          withNumberOfTouches:event.allTouches.count
+                                                                              withPointerType:_pointerType]];
 }
 
 - (void)handleTouchUpOutside:(UIView *)sender forEvent:(UIEvent *)event
@@ -238,30 +249,27 @@
     UIControl *control = (UIControl *)sender;
     [control cancelTrackingWithEvent:event];
   } else {
-    [self sendEventsInState:RNGestureHandlerStateActive
-             forViewWithTag:sender.reactTag
-              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO
-                                                         withNumberOfTouches:event.allTouches.count
-                                                             withPointerType:_pointerType]];
+    [self sendActiveStateEventIfChangedForView:sender
+                                     extraData:[RNGestureHandlerEventExtraData forPointerInside:NO
+                                                                            withNumberOfTouches:event.allTouches.count
+                                                                                withPointerType:_pointerType]];
   }
 }
 
 - (void)handleDragEnter:(UIView *)sender forEvent:(UIEvent *)event
 {
-  [self sendEventsInState:RNGestureHandlerStateActive
-           forViewWithTag:sender.reactTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES
-                                                       withNumberOfTouches:event.allTouches.count
-                                                           withPointerType:_pointerType]];
+  [self sendActiveStateEventIfChangedForView:sender
+                                   extraData:[RNGestureHandlerEventExtraData forPointerInside:YES
+                                                                          withNumberOfTouches:event.allTouches.count
+                                                                              withPointerType:_pointerType]];
 }
 
 - (void)handleDragInside:(UIView *)sender forEvent:(UIEvent *)event
 {
-  [self sendEventsInState:RNGestureHandlerStateActive
-           forViewWithTag:sender.reactTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES
-                                                       withNumberOfTouches:event.allTouches.count
-                                                           withPointerType:_pointerType]];
+  [self sendActiveStateEventIfChangedForView:sender
+                                   extraData:[RNGestureHandlerEventExtraData forPointerInside:YES
+                                                                          withNumberOfTouches:event.allTouches.count
+                                                                              withPointerType:_pointerType]];
 }
 
 - (void)handleDragOutside:(UIView *)sender forEvent:(UIEvent *)event
@@ -270,11 +278,10 @@
     return;
   }
 
-  [self sendEventsInState:RNGestureHandlerStateActive
-           forViewWithTag:sender.reactTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO
-                                                       withNumberOfTouches:event.allTouches.count
-                                                           withPointerType:_pointerType]];
+  [self sendActiveStateEventIfChangedForView:sender
+                                   extraData:[RNGestureHandlerEventExtraData forPointerInside:NO
+                                                                          withNumberOfTouches:event.allTouches.count
+                                                                              withPointerType:_pointerType]];
 }
 
 - (void)handleTouchCancel:(UIView *)sender forEvent:(UIEvent *)event

--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -14,6 +14,7 @@ import { tagMessage } from '../../utils';
 import type {
   GestureStateChangeEventWithHandlerData,
   GestureUpdateEventWithHandlerData,
+  HandlerData,
   SingleGestureName,
 } from '../../v3/types';
 import type {
@@ -430,11 +431,13 @@ export default abstract class GestureHandler implements IGestureHandler {
       onGestureHandlerReanimatedStateChange,
     }: PropsRef = this.propsRef!.current;
 
+    const isStateChange = this.lastSentState !== newState;
+
     const resultEvent: ResultEvent = !usesNativeOrVirtualDetector(
       this.actionType
     )
       ? this.transformEventData(newState, oldState)
-      : this.lastSentState !== newState
+      : isStateChange
         ? this.transformStateChangeEvent(newState, oldState)
         : this.transformUpdateEvent(newState);
 
@@ -442,7 +445,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     // Here the order is flipped to avoid workarounds such as making backup of the state and setting it to undefined first, then changing it back
     // Flipping order with setting oldState to undefined solves issue, when events were being sent twice instead of once
     // However, this may cause trouble in the future (but for now we don't know that)
-    if (this.lastSentState !== newState) {
+    if (isStateChange) {
       this.lastSentState = newState;
 
       if (this.forReanimated) {
@@ -456,6 +459,16 @@ export default abstract class GestureHandler implements IGestureHandler {
       return;
     }
 
+    // Cover only V3 path due to different event shape
+    if (!isStateChange && usesNativeOrVirtualDetector(this.actionType)) {
+      const handlerData = (
+        resultEvent.nativeEvent as GestureUpdateEventWithHandlerData<unknown>
+      ).handlerData;
+      if (this.shouldSuppressActiveUpdate(handlerData)) {
+        return;
+      }
+    }
+
     (resultEvent.nativeEvent as GestureHandlerNativeEvent).oldState = undefined;
 
     if (this.forReanimated) {
@@ -466,6 +479,12 @@ export default abstract class GestureHandler implements IGestureHandler {
       onGestureHandlerEvent?.(resultEvent);
     }
   };
+
+  protected shouldSuppressActiveUpdate(
+    _handlerData: HandlerData<unknown>
+  ): boolean {
+    return false;
+  }
 
   private transformEventData(
     newState: State,

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -209,14 +209,13 @@ export default class NativeViewGestureHandler extends GestureHandler {
   protected override shouldSuppressActiveUpdate(
     handlerData: HandlerData<NativeHandlerData>
   ): boolean {
-    const current = handlerData;
     if (
       this.lastActiveHandlerData &&
-      deepEqual(this.lastActiveHandlerData, current)
+      deepEqual(this.lastActiveHandlerData, handlerData)
     ) {
       return true;
     }
-    this.lastActiveHandlerData = current;
+    this.lastActiveHandlerData = handlerData;
     return false;
   }
 

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -2,6 +2,8 @@ import { Platform } from 'react-native';
 
 import type { ActionType } from '../../ActionType';
 import { State } from '../../State';
+import { deepEqual } from '../../utils';
+import type { HandlerData } from '../../v3/types';
 import { SingleGestureName } from '../../v3/types';
 import { DEFAULT_TOUCH_SLOP } from '../constants';
 import type { AdaptedEvent, Config, PropsRef } from '../interfaces';
@@ -19,6 +21,8 @@ export default class NativeViewGestureHandler extends GestureHandler {
   private startX = 0;
   private startY = 0;
   private minDistSq = DEFAULT_TOUCH_SLOP * DEFAULT_TOUCH_SLOP;
+
+  private lastActiveHandlerData: Record<string, unknown> | null = null;
 
   public constructor(
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>
@@ -198,5 +202,24 @@ export default class NativeViewGestureHandler extends GestureHandler {
         this.tracker.getAbsoluteCoordsAverage()
       ),
     };
+  }
+
+  protected override shouldSuppressActiveUpdate(
+    handlerData: HandlerData<unknown>
+  ): boolean {
+    const current = handlerData as Record<string, unknown>;
+    if (
+      this.lastActiveHandlerData &&
+      deepEqual(this.lastActiveHandlerData, current)
+    ) {
+      return true;
+    }
+    this.lastActiveHandlerData = current;
+    return false;
+  }
+
+  public override reset(): void {
+    super.reset();
+    this.lastActiveHandlerData = null;
   }
 }

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 import type { ActionType } from '../../ActionType';
 import { State } from '../../State';
 import { deepEqual } from '../../utils';
+import type { NativeHandlerData } from '../../v3/hooks/gestures/native/NativeTypes';
 import type { HandlerData } from '../../v3/types';
 import { SingleGestureName } from '../../v3/types';
 import { DEFAULT_TOUCH_SLOP } from '../constants';
@@ -10,6 +11,7 @@ import type { AdaptedEvent, Config, PropsRef } from '../interfaces';
 import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 import GestureHandler from './GestureHandler';
 import type IGestureHandler from './IGestureHandler';
+
 export default class NativeViewGestureHandler extends GestureHandler {
   private buttonRole!: boolean;
 
@@ -22,7 +24,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
   private startY = 0;
   private minDistSq = DEFAULT_TOUCH_SLOP * DEFAULT_TOUCH_SLOP;
 
-  private lastActiveHandlerData: Record<string, unknown> | null = null;
+  private lastActiveHandlerData: HandlerData<NativeHandlerData> | null = null;
 
   public constructor(
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>
@@ -205,9 +207,9 @@ export default class NativeViewGestureHandler extends GestureHandler {
   }
 
   protected override shouldSuppressActiveUpdate(
-    handlerData: HandlerData<unknown>
+    handlerData: HandlerData<NativeHandlerData>
   ): boolean {
-    const current = handlerData as Record<string, unknown>;
+    const current = handlerData;
     if (
       this.lastActiveHandlerData &&
       deepEqual(this.lastActiveHandlerData, current)


### PR DESCRIPTION
## Description

Updates `NativeViewGestureHandler` not to emit update event on every pointer move unless the payload would change. This significantly reduces the number of events dispatched by the native gesture handlers, which should have a positive impact on performance without causing any information loss.

Supersedes https://github.com/software-mansion/react-native-gesture-handler/pull/3348

## Test plan

Add `onUpdate={console.log}` to the internal `Touchable` implementation and check any example using `Touchable`.
