### PR TITLE
[iOS] Prevent duplicated events in Native gesture handling

### DIFF
--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -192,13 +192,22 @@
   [super unbindFromView];
 }
 
-- (void)sendActiveStateEventIfChangedForView:(UIView *)sender extraData:(RNGestureHandlerEventExtraData *)extraData
+- (BOOL)shouldSuppressActiveEvent:(RNGestureHandlerEventExtraData *)extraData
 {
-  if ([_lastActiveExtraData.data isEqualToDictionary:extraData.data]) {
-    return;
+  if (_lastActiveExtraData != nil && [_lastActiveExtraData.data isEqualToDictionary:extraData.data]) {
+    return YES;
   }
 
   _lastActiveExtraData = extraData;
+  return NO;
+}
+
+- (void)sendActiveStateEventIfChangedForView:(UIView *)sender extraData:(RNGestureHandlerEventExtraData *)extraData
+{
+  if ([self shouldSuppressActiveEvent:extraData]) {
+    return;
+  }
+
   [self sendEventsInState:RNGestureHandlerStateActive forViewWithTag:sender.reactTag withExtraData:extraData];
 }
 
@@ -245,7 +254,6 @@
                                                        withNumberOfTouches:event.allTouches.count
                                                            withPointerType:_pointerType]];
 
-  _lastActiveExtraData = nil;
   [self sendActiveStateEventIfChangedForView:sender
                                    extraData:[RNGestureHandlerEventExtraData forPointerInside:YES
                                                                           withNumberOfTouches:event.allTouches.count
@@ -330,7 +338,13 @@
   return YES;
 }
 
-#else
+- (void)reset
+{
+  [super reset];
+  _lastActiveExtraData = nil;
+}
+
+#endif
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(RNDummyGestureRecognizer *)recognizer
 {
@@ -338,7 +352,5 @@
                                       withNumberOfTouches:1
                                           withPointerType:RNGestureHandlerMouse];
 }
-
-#endif
 
 @end

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.h
@@ -96,6 +96,7 @@
 - (void)setConfig:(nullable NSDictionary *)config NS_REQUIRES_SUPER;
 - (void)updateConfig:(nullable NSDictionary *)config NS_REQUIRES_SUPER;
 - (void)updateRelations:(nonnull NSDictionary *)relations;
+- (BOOL)shouldSuppressActiveEvent:(RNGestureHandlerEventExtraData *)extraData;
 - (void)handleGesture:(nonnull id)recognizer;
 - (void)handleGesture:(nonnull id)recognizer fromReset:(BOOL)fromReset;
 - (void)handleGesture:(nonnull id)recognizer

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.h
@@ -96,7 +96,7 @@
 - (void)setConfig:(nullable NSDictionary *)config NS_REQUIRES_SUPER;
 - (void)updateConfig:(nullable NSDictionary *)config NS_REQUIRES_SUPER;
 - (void)updateRelations:(nonnull NSDictionary *)relations;
-- (BOOL)shouldSuppressActiveEvent:(RNGestureHandlerEventExtraData *)extraData;
+- (BOOL)shouldSuppressActiveEvent:(nonnull RNGestureHandlerEventExtraData *)extraData;
 - (void)handleGesture:(nonnull id)recognizer;
 - (void)handleGesture:(nonnull id)recognizer fromReset:(BOOL)fromReset;
 - (void)handleGesture:(nonnull id)recognizer

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -307,6 +307,11 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   return [self isViewParagraphComponent:recognizer.view] ? recognizer.view.subviews[0] : recognizer.view;
 }
 
+- (BOOL)shouldSuppressActiveEvent:(RNGestureHandlerEventExtraData *)extraData
+{
+  return NO;
+}
+
 - (void)handleGesture:(UIGestureRecognizer *)recognizer
 {
   [self handleGesture:recognizer fromReset:NO];
@@ -367,6 +372,10 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   _state = state;
 
   RNGestureHandlerEventExtraData *eventData = [self eventExtraData:recognizer];
+
+  if (state == RNGestureHandlerStateActive && [self shouldSuppressActiveEvent:eventData]) {
+    return;
+  }
 
   NSNumber *tag = [self chooseViewForInteraction:recognizer].reactTag;
 


### PR DESCRIPTION
## Description

I've noticed that when `Native` gesture is not attached to `UIControl` it sends different events (e.g. events containing `x` and `y` positions). I've changed that to mimic behavior from #4102

## Test plan

<details>
<summary>Tested on the following example</summary>

```tsx
import { ScrollView, StyleSheet, View } from 'react-native';
import {
  GestureDetector,
  GestureHandlerRootView,
  ScrollView as RNGHScrollView,
  Touchable,
  useNativeGesture,
} from 'react-native-gesture-handler';

export default function App() {
  const g = useNativeGesture({
    onBegin: () => {
      console.log(Date.now(), 'gesture begin');
    },
    onActivate: () => {
      console.log(Date.now(), 'gesture activate');
    },
    onUpdate: (e) => {
      console.log(Date.now(), 'gesture update', e);
    },
    onDeactivate: () => {
      console.log(Date.now(), 'gesture deactivate');
    },
    onFinalize: () => {
      console.log(Date.now(), 'gesture finalize');
    },
    shouldCancelWhenOutside: false,
  });

  return (
    <GestureHandlerRootView style={styles.container}>
      <Touchable
        cancelOnLeave={false}
        style={{
          width: 150,
          height: 45,
          backgroundColor: 'crimson',
          borderRadius: 8,
        }}
      />

      <GestureDetector gesture={g}>
        <ScrollView style={[styles.scrollView, { backgroundColor: 'green' }]}>
          {BOXES.map((color, i) => (
            <View key={i} style={[styles.box, { backgroundColor: color }]} />
          ))}
        </ScrollView>
      </GestureDetector>
      <RNGHScrollView
        onBegin={() => {
          console.log(Date.now(), 'gesture begin');
        }}
        onActivate={() => {
          console.log(Date.now(), 'gesture activate');
        }}
        onUpdate={() => {
          console.log(Date.now(), 'gesture update');
        }}
        onDeactivate={() => {
          console.log(Date.now(), 'gesture deactivate');
        }}
        onFinalize={() => {
          console.log(Date.now(), 'gesture finalize');
        }}
        style={[styles.scrollView, { backgroundColor: 'blue' }]}>
        {BOXES.map((color, i) => (
          <View key={i} style={[styles.box, { backgroundColor: color }]} />
        ))}
      </RNGHScrollView>
    </GestureHandlerRootView>
  );
}

const BOXES = [
  '#ff6b6b',
  '#ffd93d',
  '#6bcb77',
  '#4d96ff',
  '#c77dff',
  '#ff9f43',
  '#ee5a24',
  '#0652dd',
  '#1289a7',
  '#d980fa',
];

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  scrollView: {
    width: 200,
    maxHeight: 250,
    marginVertical: 8,
  },
  box: {
    width: '100%',
    height: 60,
    marginBottom: 4,
  },
});
```

</details>
