### PR TITLE
[General] Don't activate buttons on start

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/components/GestureButtons.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/GestureButtons.tsx
@@ -23,7 +23,7 @@ export const RawButton = createNativeWrapper<
   RawButtonProps
 >(GestureHandlerButton, {
   shouldCancelWhenOutside: false,
-  shouldActivateOnStart: true,
+  shouldActivateOnStart: false,
 });
 
 /**


### PR DESCRIPTION
## Description

Changes `shouldActivateOnStart` on buttons to `false` - `true` breaks nested buttons on Android.

cc @m-bert - I don't recall why it was `true` in the first place, any chance that after https://github.com/software-mansion/react-native-gesture-handler/pull/4116 it wouldn't have been needed anyway?

## Test plan

|Before|Update|
|-|-|
|<video src="https://github.com/user-attachments/assets/e6fd41f8-98dc-43e5-9d31-442621eb8e08" />|<video src="https://github.com/user-attachments/assets/c65a4fa2-2f3a-4052-8e7f-edcf96b7256d" />|





