### PR TITLE
[General] Avoid unnecessary object allocations

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
@@ -87,9 +87,8 @@ export function prepareConfigForNativeSide<
   for (const [key, value] of Object.entries(config)) {
     // @ts-ignore That's the point, we want to see if key exists in the whitelists
     if (allowedNativeProps.has(key) || handlerPropsWhiteList.has(key)) {
-      Object.assign(filteredConfig, {
-        [key]: Reanimated?.isSharedValue(value) ? value.value : value,
-      });
+      (filteredConfig as Record<string, unknown>)[key] =
+        Reanimated?.isSharedValue(value) ? value.value : value;
     } else if (PropsToFilter.has(key)) {
       continue;
     } else {

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/eventHandlersUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/eventHandlersUtils.ts
@@ -16,38 +16,49 @@ export function useMemoizedGestureCallbacks<
 >(
   callbacks: GestureCallbacks<THandlerData, TExtendedHandlerData>
 ): GestureCallbacks<THandlerData, TExtendedHandlerData> {
-  return useMemo(
-    () => ({
-      ...(callbacks.onBegin ? { onBegin: callbacks.onBegin } : {}),
-      ...(callbacks.onActivate ? { onActivate: callbacks.onActivate } : {}),
-      ...(callbacks.onDeactivate
-        ? { onDeactivate: callbacks.onDeactivate }
-        : {}),
-      ...(callbacks.onFinalize ? { onFinalize: callbacks.onFinalize } : {}),
-      ...(callbacks.onUpdate ? { onUpdate: callbacks.onUpdate } : {}),
-      ...(callbacks.onTouchesDown
-        ? { onTouchesDown: callbacks.onTouchesDown }
-        : {}),
-      ...(callbacks.onTouchesMove
-        ? { onTouchesMove: callbacks.onTouchesMove }
-        : {}),
-      ...(callbacks.onTouchesUp ? { onTouchesUp: callbacks.onTouchesUp } : {}),
-      ...(callbacks.onTouchesCancel
-        ? { onTouchesCancel: callbacks.onTouchesCancel }
-        : {}),
-    }),
-    [
-      callbacks.onActivate,
-      callbacks.onBegin,
-      callbacks.onDeactivate,
-      callbacks.onFinalize,
-      callbacks.onTouchesCancel,
-      callbacks.onTouchesDown,
-      callbacks.onTouchesMove,
-      callbacks.onTouchesUp,
-      callbacks.onUpdate,
-    ]
-  );
+  return useMemo(() => {
+    const memoized: GestureCallbacks<THandlerData, TExtendedHandlerData> = {};
+
+    if (callbacks.onBegin) {
+      memoized.onBegin = callbacks.onBegin;
+    }
+    if (callbacks.onActivate) {
+      memoized.onActivate = callbacks.onActivate;
+    }
+    if (callbacks.onDeactivate) {
+      memoized.onDeactivate = callbacks.onDeactivate;
+    }
+    if (callbacks.onFinalize) {
+      memoized.onFinalize = callbacks.onFinalize;
+    }
+    if (callbacks.onUpdate) {
+      memoized.onUpdate = callbacks.onUpdate;
+    }
+    if (callbacks.onTouchesDown) {
+      memoized.onTouchesDown = callbacks.onTouchesDown;
+    }
+    if (callbacks.onTouchesMove) {
+      memoized.onTouchesMove = callbacks.onTouchesMove;
+    }
+    if (callbacks.onTouchesUp) {
+      memoized.onTouchesUp = callbacks.onTouchesUp;
+    }
+    if (callbacks.onTouchesCancel) {
+      memoized.onTouchesCancel = callbacks.onTouchesCancel;
+    }
+
+    return memoized;
+  }, [
+    callbacks.onActivate,
+    callbacks.onBegin,
+    callbacks.onDeactivate,
+    callbacks.onFinalize,
+    callbacks.onTouchesCancel,
+    callbacks.onTouchesDown,
+    callbacks.onTouchesMove,
+    callbacks.onTouchesUp,
+    callbacks.onUpdate,
+  ]);
 }
 
 function getHandler<THandlerData, TExtendedHandlerData extends THandlerData>(

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/reanimatedUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/reanimatedUtils.ts
@@ -2,7 +2,6 @@ import { Reanimated } from '../../../handlers/gestures/reanimatedWrapper';
 import { NativeProxy } from '../../NativeProxy';
 import type {
   BaseGestureConfig,
-  GestureCallbacks,
   SharedValue,
   SharedValueOrT,
 } from '../../types';
@@ -101,14 +100,15 @@ export function hasWorkletEventHandlers<
   THandlerData,
   TExtendedHandlerData extends THandlerData,
 >(config: BaseGestureConfig<TConfig, THandlerData, TExtendedHandlerData>) {
-  return Object.entries(config).some(
-    ([key, value]) =>
-      HandlerCallbacks.has(
-        key as keyof GestureCallbacks<THandlerData, TExtendedHandlerData>
-      ) &&
-      typeof value === 'function' &&
-      '__workletHash' in value
-  );
+  for (const key of HandlerCallbacks) {
+    const value = config[key];
+
+    if (typeof value === 'function' && '__workletHash' in value) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function maybeUnpackValue<T>(


### PR DESCRIPTION
## Description

Removes unnecessary object allocations:
- `configUtils` - instead of using `Object.assign` and creating an object with a single key, the value is now assigned directly
- `eventHandlerUtils` - instead of allocating an object for each callback (even when undefined), the value is now assigned directly
- `reanimatedUtils` - instead of iterating over the entire config, allocating a `[key, value]` tuple for each field, iterate over the known callbacks

## Test plan

Run the example app
