### PR TITLE
[Web] Don't call `cancel` on unregistered handlers

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -362,7 +362,9 @@ export default abstract class GestureHandler implements IGestureHandler {
   protected onPointerCancel(_event: AdaptedEvent): void {
     // No need to send a cancel touch event explicitly here. `cancel` will
     // handle cancelling all tracked touches if the handler expects pointer data.
-    this.cancel();
+    if (GestureHandlerOrchestrator.instance.isHandlerRecorded(this)) {
+      this.cancel();
+    }
   }
   protected onPointerOutOfBounds(event: AdaptedEvent): void {
     this.tryToSendMoveEvent(true, event);

--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -363,7 +363,6 @@ export default abstract class GestureHandler implements IGestureHandler {
     // No need to send a cancel touch event explicitly here. `cancel` will
     // handle cancelling all tracked touches if the handler expects pointer data.
     this.cancel();
-    this.reset();
   }
   protected onPointerOutOfBounds(event: AdaptedEvent): void {
     this.tryToSendMoveEvent(true, event);

--- a/packages/react-native-gesture-handler/src/web/handlers/HoverGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/HoverGestureHandler.ts
@@ -52,9 +52,4 @@ export default class HoverGestureHandler extends GestureHandler {
 
     super.onPointerMove(event);
   }
-
-  protected override onPointerCancel(event: AdaptedEvent): void {
-    super.onPointerCancel(event);
-    this.reset();
-  }
 }

--- a/packages/react-native-gesture-handler/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/GestureHandlerOrchestrator.ts
@@ -270,7 +270,7 @@ export default class GestureHandlerOrchestrator {
   }
 
   public recordHandlerIfNotPresent(handler: IGestureHandler): void {
-    if (this.gestureHandlers.includes(handler)) {
+    if (this.isHandlerRecorded(handler)) {
       return;
     }
 

--- a/packages/react-native-gesture-handler/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/GestureHandlerOrchestrator.ts
@@ -32,6 +32,10 @@ export default class GestureHandlerOrchestrator {
     handler.activationIndex = Number.MAX_VALUE;
   }
 
+  public isHandlerRecorded(handler: IGestureHandler): boolean {
+    return this.gestureHandlers.includes(handler);
+  }
+
   public removeHandlerFromOrchestrator(handler: IGestureHandler): void {
     const indexInGestureHandlers = this.gestureHandlers.indexOf(handler);
     const indexInAwaitingHandlers = this.awaitingHandlers.indexOf(handler);


### PR DESCRIPTION
## Description

On web, it was possible for a handler to get canceled twice: once by some internal condition, and once by `pointercancel` event. The first time was handled correctly, since the orchestrator tracked the gesture, and it was reset correctly after being canceled. The second time, the gesture was untracked after being reset and it was canceled "in the void" and it was kept in the canceled state until it was registered again, which allowed it to be cleaned properly.

It's easy to reproduce with a `Touchable` inside a `ScrollView` and starting to scroll near the very edge of the touchable. The first cancel happens when the pointer moves out of the touchable before the scroll starts, and the second one is caused by the scroll starting.

This PR changes the behavior so that handlers need to be registered in the orchestrator before being canceled.

## Test plan

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/5534bcd7-f160-4c6c-9fc9-53643364ca95" />|<video src="https://github.com/user-attachments/assets/31a6a53c-dfa3-427b-bc8e-0e74f99ff2f9" />|







