### PR TITLE
[Android] Dispatch cancel event only when root view is enabled

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
@@ -49,7 +49,7 @@ class RNGestureHandlerRootView(context: Context?) : ReactViewGroup(context) {
     // When starting a new event stream, dispatch CANCEL event so the subtree
     // can clean up its internal state that may be stale due to Gesture Handler
     // starting to intercept events mid-stream.
-    if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+    if (rootViewEnabled && event.actionMasked == MotionEvent.ACTION_DOWN) {
       val cancelEvent = MotionEvent.obtain(event).apply { action = MotionEvent.ACTION_CANCEL }
       super.dispatchTouchEvent(cancelEvent)
       cancelEvent.recycle()


### PR DESCRIPTION
## Description

Currently, RootView on Android always dispatches `ACTION_CANCEL` before starting to process the new event stream. When multiple root views are rendered in the app, this will have a "waterfall" effect of each root view dispatching its own `ACTION_CANCEL` on top of passing the one received from the parent.

This PR addresses that by requiring the root view to be enabled to dispatch the cancel event.

## Test plan

Checked the `Nested touchables` example
