### PR TITLE
Do not check for `worklets` if babel plugin was not used

### DIFF
--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/utils.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/utils.ts
@@ -36,6 +36,11 @@ export const ALLOWED_PROPS = [
   ...nativeViewGestureHandlerProps,
 ];
 
+// This is used to check if babel plugin was used.
+function emptyWorklet() {
+  'worklet';
+}
+
 function convertToHandlerTag(ref: GestureRef): number {
   if (typeof ref === 'number') {
     return ref;
@@ -103,9 +108,11 @@ export function checkGestureCallbacksForWorklets(gesture: GestureType) {
   }
 
   const areAllNotWorklets = !areSomeWorklets && areSomeNotWorklets;
+  // @ts-ignore if callback is a worklet, the property will be available, if not then the check will return false
+  const wasBabelPluginEnabled = emptyWorklet.__workletHash !== undefined;
   // If none of the callbacks are worklets and the gesture is not explicitly marked with
   // `.runOnJS(true)` show a warning
-  if (areAllNotWorklets && !isTestEnv()) {
+  if (areAllNotWorklets && wasBabelPluginEnabled && !isTestEnv()) {
     console.warn(
       tagMessage(
         `None of the callbacks in the gesture are worklets. If you wish to run them on the JS thread use '.runOnJS(true)' modifier on the gesture to make this explicit. Otherwise, mark the callbacks as 'worklet' to run them on the UI thread.`

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/utils.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/utils.ts
@@ -36,10 +36,15 @@ export const ALLOWED_PROPS = [
   ...nativeViewGestureHandlerProps,
 ];
 
-// This is used to check if babel plugin was used.
+// In some environments (e.g. `Next.js`) Reanimated Babel plugin might not be used.
+// In that case we would wrongly suggest to add `runOnJS` to gesture configuration, even if the user doesn't use worklets at all.
+// To prevent this, we check whether the plugin is enabled by defining a worklet and checking if the `__workletHash` property is available.
 function emptyWorklet() {
   'worklet';
 }
+
+// @ts-expect-error if `emptyWorklet` is a worklet, `__workletHash` will be available, if not then the check will return false.
+const wasBabelPluginEnabled = emptyWorklet.__workletHash !== undefined;
 
 function convertToHandlerTag(ref: GestureRef): number {
   if (typeof ref === 'number') {
@@ -108,8 +113,6 @@ export function checkGestureCallbacksForWorklets(gesture: GestureType) {
   }
 
   const areAllNotWorklets = !areSomeWorklets && areSomeNotWorklets;
-  // @ts-ignore if callback is a worklet, the property will be available, if not then the check will return false
-  const wasBabelPluginEnabled = emptyWorklet.__workletHash !== undefined;
   // If none of the callbacks are worklets and the gesture is not explicitly marked with
   // `.runOnJS(true)` show a warning
   if (areAllNotWorklets && wasBabelPluginEnabled && !isTestEnv()) {


### PR DESCRIPTION
## Description

In some environments babel plugin is not used (e.g. it can be omitted when using `Next.js`). Our detector checks if callbacks are `worklets` by checking `__workletHash` field. However, if plugin wasn't used, this will be `undefined`. In that case, our warning will wrongly suggest to use `runOnJS`. This may be misleading, if plugin was skipped on `web`, but used on native platforms.

In this PR, we check if plugin was applied by checking empty worklet function. If it has `__workletHash` field it means that plugin was used. If it wasn't, we won't suggest using `runOnJS`.

## Test plan

Confirmed by the original reporter