### PR TITLE
[General] Allow to create gestures with no config

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/useFlingGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/useFlingGesture.ts
@@ -8,7 +8,11 @@ import type {
   FlingHandlerData,
 } from './FlingTypes';
 
-export function useFlingGesture(config: FlingGestureConfig): FlingGesture {
+const EMPTY_FLING_CONFIG: FlingGestureConfig = {};
+
+export function useFlingGesture(
+  config: FlingGestureConfig = EMPTY_FLING_CONFIG
+): FlingGesture {
   const flingConfig = useClonedAndRemappedConfig<
     FlingGestureProperties,
     FlingHandlerData

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/hover/useHoverGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/hover/useHoverGesture.ts
@@ -44,7 +44,11 @@ function transformHoverProps(
 
 const HoverPropsMapping = new Map<string, string>([['effect', 'hoverEffect']]);
 
-export function useHoverGesture(config: HoverGestureConfig): HoverGesture {
+const EMPTY_HOVER_CONFIG: HoverGestureConfig = {};
+
+export function useHoverGesture(
+  config: HoverGestureConfig = EMPTY_HOVER_CONFIG
+): HoverGesture {
   const hoverConfig = useClonedAndRemappedConfig<
     HoverGestureProperties,
     HoverHandlerData,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/longPress/useLongPressGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/longPress/useLongPressGesture.ts
@@ -28,8 +28,10 @@ function transformLongPressProps(
   return config;
 }
 
+const EMPTY_LONG_PRESS_CONFIG: LongPressGestureConfig = {};
+
 export function useLongPressGesture(
-  config: LongPressGestureConfig
+  config: LongPressGestureConfig = EMPTY_LONG_PRESS_CONFIG
 ): LongPressGesture {
   const longPressConfig = useClonedAndRemappedConfig<
     LongPressGestureProperties,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/manual/useManualGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/manual/useManualGesture.ts
@@ -8,7 +8,11 @@ import type {
   ManualHandlerData,
 } from './ManualTypes';
 
-export function useManualGesture(config: ManualGestureConfig): ManualGesture {
+const EMPTY_MANUAL_CONFIG: ManualGestureConfig = {};
+
+export function useManualGesture(
+  config: ManualGestureConfig = EMPTY_MANUAL_CONFIG
+): ManualGesture {
   const manualConfig = useClonedAndRemappedConfig<
     ManualGestureProperties,
     ManualHandlerData

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/useNativeGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/useNativeGesture.ts
@@ -8,7 +8,11 @@ import type {
   NativeHandlerData,
 } from './NativeTypes';
 
-export function useNativeGesture(config: NativeGestureConfig): NativeGesture {
+const EMPTY_NATIVE_CONFIG: NativeGestureConfig = {};
+
+export function useNativeGesture(
+  config: NativeGestureConfig = EMPTY_NATIVE_CONFIG
+): NativeGesture {
   const nativeConfig = useClonedAndRemappedConfig<
     NativeGestureProperties,
     NativeHandlerData

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/usePanGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/usePanGesture.ts
@@ -139,7 +139,11 @@ function transformPanProps(
   return config;
 }
 
-export function usePanGesture(config: PanGestureConfig): PanGesture {
+const EMPTY_PAN_CONFIG: PanGestureConfig = {};
+
+export function usePanGesture(
+  config: PanGestureConfig = EMPTY_PAN_CONFIG
+): PanGesture {
   if (__DEV__) {
     validatePanConfig(config);
   }

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/pinch/usePinchGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/pinch/usePinchGesture.ts
@@ -40,7 +40,11 @@ function transformPinchProps(
 
 const PinchPropsMapping = new Map<string, string>();
 
-export function usePinchGesture(config: PinchGestureConfig): PinchGesture {
+const EMPTY_PINCH_CONFIG: PinchGestureConfig = {};
+
+export function usePinchGesture(
+  config: PinchGestureConfig = EMPTY_PINCH_CONFIG
+): PinchGesture {
   const pinchConfig = useClonedAndRemappedConfig<
     PinchGestureProperties,
     PinchHandlerData,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/rotation/useRotationGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/rotation/useRotationGesture.ts
@@ -42,8 +42,10 @@ function transformRotationProps(
 
 const RotationPropsMapping = new Map<string, string>();
 
+const EMPTY_ROTATION_CONFIG: RotationGestureConfig = {};
+
 export function useRotationGesture(
-  config: RotationGestureConfig
+  config: RotationGestureConfig = EMPTY_ROTATION_CONFIG
 ): RotationGesture {
   const rotationConfig = useClonedAndRemappedConfig<
     RotationGestureProperties,

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/useTapGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/useTapGesture.ts
@@ -18,7 +18,11 @@ const TapPropsMapping = new Map<
   ['maxDelay', 'maxDelayMs'],
 ]);
 
-export function useTapGesture(config: TapGestureConfig): TapGesture {
+const EMPTY_TAP_CONFIG: TapGestureConfig = {};
+
+export function useTapGesture(
+  config: TapGestureConfig = EMPTY_TAP_CONFIG
+): TapGesture {
   const tapConfig = useClonedAndRemappedConfig<
     TapGestureProperties,
     TapHandlerData,


### PR DESCRIPTION
## Description

Updates gesture hook signatures to include the default, empty config for each gesture. This allows for creating gesture objects without passing a config, like so:

```jsx
const nativeGesture = useNativeGesture()
```

`Native` gesture would be the most useful here, since its config is often empty when pulling in a host component into RNGH's gesture system. Other gestures may be a nice DX improvement, though, since now it's simpler to create a "placeholder" gesture.

The default config is referentially stable, so it shouldn't cause unnecessary updates between renders as opposed to passing an empty object (with no compiler and memoization).

## Test plan

Static checks
