### PR TITLE
Deprecate builder API

### DIFF
--- a/packages/react-native-gesture-handler/src/handlers/gestures/flingGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/flingGesture.ts
@@ -4,7 +4,7 @@ import type { BaseGestureConfig } from './gesture';
 import { BaseGesture } from './gesture';
 
 /**
- * @deprecated Fling Gesture is deprecated and will be removed in the future. Please use `useFlingGesture` instead.
+ * @deprecated `FlingGesture` is deprecated and will be removed in the future. Please use `useFlingGesture` instead.
  */
 export class FlingGesture extends BaseGesture<FlingGestureHandlerEventPayload> {
   public override config: BaseGestureConfig & FlingGestureConfig = {};
@@ -38,6 +38,6 @@ export class FlingGesture extends BaseGesture<FlingGestureHandlerEventPayload> {
 }
 
 /**
- * @deprecated Fling Gesture is deprecated and will be removed in the future. Please use `useFlingGesture` instead.
+ * @deprecated `FlingGestureType` is deprecated and will be removed in the future. Please use `FlingGesture` instead.
  */
 export type FlingGestureType = InstanceType<typeof FlingGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/flingGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/flingGesture.ts
@@ -3,6 +3,9 @@ import type { FlingGestureHandlerEventPayload } from '../GestureHandlerEventPayl
 import type { BaseGestureConfig } from './gesture';
 import { BaseGesture } from './gesture';
 
+/**
+ * @deprecated Fling Gesture is deprecated and will be removed in the future. Please use `useFlingGesture` instead.
+ */
 export class FlingGesture extends BaseGesture<FlingGestureHandlerEventPayload> {
   public override config: BaseGestureConfig & FlingGestureConfig = {};
 
@@ -34,4 +37,7 @@ export class FlingGesture extends BaseGesture<FlingGestureHandlerEventPayload> {
   }
 }
 
+/**
+ * @deprecated Fling Gesture is deprecated and will be removed in the future. Please use `useFlingGesture` instead.
+ */
 export type FlingGestureType = InstanceType<typeof FlingGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/forceTouchGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/forceTouchGesture.ts
@@ -5,7 +5,7 @@ import type { BaseGestureConfig } from './gesture';
 import { ContinousBaseGesture } from './gesture';
 
 /**
- * @deprecated ForceTouch gesture is deprecated and will be removed in the future.
+ * @deprecated `ForceTouchGestureChangeEventPayload` is deprecated and will be removed in the future.
  */
 export type ForceTouchGestureChangeEventPayload = {
   forceChange: number;
@@ -31,7 +31,7 @@ function changeEventCalculator(
 }
 
 /**
- * @deprecated ForceTouch gesture is deprecated and will be removed in the future.
+ * @deprecated `ForceTouchGesture` is deprecated and will be removed in the future.
  */
 export class ForceTouchGesture extends ContinousBaseGesture<
   ForceTouchGestureHandlerEventPayload,
@@ -91,6 +91,6 @@ export class ForceTouchGesture extends ContinousBaseGesture<
 }
 
 /**
- * @deprecated ForceTouch gesture is deprecated and will be removed in the future.
+ * @deprecated `ForceTouchGestureType` is deprecated and will be removed in the future.
  */
 export type ForceTouchGestureType = InstanceType<typeof ForceTouchGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
@@ -23,7 +23,7 @@ import { getNextHandlerTag } from '../getNextHandlerTag';
 import type { GestureStateManagerType } from './gestureStateManager';
 
 /**
- * @deprecated Gesture is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ * @deprecated `GestureType` is deprecated and will be removed in the future. Please use `SingleGesture` instead.
  */
 export type GestureType =
   | BaseGesture<Record<string, unknown>>
@@ -39,7 +39,7 @@ export type GestureType =
   | BaseGesture<HoverGestureHandlerEventPayload>;
 
 /**
- *  @deprecated GestureRef is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ * @deprecated `GestureRef` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
  */
 export type GestureRef =
   | number

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
@@ -39,7 +39,7 @@ export type GestureType =
   | BaseGesture<HoverGestureHandlerEventPayload>;
 
 /**
- * @deprecated `GestureRef` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ * @deprecated `GestureRef` is deprecated and will be removed in the future.
  */
 export type GestureRef =
   | number

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
@@ -22,6 +22,9 @@ import type {
 import { getNextHandlerTag } from '../getNextHandlerTag';
 import type { GestureStateManagerType } from './gestureStateManager';
 
+/**
+ * @deprecated Gesture is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ */
 export type GestureType =
   | BaseGesture<Record<string, unknown>>
   | BaseGesture<Record<string, never>>
@@ -35,6 +38,9 @@ export type GestureType =
   | BaseGesture<NativeViewGestureHandlerPayload>
   | BaseGesture<HoverGestureHandlerEventPayload>;
 
+/**
+ *  @deprecated GestureRef is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ */
 export type GestureRef =
   | number
   | GestureType

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureComposition.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureComposition.ts
@@ -119,7 +119,19 @@ export class ExclusiveGesture extends ComposedGesture {
   }
 }
 
+/**
+ * @deprecated `ComposedGestureType` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ */
 export type ComposedGestureType = InstanceType<typeof ComposedGesture>;
+/**
+ * @deprecated `RaceGestureType` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ */
 export type RaceGestureType = ComposedGestureType;
+/**
+ * @deprecated `SimultaneousGestureType` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ */
 export type SimultaneousGestureType = InstanceType<typeof SimultaneousGesture>;
+/**
+ * @deprecated `ExclusiveGestureType` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ */
 export type ExclusiveGestureType = InstanceType<typeof ExclusiveGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureComposition.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureComposition.ts
@@ -12,6 +12,9 @@ function extendRelation(
   }
 }
 
