### PR TITLE
[iOS] Disable visual feedback on disabled buttons

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -304,6 +304,10 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
 
 - (void)handleAnimatePressIn
 {
+  if (!_userEnabled) {
+    return;
+  }
+
   if (_pendingPressOutBlock) {
     dispatch_block_cancel(_pendingPressOutBlock);
     _pendingPressOutBlock = nil;


### PR DESCRIPTION
## Description

`Touchable` on iOS shows visual feedback when it's in `disabled` state. The callbacks are, correctly, not dispatched - the glitch is purely visual.

## Test plan

Add `disabled` to a `Touchable` with visual feedback and make sure it's not shown.
