### PR TITLE
[Web] Find `Switch` input only in direct children

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -104,19 +104,11 @@ export default class NativeViewGestureHandler extends GestureHandler {
     const view = this.delegate.view as HTMLElement;
     const isRNGHText = view.hasAttribute('rnghtext');
 
-    console.log(
-      this.buttonRole,
-      this.switchRole,
-      this.shouldActivateOnStart,
-      view
-    );
-
     if (
       (this.buttonRole && this.shouldActivateOnStart) ||
       this.switchRole ||
       isRNGHText
     ) {
-      console.log('siema');
       this.activate();
     }
   }

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -50,7 +50,8 @@ export default class NativeViewGestureHandler extends GestureHandler {
 
     this.restoreViewStyles(view);
     this.buttonRole = view.getAttribute('role') === 'button';
-    this.switchRole = view.querySelector('input[role="switch"]') !== null;
+    this.switchRole =
+      view.querySelector(':scope > input[role="switch"]') !== null;
   }
 
   public override updateGestureConfig(config: Config): void {
@@ -103,11 +104,19 @@ export default class NativeViewGestureHandler extends GestureHandler {
     const view = this.delegate.view as HTMLElement;
     const isRNGHText = view.hasAttribute('rnghtext');
 
+    console.log(
+      this.buttonRole,
+      this.switchRole,
+      this.shouldActivateOnStart,
+      view
+    );
+
     if (
       (this.buttonRole && this.shouldActivateOnStart) ||
       this.switchRole ||
       isRNGHText
     ) {
+      console.log('siema');
       this.activate();
     }
   }


### PR DESCRIPTION
## Description

In #4112 I've adjusted `Native` gesture for `Switch` component on web. Using `querySelector` on `view` broke our example app, as now it looks for `input` element in the whole subtree.

To fix this, I've added [`:scope >`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:scope#using_scope_in_javascript) which limits `querySelector` only to direct children.

## Test plan

`expo-example` on web