+/**
+ * @deprecated `ComposedGesture` is deprecated and will be removed in the future. Please use `useCompetingGestures` instead.
+ */
 export class ComposedGesture extends Gesture {
   protected gestures: Gesture[] = [];
   protected simultaneousGestures: GestureType[] = [];
@@ -70,6 +73,9 @@ export class ComposedGesture extends Gesture {
   }
 }
 
+/**
+ * @deprecated `SimultaneousGesture` is deprecated and will be removed in the future. Please use `useSimultaneousGestures` instead.
+ */
 export class SimultaneousGesture extends ComposedGesture {
   override prepare() {
     // This piece of magic works something like this:
@@ -96,6 +102,9 @@ export class SimultaneousGesture extends ComposedGesture {
   }
 }
 
+/**
+ * @deprecated `ExclusiveGesture` is deprecated and will be removed in the future. Please use `useExclusiveGestures` instead.
+ */
 export class ExclusiveGesture extends ComposedGesture {
   override prepare() {
     // Transforms the array of gestures into array of grouped raw (not composed) gestures
@@ -120,18 +129,18 @@ export class ExclusiveGesture extends ComposedGesture {
 }
 
 /**
- * @deprecated `ComposedGestureType` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ * @deprecated `ComposedGestureType` is deprecated and will be removed in the future. Please use `ComposedGesture` instead.
  */
 export type ComposedGestureType = InstanceType<typeof ComposedGesture>;
 /**
- * @deprecated `RaceGestureType` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ * @deprecated `RaceGestureType` is deprecated and will be removed in the future. Please use `ComposedGesture` instead.
  */
 export type RaceGestureType = ComposedGestureType;
 /**
- * @deprecated `SimultaneousGestureType` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ * @deprecated `SimultaneousGestureType` is deprecated and will be removed in the future. Please use `ComposedGesture` instead.
  */
 export type SimultaneousGestureType = InstanceType<typeof SimultaneousGesture>;
 /**
- * @deprecated `ExclusiveGestureType` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ * @deprecated `ExclusiveGestureType` is deprecated and will be removed in the future. Please use `ComposedGesture` instead.
  */
 export type ExclusiveGestureType = InstanceType<typeof ExclusiveGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureObjects.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureObjects.ts
@@ -16,6 +16,8 @@ import { RotationGesture } from './rotationGesture';
 import { TapGesture } from './tapGesture';
 
 /**
+ * @deprecated Gestures created with builder API are deprecated and will be removed in a future version of Gesture Handler. Please migrate to the new, hook-based API.
+ *
  * `Gesture` is the object that allows you to create and compose gestures.
  *
  * ### Remarks
@@ -25,6 +27,8 @@ import { TapGesture } from './tapGesture';
  */
 export const GestureObjects = {
   /**
+   * @deprecated Tap Gesture is deprecated and will be removed in the future. Please use `useTapGesture` instead.
+   *
    * A discrete gesture that recognizes one or many taps.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/tap-gesture
    */
@@ -33,6 +37,8 @@ export const GestureObjects = {
   },
 
   /**
+   * @deprecated Pan Gesture is deprecated and will be removed in the future. Please use `usePanGesture` instead.
+   *
    * A continuous gesture that can recognize a panning (dragging) gesture and track its movement.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture
    */
@@ -41,6 +47,8 @@ export const GestureObjects = {
   },
 
   /**
+   * @deprecated Pinch Gesture is deprecated and will be removed in the future. Please use `usePinchGesture` instead.
+   *
    * A continuous gesture that recognizes pinch gesture. It allows for tracking the distance between two fingers and use that information to scale or zoom your content.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pinch-gesture
    */
@@ -49,6 +57,8 @@ export const GestureObjects = {
   },
 
   /**
+   * @deprecated Rotation Gesture is deprecated and will be removed in the future. Please use `useRotationGesture` instead.
+   *
    * A continuous gesture that can recognize rotation and track its movement.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/rotation-gesture
    */
@@ -57,6 +67,8 @@ export const GestureObjects = {
   },
 
   /**
+   * @deprecated Fling Gesture is deprecated and will be removed in the future. Please use `useFlingGesture` instead.
+   *
    * A discrete gesture that activates when the movement is sufficiently fast.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/fling-gesture
    */
@@ -65,6 +77,8 @@ export const GestureObjects = {
   },
 
   /**
+   * @deprecated Long Press Gesture is deprecated and will be removed in the future. Please use `useLongPressGesture` instead.
+   *
    * A discrete gesture that activates when the corresponding view is pressed for a sufficiently long time.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/long-press-gesture
    */
@@ -84,6 +98,8 @@ export const GestureObjects = {
   },
 
   /**
+   * @deprecated Native Gesture is deprecated and will be removed in the future. Please use `useNativeGesture` instead.
+   *
    * A gesture that allows other touch handling components to participate in RNGH's gesture system.
    * When used, the other component should be the direct child of a `GestureDetector`.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/native-gesture
@@ -93,6 +109,8 @@ export const GestureObjects = {
   },
 
   /**
+   * @deprecated Manual Gesture is deprecated and will be removed in the future. Please use `useManualGesture` instead.
+   *
    * A plain gesture that has no specific activation criteria nor event data set.
    * Its state has to be controlled manually using a state manager.
    * It will not fail when all the pointers are lifted from the screen.
@@ -103,6 +121,8 @@ export const GestureObjects = {
   },
 
   /**
+   * @deprecated Hover Gesture is deprecated and will be removed in the future. Please use `useHoverGesture` instead.
+   *
    * A continuous gesture that can recognize hovering above the view it's attached to.
    * The hover effect may be activated by moving a mouse or a stylus over the view.
    *
@@ -113,6 +133,8 @@ export const GestureObjects = {
   },
 
   /**
+   * @deprecated Race Gesture is deprecated and will be removed in the future. Please use `useCompetingGestures` instead.
+   *
    * Builds a composed gesture consisting of gestures provided as parameters.
    * The first one that becomes active cancels the rest of gestures.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/gesture-composition/#race
@@ -122,6 +144,8 @@ export const GestureObjects = {
   },
 
   /**
+   * @deprecated Simultaneous Gesture is deprecated and will be removed in the future. Please use `useSimultaneousGestures` instead.
+   *
    * Builds a composed gesture that allows all base gestures to run simultaneously.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/gesture-composition/#simultaneous
    */
@@ -130,6 +154,8 @@ export const GestureObjects = {
   },
 
   /**
+   * @deprecated Exclusive Gesture is deprecated and will be removed in the future. Please use `useExclusiveGestures` instead.
+   *
    * Builds a composed gesture where only one of the provided gestures can become active.
    * Priority is decided through the order of gestures: the first one has higher priority
    * than the second one, second one has higher priority than the third one, and so on.

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureObjects.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureObjects.ts
@@ -87,7 +87,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated `Gesture.ForceTouch()` is deprecated and will be removed in the future. Please use `useForceTouchGesture` instead.
+   * @deprecated `Gesture.ForceTouch()` is deprecated and will be removed in the future.
    *
    *  #### iOS only
    * A continuous gesture that recognizes force of a touch. It allows for tracking pressure of touch on some iOS devices.
@@ -98,7 +98,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated `Gesture.Native()` is deprecated and will be removed in the future.
+   * @deprecated `Gesture.Native()` is deprecated and will be removed in the future. Please use `useNativeGesture` instead.
    *
    * A gesture that allows other touch handling components to participate in RNGH's gesture system.
    * When used, the other component should be the direct child of a `GestureDetector`.

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureObjects.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureObjects.ts
@@ -98,7 +98,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated `Gesture.Native()` is deprecated and will be removed in the future. Please use `useNativeGesture` instead.
+   * @deprecated `Gesture.Native()` is deprecated and will be removed in the future.
    *
    * A gesture that allows other touch handling components to participate in RNGH's gesture system.
    * When used, the other component should be the direct child of a `GestureDetector`.

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureObjects.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureObjects.ts
@@ -16,7 +16,7 @@ import { RotationGesture } from './rotationGesture';
 import { TapGesture } from './tapGesture';
 
 /**
- * @deprecated Gestures created with builder API are deprecated and will be removed in a future version of Gesture Handler. Please migrate to the new, hook-based API.
+ * @deprecated `Gesture` builder API is deprecated and will be removed in a future version of Gesture Handler. Please migrate to the new, hook-based API.
  *
  * `Gesture` is the object that allows you to create and compose gestures.
  *
@@ -27,7 +27,7 @@ import { TapGesture } from './tapGesture';
  */
 export const GestureObjects = {
   /**
-   * @deprecated Tap Gesture is deprecated and will be removed in the future. Please use `useTapGesture` instead.
+   * @deprecated `Gesture.Tap()` is deprecated and will be removed in the future. Please use `useTapGesture` instead.
    *
    * A discrete gesture that recognizes one or many taps.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/tap-gesture
@@ -37,7 +37,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated Pan Gesture is deprecated and will be removed in the future. Please use `usePanGesture` instead.
+   * @deprecated `Gesture.Pan()` is deprecated and will be removed in the future. Please use `usePanGesture` instead.
    *
    * A continuous gesture that can recognize a panning (dragging) gesture and track its movement.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture
@@ -47,7 +47,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated Pinch Gesture is deprecated and will be removed in the future. Please use `usePinchGesture` instead.
+   * @deprecated `Gesture.Pinch()` is deprecated and will be removed in the future. Please use `usePinchGesture` instead.
    *
    * A continuous gesture that recognizes pinch gesture. It allows for tracking the distance between two fingers and use that information to scale or zoom your content.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pinch-gesture
@@ -57,7 +57,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated Rotation Gesture is deprecated and will be removed in the future. Please use `useRotationGesture` instead.
+   * @deprecated `Gesture.Rotation()` is deprecated and will be removed in the future. Please use `useRotationGesture` instead.
    *
    * A continuous gesture that can recognize rotation and track its movement.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/rotation-gesture
@@ -67,7 +67,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated Fling Gesture is deprecated and will be removed in the future. Please use `useFlingGesture` instead.
+   * @deprecated `Gesture.Fling()` is deprecated and will be removed in the future. Please use `useFlingGesture` instead.
    *
    * A discrete gesture that activates when the movement is sufficiently fast.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/fling-gesture
@@ -77,7 +77,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated Long Press Gesture is deprecated and will be removed in the future. Please use `useLongPressGesture` instead.
+   * @deprecated `Gesture.LongPress()` is deprecated and will be removed in the future. Please use `useLongPressGesture` instead.
    *
    * A discrete gesture that activates when the corresponding view is pressed for a sufficiently long time.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/long-press-gesture
@@ -87,7 +87,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated ForceTouch gesture is deprecated and will be removed in the future.
+   * @deprecated `Gesture.ForceTouch()` is deprecated and will be removed in the future. Please use `useForceTouchGesture` instead.
    *
    *  #### iOS only
    * A continuous gesture that recognizes force of a touch. It allows for tracking pressure of touch on some iOS devices.
@@ -98,7 +98,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated Native Gesture is deprecated and will be removed in the future. Please use `useNativeGesture` instead.
+   * @deprecated `Gesture.Native()` is deprecated and will be removed in the future. Please use `useNativeGesture` instead.
    *
    * A gesture that allows other touch handling components to participate in RNGH's gesture system.
    * When used, the other component should be the direct child of a `GestureDetector`.
@@ -109,7 +109,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated Manual Gesture is deprecated and will be removed in the future. Please use `useManualGesture` instead.
+   * @deprecated `Gesture.Manual()` is deprecated and will be removed in the future. Please use `useManualGesture` instead.
    *
    * A plain gesture that has no specific activation criteria nor event data set.
    * Its state has to be controlled manually using a state manager.
@@ -121,7 +121,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated Hover Gesture is deprecated and will be removed in the future. Please use `useHoverGesture` instead.
+   * @deprecated `Gesture.Hover()` is deprecated and will be removed in the future. Please use `useHoverGesture` instead.
    *
    * A continuous gesture that can recognize hovering above the view it's attached to.
    * The hover effect may be activated by moving a mouse or a stylus over the view.
@@ -133,7 +133,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated Race Gesture is deprecated and will be removed in the future. Please use `useCompetingGestures` instead.
+   * @deprecated `Gesture.Race()` is deprecated and will be removed in the future. Please use `useCompetingGestures` instead.
    *
    * Builds a composed gesture consisting of gestures provided as parameters.
    * The first one that becomes active cancels the rest of gestures.
@@ -144,7 +144,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated Simultaneous Gesture is deprecated and will be removed in the future. Please use `useSimultaneousGestures` instead.
+   * @deprecated `Gesture.Simultaneous()` is deprecated and will be removed in the future. Please use `useSimultaneousGestures` instead.
    *
    * Builds a composed gesture that allows all base gestures to run simultaneously.
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/gesture-composition/#simultaneous
@@ -154,7 +154,7 @@ export const GestureObjects = {
   },
 
   /**
-   * @deprecated Exclusive Gesture is deprecated and will be removed in the future. Please use `useExclusiveGestures` instead.
+   * @deprecated `Gesture.Exclusive()` is deprecated and will be removed in the future. Please use `useExclusiveGestures` instead.
    *
    * Builds a composed gesture where only one of the provided gestures can become active.
    * Priority is decided through the order of gestures: the first one has higher priority

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureStateManager.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureStateManager.ts
@@ -1,6 +1,9 @@
 import { State } from '../../State';
 import { tagMessage } from '../../utils';
 
+/**
+ * @deprecated `GestureStateManagerType` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ */
 export interface GestureStateManagerType {
   begin: () => void;
   activate: () => void;
@@ -49,6 +52,9 @@ function create(handlerTag: number): GestureStateManagerType {
   };
 }
 
+/**
+ * @deprecated `GestureStateManager` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ */
 export const GestureStateManager = {
   create,
 };

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureStateManager.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureStateManager.ts
@@ -2,7 +2,7 @@ import { State } from '../../State';
 import { tagMessage } from '../../utils';
 
 /**
- * @deprecated `GestureStateManagerType` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ * @deprecated `LegacyGestureStateManagerType` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
  */
 export interface GestureStateManagerType {
   begin: () => void;
@@ -53,7 +53,7 @@ function create(handlerTag: number): GestureStateManagerType {
 }
 
 /**
- * @deprecated `GestureStateManager` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
+ * @deprecated `LegacyGestureStateManager` is deprecated and will be removed in the future. Please use the new, hook-based API instead.
  */
 export const GestureStateManager = {
   create,

--- a/packages/react-native-gesture-handler/src/handlers/gestures/hoverGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/hoverGesture.ts
@@ -41,6 +41,9 @@ function changeEventCalculator(
   return { ...current, ...changePayload };
 }
 
+/**
+ * @deprecated Hover Gesture is deprecated and will be removed in the future. Please use `useHoverGesture` instead.
+ */
 export class HoverGesture extends ContinousBaseGesture<
   HoverGestureHandlerEventPayload,
   HoverGestureChangeEventPayload
@@ -75,4 +78,7 @@ export class HoverGesture extends ContinousBaseGesture<
   }
 }
 
+/**
+ * @deprecated Hover Gesture is deprecated and will be removed in the future. Please use `useHoverGesture` instead.
+ */
 export type HoverGestureType = InstanceType<typeof HoverGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/hoverGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/hoverGesture.ts
@@ -42,7 +42,7 @@ function changeEventCalculator(
 }
 
 /**
- * @deprecated Hover Gesture is deprecated and will be removed in the future. Please use `useHoverGesture` instead.
+ * @deprecated `HoverGesture` is deprecated and will be removed in the future. Please use `useHoverGesture` instead.
  */
 export class HoverGesture extends ContinousBaseGesture<
   HoverGestureHandlerEventPayload,
@@ -79,6 +79,6 @@ export class HoverGesture extends ContinousBaseGesture<
 }
 
 /**
- * @deprecated Hover Gesture is deprecated and will be removed in the future. Please use `useHoverGesture` instead.
+ * @deprecated `HoverGestureType` is deprecated and will be removed in the future. Please use `HoverGesture` instead.
  */
 export type HoverGestureType = InstanceType<typeof HoverGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/longPressGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/longPressGesture.ts
@@ -3,6 +3,9 @@ import type { LongPressGestureConfig } from '../LongPressGestureHandler';
 import type { BaseGestureConfig } from './gesture';
 import { BaseGesture } from './gesture';
 
+/**
+ * @deprecated Long Press Gesture is deprecated and will be removed in the future. Please use `useLongPressGesture` instead.
+ */
 export class LongPressGesture extends BaseGesture<LongPressGestureHandlerEventPayload> {
   public override config: BaseGestureConfig & LongPressGestureConfig = {};
 
@@ -43,4 +46,7 @@ export class LongPressGesture extends BaseGesture<LongPressGestureHandlerEventPa
   }
 }
 
+/**
+ * @deprecated Long Press Gesture is deprecated and will be removed in the future. Please use `useLongPressGesture` instead.
+ */
 export type LongPressGestureType = InstanceType<typeof LongPressGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/longPressGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/longPressGesture.ts
@@ -4,7 +4,7 @@ import type { BaseGestureConfig } from './gesture';
 import { BaseGesture } from './gesture';
 
 /**
- * @deprecated Long Press Gesture is deprecated and will be removed in the future. Please use `useLongPressGesture` instead.
+ * @deprecated `LongPressGesture` is deprecated and will be removed in the future. Please use `useLongPressGesture` instead.
  */
 export class LongPressGesture extends BaseGesture<LongPressGestureHandlerEventPayload> {
   public override config: BaseGestureConfig & LongPressGestureConfig = {};
@@ -47,6 +47,6 @@ export class LongPressGesture extends BaseGesture<LongPressGestureHandlerEventPa
 }
 
 /**
- * @deprecated Long Press Gesture is deprecated and will be removed in the future. Please use `useLongPressGesture` instead.
+ * @deprecated `LongPressGestureType` is deprecated and will be removed in the future. Please use `LongPressGesture` instead.
  */
 export type LongPressGestureType = InstanceType<typeof LongPressGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/manualGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/manualGesture.ts
@@ -9,6 +9,9 @@ function changeEventCalculator(
   return current;
 }
 
+/**
+ * @deprecated `ManualGesture` is deprecated and will be removed in the future. Please use `useManualGesture` instead.
+ */
 export class ManualGesture extends ContinousBaseGesture<
   Record<string, never>,
   Record<string, never>
@@ -29,6 +32,6 @@ export class ManualGesture extends ContinousBaseGesture<
 }
 
 /**
- * @deprecated Manual Gesture is deprecated and will be removed in the future. Please use `useManualGesture` instead.
+ * @deprecated `ManualGestureType` is deprecated and will be removed in the future. Please use `ManualGesture` instead.
  */
 export type ManualGestureType = InstanceType<typeof ManualGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/manualGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/manualGesture.ts
@@ -28,4 +28,7 @@ export class ManualGesture extends ContinousBaseGesture<
   }
 }
 
