### PR TITLE
[iOS] Fix `enabled` state diverging between the handler and its recognizer

### DIFF
--- a/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
@@ -269,7 +269,6 @@
   [self triggerActionFromReset];
   [_gestureHandler.pointerTracker reset];
   [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(activateAfterLongPress) object:nil];
-  self.enabled = YES;
   [super reset];
   [_gestureHandler reset];
 

--- a/packages/react-native-gesture-handler/apple/Handlers/RNTapHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNTapHandler.m
@@ -258,7 +258,7 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
   [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
   _tapsSoFar = 0;
   _maxNumberOfTouches = 0;
-  self.enabled = YES;
+  self.enabled = _gestureHandler.enabled;
   [super reset];
   [_gestureHandler reset];
 }

--- a/packages/react-native-gesture-handler/apple/RNRootViewGestureRecognizer.m
+++ b/packages/react-native-gesture-handler/apple/RNRootViewGestureRecognizer.m
@@ -33,18 +33,6 @@
   return self;
 }
 
-- (BOOL)shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
-{
-  // This method is used to implement "enabled" feature for gesture handlers. We enforce gesture
-  // recognizers that are connected with "disabled" handlers to wait for the root gesture
-  // recognizer to fail and this way we block them from acting.
-  RNGestureHandler *otherHandler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
-  if (otherHandler != nil && otherHandler.enabled == NO) {
-    return YES;
-  }
-  return NO;
-}
-
 - (BOOL)canPreventGestureRecognizer:(UIGestureRecognizer *)preventedGestureRecognizer
 {
   return ![preventedGestureRecognizer isKindOfClass:[RCTSurfaceTouchHandler class]];


### PR DESCRIPTION
## Description

Since some recognizers changed their own state in `reset`, it was possible for the value to desync between the recognizer and the handler. This could lead to issues where a "disabled" handler would block other gestures from firing.

This PR:
- removes explicit `enabled = YES` from pan gesture, since it never changes the value by itself
- replaces `enabled = YES` with `enabled = _gestureHandler.enabled` for tap, since it can set its own `enabled` to `NO` to cancel itself
- removes `shouldBeRequiredToFailByGestureRecognizer` from the root recognizer - it was added in de0ffb4948d68ea575bef2f2ace2dc04aa9f9db6, before aligning `enabled` between recognizer and handler in a64b42536971014f7de939420c531f45c51d080d. Disabled recognizers should never be considered for recognition, so this is effectively a no-op.

## Test plan

Tested on the provided repro: https://github.com/pawicao/rngh-v3-testing/blob/enabled-repro/src/app/index.tsx

Zoom in, pan around, zoom out, try to scroll horizontally

