### PR TITLE
[iOS] Fix `LegacyPressable` not emitting `onPressOut`

### DIFF
--- a/packages/react-native-gesture-handler/src/components/Pressable/stateDefinitions.ts
+++ b/packages/react-native-gesture-handler/src/components/Pressable/stateDefinitions.ts
@@ -62,6 +62,9 @@ function getIosStatesConfig(
       callback: handlePressIn,
     },
     {
+      eventName: StateMachineEvent.NATIVE_START,
+    },
+    {
       eventName: StateMachineEvent.FINALIZE,
       callback: handlePressOut,
     },

--- a/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
@@ -308,7 +308,7 @@ const Pressable = (props: PressableProps) => {
       stateMachine.handleEvent(StateMachineEvent.NATIVE_BEGIN);
     },
     onActivate: () => {
-      if (Platform.OS !== 'android' && Platform.OS !== 'ios') {
+      if (Platform.OS !== 'android') {
         // Native.onActivate is broken with Android + hitSlop
         stateMachine.handleEvent(StateMachineEvent.NATIVE_START);
       }


### PR DESCRIPTION
## Description

Fixes the `LegacyPressable` on iOS getting stuck due to an unhandled `NATIVE_START` event. Updates the non-legacy implementation to also dispatch the `NATIVE_START`, which is now expected by the state machine.

## Test plan

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/7e7476f1-0d61-40d9-9c13-4f157b050bb6" />|<video src="https://github.com/user-attachments/assets/11e3b42b-e9b9-4b4f-a8cb-6dc9f20e2001" />|