+/**
+ * @deprecated Manual Gesture is deprecated and will be removed in the future. Please use `useManualGesture` instead.
+ */
 export type ManualGestureType = InstanceType<typeof ManualGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/nativeGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/nativeGesture.ts
@@ -3,6 +3,9 @@ import type { NativeViewGestureConfig } from '../NativeViewGestureHandler';
 import type { BaseGestureConfig } from './gesture';
 import { BaseGesture } from './gesture';
 
+/**
+ * @deprecated `NativeGesture` is deprecated and will be removed in the future. Please use `useNativeGesture` instead.
+ */
 export class NativeGesture extends BaseGesture<NativeViewGestureHandlerPayload> {
   public override config: BaseGestureConfig & NativeViewGestureConfig = {};
 
@@ -31,4 +34,7 @@ export class NativeGesture extends BaseGesture<NativeViewGestureHandlerPayload> 
   }
 }
 
+/**
+ * @deprecated `NativeGestureType` is deprecated and will be removed in the future. Please use `NativeGesture` instead.
+ */
 export type NativeGestureType = InstanceType<typeof NativeGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/panGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/panGesture.ts
@@ -4,6 +4,9 @@ import type { PanGestureConfig } from '../PanGestureHandler';
 import type { BaseGestureConfig } from './gesture';
 import { ContinousBaseGesture } from './gesture';
 
