### PR TITLE
[Android] Cancel button gesture when other handlers are extracted before it

### DIFF
--- a/apps/common-app/src/new_api/tests/nestedTouchables/index.tsx
+++ b/apps/common-app/src/new_api/tests/nestedTouchables/index.tsx
@@ -12,6 +12,7 @@ export default function NestedTouchablesExample() {
   const [log, setLog] = useState<string[]>([]);
 
   const pushLog = (message: string) => {
+    console.log(message);
     setLog((prev) =>
       [...prev, `[${new Date().toLocaleTimeString()}] ${message}`].slice(-6)
     );
@@ -20,11 +21,13 @@ export default function NestedTouchablesExample() {
   const outerTap = useTapGesture({
     runOnJS: true,
     onActivate: () => pushLog('outer tap gesture'),
+    testID: 'outer-tap',
   });
 
   const innerTap = useTapGesture({
     runOnJS: true,
     onActivate: () => pushLog('inner tap gesture'),
+    testID: 'inner-tap',
   });
 
   return (
@@ -40,6 +43,11 @@ export default function NestedTouchablesExample() {
 
           <Touchable
             style={[styles.layer, styles.outerTouchable]}
+            testID="outer-touchable"
+            activeUnderlayOpacity={0.3}
+            onPressIn={() => pushLog('outer press in')}
+            onPressOut={() => pushLog('outer press out')}
+            onLongPress={() => pushLog('outer long press')}
             onPress={() => pushLog('outer Touchable')}>
             <Text style={styles.layerLabel}>Outer Touchable</Text>
 
@@ -49,6 +57,11 @@ export default function NestedTouchablesExample() {
 
                 <Touchable
                   style={[styles.layer, styles.innerTouchable]}
+                  testID="inner-touchable"
+                  activeUnderlayOpacity={0.3}
+                  onPressIn={() => pushLog('inner press in')}
+                  onPressOut={() => pushLog('inner press out')}
+                  onLongPress={() => pushLog('inner long press')}
                   onPress={() => pushLog('inner Touchable')}>
                   <Text style={styles.layerLabel}>Inner Touchable</Text>
                 </Touchable>

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -693,7 +693,7 @@ open class GestureHandler {
     return interactionController?.shouldHandlerBeCancelledBy(this, handler) ?: false
   }
 
-  open fun shouldBeginWithRecorded(recorded: List<GestureHandler>): Boolean = true
+  open fun shouldBeginWithRecordedHandlers(recorded: List<GestureHandler>): Boolean = true
 
   fun isWithinBounds(view: View?, posX: Float, posY: Float): Boolean {
     if (RNSVGHitTester.isSvgElement(view!!)) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -693,6 +693,8 @@ open class GestureHandler {
     return interactionController?.shouldHandlerBeCancelledBy(this, handler) ?: false
   }
 
+  open fun shouldBeginWithRecorded(recorded: List<GestureHandler>): Boolean = true
+
   fun isWithinBounds(view: View?, posX: Float, posY: Float): Boolean {
     if (RNSVGHitTester.isSvgElement(view!!)) {
       return RNSVGHitTester.hitTest(view, posX, posY)

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -448,7 +448,6 @@ class GestureHandlerOrchestrator(
       return
     }
 
-    gestureHandlers.add(handler)
     handler.isActive = false
     handler.isAwaiting = false
     handler.activationIndex = Int.MAX_VALUE
@@ -457,6 +456,8 @@ class GestureHandlerOrchestrator(
     if (!handler.shouldBeginWithRecorded(gestureHandlers)) {
       handler.cancel()
     }
+
+    gestureHandlers.add(handler)
   }
 
   private fun isViewOverflowingParent(view: View): Boolean {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -453,6 +453,10 @@ class GestureHandlerOrchestrator(
     handler.isAwaiting = false
     handler.activationIndex = Int.MAX_VALUE
     handler.prepare(view, this)
+
+    if (!handler.shouldBeginWithRecorded(gestureHandlers)) {
+      handler.cancel()
+    }
   }
 
   private fun isViewOverflowingParent(view: View): Boolean {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -453,7 +453,7 @@ class GestureHandlerOrchestrator(
     handler.activationIndex = Int.MAX_VALUE
     handler.prepare(view, this)
 
-    if (!handler.shouldBeginWithRecorded(gestureHandlers)) {
+    if (!handler.shouldBeginWithRecordedHandlers(gestureHandlers)) {
       handler.cancel()
     }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -83,6 +83,9 @@ class NativeViewGestureHandler : GestureHandler() {
 
   override fun shouldBeCancelledBy(handler: GestureHandler): Boolean = !disallowInterruption
 
+  override fun shouldBeginWithRecorded(recorded: List<GestureHandler>): Boolean =
+    hook.shouldBeginWithRecorded(recorded, this)
+
   override fun onPrepare() {
     when (val view = view) {
       is NativeViewGestureHandlerHook -> this.hook = view
@@ -270,6 +273,15 @@ class NativeViewGestureHandler : GestureHandler() {
      * by this one.
      */
     fun shouldCancelRootViewGestureHandlerIfNecessary() = false
+
+    /**
+     * Called when the handler is being recorded by the orchestrator, before any pointer events
+     * are delivered. Returning `false` cancels the handler immediately.
+     *
+     * @param recorded handlers already recorded for the current touch
+     * @param handler the handler being recorded
+     */
+    fun shouldBeginWithRecorded(recorded: List<GestureHandler>, handler: NativeViewGestureHandler): Boolean = true
 
     /**
      * Passes the event down to the underlying view using the correct method.

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -83,8 +83,8 @@ class NativeViewGestureHandler : GestureHandler() {
 
   override fun shouldBeCancelledBy(handler: GestureHandler): Boolean = !disallowInterruption
 
-  override fun shouldBeginWithRecorded(recorded: List<GestureHandler>): Boolean =
-    hook.shouldBeginWithRecorded(recorded, this)
+  override fun shouldBeginWithRecordedHandlers(recorded: List<GestureHandler>): Boolean =
+    hook.shouldBeginWithRecordedHandlers(recorded, this)
 
   override fun onPrepare() {
     when (val view = view) {
@@ -281,7 +281,8 @@ class NativeViewGestureHandler : GestureHandler() {
      * @param recorded handlers already recorded for the current touch
      * @param handler the handler being recorded
      */
-    fun shouldBeginWithRecorded(recorded: List<GestureHandler>, handler: NativeViewGestureHandler): Boolean = true
+    fun shouldBeginWithRecordedHandlers(recorded: List<GestureHandler>, handler: NativeViewGestureHandler): Boolean =
+      true
 
     /**
      * Passes the event down to the underlying view using the correct method.

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -42,6 +42,8 @@ import com.facebook.react.uimanager.style.BorderStyle
 import com.facebook.react.uimanager.style.LogicalEdge
 import com.facebook.react.viewmanagers.RNGestureHandlerButtonManagerDelegate
 import com.facebook.react.viewmanagers.RNGestureHandlerButtonManagerInterface
+import com.swmansion.gesturehandler.core.GestureHandler
+import com.swmansion.gesturehandler.core.HoverGestureHandler
 import com.swmansion.gesturehandler.core.NativeViewGestureHandler
 import com.swmansion.gesturehandler.react.RNGestureHandlerButtonViewManager.ButtonViewGroup
 
@@ -737,6 +739,9 @@ class RNGestureHandlerButtonViewManager :
       tryFreeingResponder()
       isTouched = false
     }
+
+    override fun shouldBeginWithRecorded(recorded: List<GestureHandler>, handler: NativeViewGestureHandler): Boolean =
+      recorded.all { it.shouldRecognizeSimultaneously(handler) || it.view == this || it is HoverGestureHandler }
 
     private fun tryFreeingResponder() {
       if (touchResponder === this) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -740,13 +740,15 @@ class RNGestureHandlerButtonViewManager :
       isTouched = false
     }
 
-    override fun shouldBeginWithRecorded(recorded: List<GestureHandler>, handler: NativeViewGestureHandler): Boolean =
-      recorded.all {
-        it.shouldRecognizeSimultaneously(handler) ||
-          handler.shouldRecognizeSimultaneously(it) ||
-          it.view == this ||
-          it is HoverGestureHandler
-      }
+    override fun shouldBeginWithRecordedHandlers(
+      recorded: List<GestureHandler>,
+      handler: NativeViewGestureHandler,
+    ): Boolean = recorded.all {
+      it.shouldRecognizeSimultaneously(handler) ||
+        handler.shouldRecognizeSimultaneously(it) ||
+        it.view == this ||
+        it is HoverGestureHandler
+    }
 
     private fun tryFreeingResponder() {
       if (touchResponder === this) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -741,7 +741,12 @@ class RNGestureHandlerButtonViewManager :
     }
 
     override fun shouldBeginWithRecorded(recorded: List<GestureHandler>, handler: NativeViewGestureHandler): Boolean =
-      recorded.all { it.shouldRecognizeSimultaneously(handler) || it.view == this || it is HoverGestureHandler }
+      recorded.all {
+        it.shouldRecognizeSimultaneously(handler) ||
+          handler.shouldRecognizeSimultaneously(it) ||
+          it.view == this ||
+          it is HoverGestureHandler
+      }
 
     private fun tryFreeingResponder() {
       if (touchResponder === this) {


### PR DESCRIPTION
## Description

Buttons on Android were showing feedback on press, even if another gesture would be activated before the button, canceling it. This PR addresses this by introducing `shouldBeginWithRecorded` method, which is a similar idea to `gestureRecognizerShouldBegin` from iOS.

Since gesture handlers are extracted bottom-up, we can rely on already extracted gestures to decide whether a button should be allowed to begin at all. If the button is a leaf or all other gestures are explicitly simultaneous with it, it can be recognized, otherwise we need to cancel it since other gestures will be receiving events.

This change aligns the nested button/gesture behavior with iOS.

The explicit conditions needed for an already registered handler NOT to cancel the button are:
- they are marked as simultaneous
- they are attached to the same view (`Pressable` relies on this)
- the extracted gesture is `Hover`, which shouldn't block buttons, as that would make them effectively disabled

## Test plan

Tested on the updated `Nested touchables` example

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/d51f35b0-d5e2-4f45-ba9f-55dd62ea3a88" />|<video src="https://github.com/user-attachments/assets/55d58b4a-0264-4f6b-a5ae-b855f785e915" />|






