### PR TITLE
[iOS] Remove a redundant `detachHandlerWithTag` definition

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.h
@@ -16,7 +16,6 @@
                       toView:(nonnull RNGHUIView *)view
               withActionType:(RNGestureHandlerActionType)actionType
             withHostDetector:(nullable RNGHUIView *)hostDetector;
-- (void)detachHandlerWithTag:(nonnull NSNumber *)handlerTag;
 - (void)detachHandlerWithTag:(nonnull NSNumber *)handlerTag fromHostDetector:(nonnull RNGHUIView *)hostDetectorView;
 - (void)dropHandlerWithTag:(nonnull NSNumber *)handlerTag;
 - (void)dropAllHandlers;


### PR DESCRIPTION
## Description

Removes redundant `detachHandlerWithTag` definition, which was never used and never implemented. Most likely a result of a merge commit.

## Test plan

Compile the app