+/**
+ * @deprecated Pan Gesture is deprecated and will be removed in the future. Please use `usePanGesture` instead.
+ */
 export type PanGestureChangeEventPayload = {
   changeX: number;
   changeY: number;
@@ -30,6 +33,9 @@ function changeEventCalculator(
   return { ...current, ...changePayload };
 }
 
+/**
+ * @deprecated Pan Gesture is deprecated and will be removed in the future. Please use `usePanGesture` instead.
+ */
 export class PanGesture extends ContinousBaseGesture<
   PanGestureHandlerEventPayload,
   PanGestureChangeEventPayload
@@ -219,4 +225,7 @@ export class PanGesture extends ContinousBaseGesture<
   }
 }
 
+/**
+ * @deprecated Pan Gesture is deprecated and will be removed in the future. Please use `usePanGesture` instead.
+ */
 export type PanGestureType = InstanceType<typeof PanGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/panGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/panGesture.ts
@@ -5,7 +5,7 @@ import type { BaseGestureConfig } from './gesture';
 import { ContinousBaseGesture } from './gesture';
 
 /**
- * @deprecated Pan Gesture is deprecated and will be removed in the future. Please use `usePanGesture` instead.
+ * @deprecated `PanGestureChangeEventPayload` is deprecated and will be removed in the future. Please use `PanGestureActiveEvent` instead.
  */
 export type PanGestureChangeEventPayload = {
   changeX: number;
@@ -34,7 +34,7 @@ function changeEventCalculator(
 }
 
 /**
- * @deprecated Pan Gesture is deprecated and will be removed in the future. Please use `usePanGesture` instead.
+ * @deprecated `PanGesture` is deprecated and will be removed in the future. Please use `usePanGesture` instead.
  */
 export class PanGesture extends ContinousBaseGesture<
   PanGestureHandlerEventPayload,
@@ -226,6 +226,6 @@ export class PanGesture extends ContinousBaseGesture<
 }
 
 /**
- * @deprecated Pan Gesture is deprecated and will be removed in the future. Please use `usePanGesture` instead.
+ * @deprecated `PanGestureType` is deprecated and will be removed in the future. Please use `PanGesture` instead.
  */
 export type PanGestureType = InstanceType<typeof PanGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/pinchGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/pinchGesture.ts
