### PR TITLE
[General] Do not prepare config multiple times

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -31,7 +31,11 @@ export function useGesture<
   config: BaseGestureConfig<TConfig, THandlerData, TExtendedHandlerData>
 ): SingleGesture<TConfig, THandlerData, TExtendedHandlerData> {
   const handlerTag = useMemo(() => getNextHandlerTag(), []);
-  const previousConfig = useMemo(() => config, []);
+  const previousConfig = useMemo(() => {
+    prepareConfig(config);
+
+    return config;
+  }, []);
 
   if (config.disableReanimated !== previousConfig.disableReanimated) {
     throw new Error(

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -16,7 +16,6 @@ import type {
 import { useGestureCallbacks } from './useGestureCallbacks';
 import {
   bindSharedValues,
-  prepareConfig,
   prepareConfigForNativeSide,
   prepareRelations,
   unbindSharedValues,
@@ -31,24 +30,14 @@ export function useGesture<
   config: BaseGestureConfig<TConfig, THandlerData, TExtendedHandlerData>
 ): SingleGesture<TConfig, THandlerData, TExtendedHandlerData> {
   const handlerTag = useMemo(() => getNextHandlerTag(), []);
-  const initialDisableReanimated = useRef(config.disableReanimated);
-  const preparedConfig = useRef<typeof config | null>(null);
+  const disableReanimated = useMemo(() => config.disableReanimated, []);
 
-  if (config.disableReanimated !== initialDisableReanimated.current) {
+  if (config.disableReanimated !== disableReanimated) {
     throw new Error(
       tagMessage(
         'The "disableReanimated" property must not be changed after the handler is created.'
       )
     );
-  }
-
-  // This has to be done ASAP as other hooks depend `shouldUseReanimatedDetector`.
-  //
-  // We only need to prepare config once. If Reanimated is used and we try to prepare the same config again,
-  // it will result in warnings, as config has already been sent to the native side (i.e. config is frozen).
-  if (config !== preparedConfig.current) {
-    prepareConfig(config);
-    preparedConfig.current = config;
   }
 
   // TODO: Call only necessary hooks depending on which callbacks are defined (?)

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -31,13 +31,10 @@ export function useGesture<
   config: BaseGestureConfig<TConfig, THandlerData, TExtendedHandlerData>
 ): SingleGesture<TConfig, THandlerData, TExtendedHandlerData> {
   const handlerTag = useMemo(() => getNextHandlerTag(), []);
-  const previousConfig = useMemo(() => {
-    prepareConfig(config);
+  const initialDisableReanimated = useRef(config.disableReanimated);
+  const preparedConfig = useRef<typeof config | null>(null);
 
-    return config;
-  }, []);
-
-  if (config.disableReanimated !== previousConfig.disableReanimated) {
+  if (config.disableReanimated !== initialDisableReanimated.current) {
     throw new Error(
       tagMessage(
         'The "disableReanimated" property must not be changed after the handler is created.'
@@ -49,8 +46,9 @@ export function useGesture<
   //
   // We only need to prepare config once. If Reanimated is used and we try to prepare the same config again,
   // it will result in warnings, as config has already been sent to the native side (i.e. config is frozen).
-  if (config !== previousConfig) {
+  if (config !== preparedConfig.current) {
     prepareConfig(config);
+    preparedConfig.current = config;
   }
 
   // TODO: Call only necessary hooks depending on which callbacks are defined (?)

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -31,9 +31,9 @@ export function useGesture<
   config: BaseGestureConfig<TConfig, THandlerData, TExtendedHandlerData>
 ): SingleGesture<TConfig, THandlerData, TExtendedHandlerData> {
   const handlerTag = useMemo(() => getNextHandlerTag(), []);
-  const disableReanimated = useMemo(() => config.disableReanimated, []);
+  const previousConfig = useMemo(() => config, []);
 
-  if (config.disableReanimated !== disableReanimated) {
+  if (config.disableReanimated !== previousConfig.disableReanimated) {
     throw new Error(
       tagMessage(
         'The "disableReanimated" property must not be changed after the handler is created.'
@@ -42,7 +42,12 @@ export function useGesture<
   }
 
   // This has to be done ASAP as other hooks depend `shouldUseReanimatedDetector`.
-  prepareConfig(config);
+  //
+  // We only need to prepare config once. If Reanimated is used and we try to preapre the same config again,
+  // it will result in warnings, as config has already been sent to the native side (i.e. config is frozen).
+  if (config !== previousConfig) {
+    prepareConfig(config);
+  }
 
   // TODO: Call only necessary hooks depending on which callbacks are defined (?)
   const { jsEventHandler, reanimatedEventHandler, animatedEventHandler } =

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -43,7 +43,7 @@ export function useGesture<
 
   // This has to be done ASAP as other hooks depend `shouldUseReanimatedDetector`.
   //
-  // We only need to prepare config once. If Reanimated is used and we try to preapre the same config again,
+  // We only need to prepare config once. If Reanimated is used and we try to prepare the same config again,
   // it will result in warnings, as config has already been sent to the native side (i.e. config is frozen).
   if (config !== previousConfig) {
     prepareConfig(config);

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
@@ -125,7 +125,7 @@ function remapProps<
   TInternalConfig extends Record<string, unknown>,
 >(
   config: TConfig & TInternalConfig,
-  propsMapping: Map<string, string>
+  propsMapping: ReadonlyMap<string, string>
 ): TInternalConfig {
   type MergedConfig = TConfig & TInternalConfig;
 
@@ -156,7 +156,7 @@ export function useClonedAndRemappedConfig<
   config: ExcludeInternalConfigProps<
     BaseGestureConfig<TConfig, THandlerData, TExtendedHandlerData>
   >,
-  propsMapping: Map<string, string> = DEFAULT_PROPS_MAPPING,
+  propsMapping: ReadonlyMap<string, string> = DEFAULT_PROPS_MAPPING,
   propsTransformer: (
     config: TInternalConfig
   ) => TInternalConfig = DEFAULT_PROPS_TRANSFORMER

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
@@ -161,11 +161,15 @@ export function useClonedAndRemappedConfig<
       TExtendedHandlerData
     >(config);
 
-    return propsTransformer(
+    const transformedConfig = propsTransformer(
       remapProps<TConfig, TInternalConfig>(
         clonedConfig as TConfig & TInternalConfig,
         propsMapping
       )
     );
+
+    prepareConfig(transformedConfig);
+
+    return transformedConfig;
   }, [config, propsMapping, propsTransformer]);
 }

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
@@ -142,6 +142,11 @@ function remapProps<
   return config;
 }
 
+const DEFAULT_PROPS_MAPPING = new Map<string, string>();
+const DEFAULT_PROPS_TRANSFORMER = <TConfig extends object>(
+  config: TConfig
+): TConfig => config;
+
 export function useClonedAndRemappedConfig<
   TConfig extends Record<string, unknown>,
   THandlerData,
@@ -151,8 +156,10 @@ export function useClonedAndRemappedConfig<
   config: ExcludeInternalConfigProps<
     BaseGestureConfig<TConfig, THandlerData, TExtendedHandlerData>
   >,
-  propsMapping: Map<string, string> = new Map(),
-  propsTransformer: (config: TInternalConfig) => TInternalConfig = (cfg) => cfg
+  propsMapping: Map<string, string> = DEFAULT_PROPS_MAPPING,
+  propsTransformer: (
+    config: TInternalConfig
+  ) => TInternalConfig = DEFAULT_PROPS_TRANSFORMER
 ): BaseGestureConfig<TInternalConfig, THandlerData, TExtendedHandlerData> {
   return useMemo(() => {
     const clonedConfig = cloneConfig<

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
@@ -16,7 +16,7 @@ import {
 } from './propsWhiteList';
 import { hasWorkletEventHandlers, maybeUnpackValue } from './reanimatedUtils';
 
-export function prepareConfig<
+export function resolveInternalConfigProps<
   TConfig extends object,
   THandlerData,
   TExtendedHandlerData extends THandlerData,
@@ -168,7 +168,7 @@ export function useClonedAndRemappedConfig<
       )
     );
 
-    prepareConfig(transformedConfig);
+    resolveInternalConfigProps(transformedConfig);
 
     return transformedConfig;
   }, [config, propsMapping, propsTransformer]);

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/index.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/index.ts
@@ -1,5 +1,4 @@
 export {
-  prepareConfig,
   prepareConfigForNativeSide,
   useClonedAndRemappedConfig,
 } from './configUtils';


### PR DESCRIPTION
## Description

Calling `preapreConfig` multiple times with the same config object results in warning from `react-native-worklets`, as the config object is frozen once it is passed to the native side (e.g. [`bindSharedValues`](https://github.com/software-mansion/react-native-gesture-handler/blob/9d256aeca3e7ec4e3bafedc710070b21a64035ec/packages/react-native-gesture-handler/src/v3/hooks/utils/reanimatedUtils.ts#L67))

## Test plan

Tested on the [repro app](https://github.com/pawicao/rngh-v3-testing/tree/main).