### PR TITLE
[iOS] Handle `0` duration animation correctly on `Touchable`

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -173,6 +173,17 @@
       _underlayLayer.presentationLayer ? [_underlayLayer.presentationLayer opacity] : _underlayLayer.opacity;
   [_underlayLayer removeAllAnimations];
 
+  // CABasicAnimation with duration 0 resolves to the current CATransaction's
+  // default duration (0.25s), not "no animation". Snap the value directly
+  // with implicit actions disabled to get a true instant update.
+  if (durationMs <= 0) {
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    _underlayLayer.opacity = toOpacity;
+    [CATransaction commit];
+    return;
+  }
+
   CABasicAnimation *anim = [CABasicAnimation animationWithKeyPath:@"opacity"];
   anim.fromValue = @(_underlayLayer.opacity);
   anim.toValue = @(toOpacity);


### PR DESCRIPTION
## Description

On iOS, setting `tapAnimationDuration` on Touchable didn't turn off the animation entirely, instead making it take 0.25s. CoreAnimation treats `0` in this case as `not set` and uses the default duration.

This PR adds an explicit check for the `0` duration and applies the end state immediately for the underlay.

## Test plan

```jsx
      <Touchable
        style={{
          width: 220,
          paddingVertical: 20,
          borderRadius: 12,
          backgroundColor: '#A0D5EF',
          alignItems: 'center',
          justifyContent: 'center',
          overflow: 'hidden',
        }}
        underlayColor={COLORS.RED}
        activeUnderlayOpacity={0.6}
        tapAnimationDuration={0}
        onPress={() => pushLog('onPress')}>
        <Text>Hold me</Text>
      </Touchable>
```