@@ -3,7 +3,7 @@ import type { PinchGestureHandlerEventPayload } from '../GestureHandlerEventPayl
 import { ContinousBaseGesture } from './gesture';
 
 /**
- * @deprecated Pinch Gesture is deprecated and will be removed in the future. Please use `usePinchGesture` instead.
+ * @deprecated `PinchGestureChangeEventPayload` is deprecated and will be removed in the future. Please use `PinchGestureActiveEvent` instead.
  */
 export type PinchGestureChangeEventPayload = {
   scaleChange: number;
@@ -29,7 +29,7 @@ function changeEventCalculator(
 }
 
 /**
- * @deprecated Pinch Gesture is deprecated and will be removed in the future. Please use `usePinchGesture` instead.
+ * @deprecated `PinchGesture` is deprecated and will be removed in the future. Please use `usePinchGesture` instead.
  */
 export class PinchGesture extends ContinousBaseGesture<
   PinchGestureHandlerEventPayload,
@@ -55,6 +55,6 @@ export class PinchGesture extends ContinousBaseGesture<
 }
 
 /**
- * @deprecated Pinch Gesture is deprecated and will be removed in the future. Please use `usePinchGesture` instead.
+ * @deprecated `PinchGestureType` is deprecated and will be removed in the future. Please use `PinchGesture` instead.
  */
 export type PinchGestureType = InstanceType<typeof PinchGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/pinchGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/pinchGesture.ts
