### PR TITLE
[General] Change `Touchable` callback order

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -93,10 +93,10 @@ export const Touchable = (props: TouchableProps) => {
     (e: EndCallbackEventType) => {
       if (pointerState.current === PointerState.INSIDE) {
         onPressOut?.(e);
+      }
 
-        if (!e.canceled && !longPressDetected.current) {
-          onPress?.(e);
-        }
+      if (!e.canceled && !longPressDetected.current && e.pointerInside) {
+        onPress?.(e);
       }
 
       pointerState.current = PointerState.UNKNOWN;
@@ -106,7 +106,7 @@ export const Touchable = (props: TouchableProps) => {
         longPressTimeout.current = undefined;
       }
     },
-    [onPressOut]
+    [onPressOut, onPress]
   );
 
   const onUpdate = useCallback(

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -89,19 +89,14 @@ export const Touchable = (props: TouchableProps) => {
     }
   }, []);
 
-  const onDeactivate = useCallback(
-    (e: EndCallbackEventType) => {
-      if (!e.canceled && !longPressDetected.current && e.pointerInside) {
-        onPress?.(e);
-      }
-    },
-    [onPress]
-  );
-
   const onFinalize = useCallback(
     (e: EndCallbackEventType) => {
       if (pointerState.current === PointerState.INSIDE) {
         onPressOut?.(e);
+
+        if (!e.canceled && !longPressDetected.current) {
+          onPress?.(e);
+        }
       }
 
       pointerState.current = PointerState.UNKNOWN;
@@ -157,7 +152,6 @@ export const Touchable = (props: TouchableProps) => {
       enabled={!disabled}
       onBegin={onBegin}
       onActivate={onActivate}
-      onDeactivate={onDeactivate}
       onFinalize={onFinalize}
       onUpdate={onUpdate}
       defaultOpacity={defaultOpacity}


### PR DESCRIPTION
## Description

Since https://github.com/software-mansion/react-native-gesture-handler/pull/4116 is closed, this backports the part that changed the callback ordering.

## Test plan

Verify that the order is `onPressIn` -> `onPressOut` -> `onPress`.
