### PR TITLE
[Web] Remove explicit reset from `onPointerCancel`

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -363,7 +363,6 @@ export default abstract class GestureHandler implements IGestureHandler {
     // No need to send a cancel touch event explicitly here. `cancel` will
     // handle cancelling all tracked touches if the handler expects pointer data.
     this.cancel();
-    this.reset();
   }
   protected onPointerOutOfBounds(event: AdaptedEvent): void {
     this.tryToSendMoveEvent(true, event);

--- a/packages/react-native-gesture-handler/src/web/handlers/HoverGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/HoverGestureHandler.ts
@@ -52,9 +52,4 @@ export default class HoverGestureHandler extends GestureHandler {
 
     super.onPointerMove(event);
   }
-
-  protected override onPointerCancel(event: AdaptedEvent): void {
-    super.onPointerCancel(event);
-    this.reset();
-  }
 }


### PR DESCRIPTION
## Description

https://github.com/software-mansion/react-native-gesture-handler/pull/4128 changed how handlers kept in the orchestrator are treated - those can now influence other handlers' state. When trying to use the `Touchable` component in the example app, I've noticed that other buttons become unresponsive after scrolling cancels the pressed button.

This turned out to be caused by an explicit `reset` call inside `onPointerCancel`. This caused the handler's state to go to `UNDETERMINED` between the change to `CANCELED` and the time the orchestrator runs `cleanupFinishedHandlers`. When the orchestrator goes over the handlers to clean, it ignores handlers that are not in a finished state. Since the gesture changed to `UNDETERMINED`, it was kept in the orchestrator after being canceled.

Note that the handler is still being reset by the orchestrator in a scheduled microtask.

## Test plan

I replaced `RectButtons` on in the example app list with `Touchables`

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/84f64388-9cac-4ac5-bc05-afc03007178e" />|<video src="https://github.com/user-attachments/assets/262d0215-3360-42a7-bb53-02ec1b8488ab" />|