@@ -2,6 +2,9 @@ import type { GestureUpdateEvent } from '../gestureHandlerCommon';
 import type { PinchGestureHandlerEventPayload } from '../GestureHandlerEventPayload';
 import { ContinousBaseGesture } from './gesture';
 
+/**
+ * @deprecated Pinch Gesture is deprecated and will be removed in the future. Please use `usePinchGesture` instead.
+ */
 export type PinchGestureChangeEventPayload = {
   scaleChange: number;
 };
@@ -25,6 +28,9 @@ function changeEventCalculator(
   return { ...current, ...changePayload };
 }
 
+/**
+ * @deprecated Pinch Gesture is deprecated and will be removed in the future. Please use `usePinchGesture` instead.
+ */
 export class PinchGesture extends ContinousBaseGesture<
   PinchGestureHandlerEventPayload,
   PinchGestureChangeEventPayload
@@ -48,4 +54,7 @@ export class PinchGesture extends ContinousBaseGesture<
   }
 }
 
+/**
+ * @deprecated Pinch Gesture is deprecated and will be removed in the future. Please use `usePinchGesture` instead.
+ */
 export type PinchGestureType = InstanceType<typeof PinchGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/rotationGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/rotationGesture.ts
@@ -26,7 +26,7 @@ function changeEventCalculator(
 }
 
 /**
- * @deprecated Rotation Gesture is deprecated and will be removed in the future. Please use `useRotationGesture` instead.
+ * @deprecated `RotationGesture` is deprecated and will be removed in the future. Please use `useRotationGesture` instead.
  */
 export class RotationGesture extends ContinousBaseGesture<
   RotationGestureHandlerEventPayload,
