### PR TITLE
[Web] Fix `Pressable` not calling `onPress*` callbacks

### DIFF
--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -323,7 +323,8 @@ const LegacyPressable = (props: LegacyPressableProps) => {
               handleFinalize();
             }
           }
-        }),
+        })
+        .shouldActivateOnStart(Platform.OS === 'web'),
     [stateMachine, handlePressOut, handleFinalize]
   );
 

--- a/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
@@ -331,6 +331,7 @@ const Pressable = (props: PressableProps) => {
     block,
     requireToFail,
     hitSlop: appliedHitSlop,
+    shouldActivateOnStart: Platform.OS === 'web',
   });
 
   const gesture = useSimultaneousGestures(


### PR DESCRIPTION
## Description

#4108 introduced [another condition](https://github.com/software-mansion/react-native-gesture-handler/blob/061ea9588f5a373498ee4c72237de339b95df81b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts#L108) for activation of `Native` gesture. Since `Pressables` use `PureNativeButton`, not `RawButton`, they do not meet this condition, hence they don't activate

## Test plan

`Pressables` examples in `expo-example`