@@ -52,6 +52,6 @@ export class RotationGesture extends ContinousBaseGesture<
 }
 
 /**
- * @deprecated Rotation Gesture is deprecated and will be removed in the future. Please use `useRotationGesture` instead.
+ * @deprecated `RotationGestureType` is deprecated and will be removed in the future. Please use `RotationGesture` instead.
  */
 export type RotationGestureType = InstanceType<typeof RotationGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/rotationGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/rotationGesture.ts
@@ -25,6 +25,9 @@ function changeEventCalculator(
   return { ...current, ...changePayload };
 }
 
+/**
+ * @deprecated Rotation Gesture is deprecated and will be removed in the future. Please use `useRotationGesture` instead.
+ */
 export class RotationGesture extends ContinousBaseGesture<
   RotationGestureHandlerEventPayload,
   RotationGestureChangeEventPayload
@@ -48,4 +51,7 @@ export class RotationGesture extends ContinousBaseGesture<
   }
 }
 
+/**
+ * @deprecated Rotation Gesture is deprecated and will be removed in the future. Please use `useRotationGesture` instead.
+ */
 export type RotationGestureType = InstanceType<typeof RotationGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/tapGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/tapGesture.ts
@@ -4,7 +4,7 @@ import type { BaseGestureConfig } from './gesture';
 import { BaseGesture } from './gesture';
 
 /**
- * @deprecated Tap Gesture is deprecated and will be removed in the future. Please use `useTapGesture` instead.
+ * @deprecated `TapGesture` is deprecated and will be removed in the future. Please use `useTapGesture` instead.
  */
 export class TapGesture extends BaseGesture<TapGestureHandlerEventPayload> {
   public override config: BaseGestureConfig & TapGestureConfig = {};
@@ -88,6 +88,6 @@ export class TapGesture extends BaseGesture<TapGestureHandlerEventPayload> {
 }
 
 /**
- * @deprecated Tap Gesture is deprecated and will be removed in the future. Please use `useTapGesture` instead.
+ * @deprecated `TapGestureType` is deprecated and will be removed in the future. Please use `TapGesture` instead.
  */
 export type TapGestureType = InstanceType<typeof TapGesture>;

--- a/packages/react-native-gesture-handler/src/handlers/gestures/tapGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/tapGesture.ts
@@ -3,6 +3,9 @@ import type { TapGestureConfig } from '../TapGestureHandler';
 import type { BaseGestureConfig } from './gesture';
 import { BaseGesture } from './gesture';
 
+/**
+ * @deprecated Tap Gesture is deprecated and will be removed in the future. Please use `useTapGesture` instead.
+ */
 export class TapGesture extends BaseGesture<TapGestureHandlerEventPayload> {
   public override config: BaseGestureConfig & TapGestureConfig = {};
 
@@ -84,4 +87,7 @@ export class TapGesture extends BaseGesture<TapGestureHandlerEventPayload> {
   }
 }
 
+/**
+ * @deprecated Tap Gesture is deprecated and will be removed in the future. Please use `useTapGesture` instead.
+ */
 export type TapGestureType = InstanceType<typeof TapGesture>;


### PR DESCRIPTION
## Description

The time to deprecate builder API has come.

## Test plan

Checked in vsc that v2 related elements are marked as deprecated.