### PR TITLE
Revert "Add RNRepo to ci builds (#4141)"

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -6,9 +6,6 @@ on:
       - .github/workflows/android-build.yml
       - packages/react-native-gesture-handler/android/**
       - apps/basic-example/android/**
-      - apps/basic-example/package.json
-      - rnrepo.config.json
-      - yarn.lock
   push:
     branches:
       - main
@@ -48,4 +45,4 @@ jobs:
 
       - name: Build app
         working-directory: ${{ matrix.working-directory }}/android
-        run: ./gradlew :app:assembleDebug --console=plain -PreactNativeArchitectures=arm64-v8a
+        run: ./gradlew assembleDebug --console=plain -PreactNativeArchitectures=arm64-v8a

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -7,9 +7,6 @@ on:
       - packages/react-native-gesture-handler/RNGestureHandler.podspec
       - packages/react-native-gesture-handler/apple/**
       - apps/basic-example/ios/**
-      - apps/basic-example/package.json
-      - rnrepo.config.json
-      - yarn.lock
   push:
     branches:
       - main

--- a/apps/basic-example/android/app/build.gradle
+++ b/apps/basic-example/android/app/build.gradle
@@ -2,21 +2,6 @@ apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
-def isCIEnabled() {
-    return ["1", "true"].contains(System.getenv("CI")?.toLowerCase())
-}
-
-def isRNRepoEnabled() {
-    // return false // Uncomment to disable RNRepo locally
-    return System.getenv("DISABLE_RNREPO") == null
-}
-
-// Use RNRepo in CI builds. 
-// Set DISABLE_RNREPO to any value to disable RNRepo.
-if (isCIEnabled() && isRNRepoEnabled()) {
-    apply plugin: "org.rnrepo.tools.prebuilds-plugin"
-}
-
 /**
  * This is the configuration block to customize your React Native Android app.
  * By default you don't need to apply any configuration, just uncomment the lines you need.

--- a/apps/basic-example/android/build.gradle
+++ b/apps/basic-example/android/build.gradle
@@ -12,22 +12,10 @@ buildscript {
         google()
         mavenCentral()
     }
-    // RNRepo plugin classpath for CI builds (plugin applied in app/build.gradle).
-    // To disable RNRepo support, set DISABLE_RNREPO environment variable to ANY value.
-    def rnrepoClasspath = {
-        def rnrepoDir = new File(
-            providers.exec {
-                workingDir(rootDir)
-                commandLine("node", "--print", "require.resolve('@rnrepo/build-tools/package.json')")
-            }.standardOutput.asText.get().trim()
-        ).getParentFile().absolutePath
-        return fileTree(dir: "${rnrepoDir}/gradle-plugin/build/libs", include: ["prebuilds-plugin.jar"])
-    }
     dependencies {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
-        classpath rnrepoClasspath()
     }
     allprojects {
         project.pluginManager.withPlugin("com.facebook.react") {

--- a/apps/basic-example/ios/Podfile
+++ b/apps/basic-example/ios/Podfile
@@ -5,24 +5,6 @@ require Pod::Executable.execute_command('node', ['-p',
     {paths: ["../../../node_modules"]},
   )', __dir__]).strip
 
-def is_ci_enabled?
-  %w[1 true].include?(ENV['CI'].to_s.downcase)
-end
-
-# ENV['DISABLE_RNREPO'] = "1" # Uncomment to disable RNRepo even in CI
-def is_rnrepo_enabled?
-  ENV['DISABLE_RNREPO'].nil?
-end
-
-# Use RNRepo in CI builds. Set DISABLE_RNREPO to any value to disable RNRepo.
-if is_ci_enabled? && is_rnrepo_enabled?
-  require Pod::Executable.execute_command('node', ['-p',
-    'require.resolve(
-      "@rnrepo/build-tools/cocoapods-plugin/lib/plugin.rb",
-      {paths: [process.argv[1]]},
-    )', __dir__]).strip
-end
-
 require_relative '../../../scripts/clangd-add-xcode-step.rb'
 
 ENV['GH_EXAMPLE_APP_NAME'] = 'BasicExample'
@@ -46,9 +28,6 @@ target 'BasicExample' do
   )
 
   post_install do |installer|
-    if is_ci_enabled? && is_rnrepo_enabled?
-      rnrepo_post_install(installer)
-    end
     react_native_post_install(
       installer,
       config[:reactNativePath],

--- a/apps/basic-example/package.json
+++ b/apps/basic-example/package.json
@@ -35,7 +35,6 @@
     "@react-native/jest-preset": "0.85.0",
     "@react-native/metro-config": "0.85.0",
     "@react-native/typescript-config": "0.85.0",
-    "@rnrepo/build-tools": "~0.1.3-beta.0",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.2.0",
     "@types/react-test-renderer": "^19.1.0",

--- a/apps/expo-example/app.config.js
+++ b/apps/expo-example/app.config.js
@@ -46,7 +46,6 @@ export default {
           ],
         },
       ],
-      "@rnrepo/expo-config-plugin",
     ],
   },
 };

--- a/apps/expo-example/package.json
+++ b/apps/expo-example/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
-    "@rnrepo/expo-config-plugin": "0.3.0-beta.3",
     "@types/react": "~19.1.10",
     "@types/react-dom": "~19.1.7",
     "@types/react-native-web": "^0",

--- a/rnrepo.config.json
+++ b/rnrepo.config.json
@@ -1,6 +1,0 @@
-{
-    "denyList": {
-        "android": ["react-native-gesture-handler"],
-        "ios": ["react-native-gesture-handler"]
-    }
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,27 +1844,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/config-plugins@npm:*":
-  version: 55.0.8
-  resolution: "@expo/config-plugins@npm:55.0.8"
-  dependencies:
-    "@expo/config-types": "npm:^55.0.5"
-    "@expo/json-file": "npm:~10.0.13"
-    "@expo/plist": "npm:^0.5.2"
-    "@expo/sdk-runtime-versions": "npm:^1.0.0"
-    chalk: "npm:^4.1.2"
-    debug: "npm:^4.3.5"
-    getenv: "npm:^2.0.0"
-    glob: "npm:^13.0.0"
-    resolve-from: "npm:^5.0.0"
-    semver: "npm:^7.5.4"
-    slugify: "npm:^1.6.6"
-    xcode: "npm:^3.0.1"
-    xml2js: "npm:0.6.0"
-  checksum: 10c0/14f15495ea885c295dbb4df6d0c88753099601b109489d8bdb7fd75caa52a47349edde11265fc5af26e48680cf5b54ccccffe7305cacf22542f24519bb13de58
-  languageName: node
-  linkType: hard
-
 "@expo/config-plugins@npm:~54.0.4":
   version: 54.0.4
   resolution: "@expo/config-plugins@npm:54.0.4"
@@ -1884,13 +1863,6 @@ __metadata:
     xcode: "npm:^3.0.1"
     xml2js: "npm:0.6.0"
   checksum: 10c0/c7537485a0e883d8a98f1fb93335a1f56d4be2c2a4b5676ba09a8e9253190996241022f841c437e64578fa63b20b6ecf843d88b52930b890fa199d7aa188253f
-  languageName: node
-  linkType: hard
-
-"@expo/config-types@npm:*, @expo/config-types@npm:^55.0.5":
-  version: 55.0.5
-  resolution: "@expo/config-types@npm:55.0.5"
-  checksum: 10c0/24ce0481cc465ddd3b53cfdde099ef4e899b1f8fff224a0f249b88c93e6c98930e99a55f3929eb53d08138b1b66102ece7b76e16f4e5fadcdf5bbac26c9c3d7e
   languageName: node
   linkType: hard
 
@@ -1998,7 +1970,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/json-file@npm:^10.0.13, @expo/json-file@npm:^10.0.8, @expo/json-file@npm:~10.0.13, @expo/json-file@npm:~10.0.8":
+"@expo/json-file@npm:^10.0.13, @expo/json-file@npm:^10.0.8, @expo/json-file@npm:~10.0.8":
   version: 10.0.13
   resolution: "@expo/json-file@npm:10.0.13"
   dependencies:
@@ -2115,17 +2087,6 @@ __metadata:
     base64-js: "npm:^1.2.3"
     xmlbuilder: "npm:^15.1.1"
   checksum: 10c0/5bacdb6f8c5e0e56da07f4504290036e3a5433164a29bea7857e72234137d8eaa04adb319221fcc1ec7f931d40d7f9f6fc9528fa601ed18c308a4cf8179f7783
-  languageName: node
-  linkType: hard
-
-"@expo/plist@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "@expo/plist@npm:0.5.2"
-  dependencies:
-    "@xmldom/xmldom": "npm:^0.8.8"
-    base64-js: "npm:^1.5.1"
-    xmlbuilder: "npm:^15.1.1"
-  checksum: 10c0/19adae2a365ac1a12db93682fb310ff8be03c711f9173bebe5841cbe60cdfb749247bc1a95fa0977b5bac3aa6a078a0fceeafe4ff6c66d1ed67cce496679e310
   languageName: node
   linkType: hard
 
@@ -4724,28 +4685,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rnrepo/build-tools@npm:0.1.3-beta.0, @rnrepo/build-tools@npm:~0.1.3-beta.0":
-  version: 0.1.3-beta.0
-  resolution: "@rnrepo/build-tools@npm:0.1.3-beta.0"
-  checksum: 10c0/83d2c2b05d87ab038d139c56b2e8ea1df071c41a51094a6464d9c7bc5794f25eb289b8b9298418e829d9ebfe723a77d5556fb1eaf69d87b25dda1f7d19d2d5fb
-  languageName: node
-  linkType: hard
-
-"@rnrepo/expo-config-plugin@npm:0.3.0-beta.3":
-  version: 0.3.0-beta.3
-  resolution: "@rnrepo/expo-config-plugin@npm:0.3.0-beta.3"
-  dependencies:
-    "@expo/config-plugins": "npm:*"
-    "@expo/config-types": "npm:*"
-    "@rnrepo/build-tools": "npm:0.1.3-beta.0"
-  peerDependencies:
-    expo: "*"
-    react: "*"
-    react-native: "*"
-  checksum: 10c0/e6d010122e04e4bb93d2410de7b0b6a28f512e810ddd7474f9f18565599a1cdd5a269374839d9987412c7006d731274d8b3cd6c8166e4eb187243035667e06a2
-  languageName: node
-  linkType: hard
-
 "@sideway/address@npm:^4.1.5":
   version: 4.1.5
   resolution: "@sideway/address@npm:4.1.5"
@@ -6320,7 +6259,6 @@ __metadata:
     "@react-native/jest-preset": "npm:0.85.0"
     "@react-native/metro-config": "npm:0.85.0"
     "@react-native/typescript-config": "npm:0.85.0"
-    "@rnrepo/build-tools": "npm:~0.1.3-beta.0"
     "@types/jest": "npm:^29.5.13"
     "@types/react": "npm:^19.2.0"
     "@types/react-test-renderer": "npm:^19.1.0"
@@ -8840,7 +8778,6 @@ __metadata:
     "@react-navigation/elements": "npm:^2.3.8"
     "@react-navigation/native": "npm:^7.1.6"
     "@react-navigation/stack": "npm:^7.2.10"
-    "@rnrepo/expo-config-plugin": "npm:0.3.0-beta.3"
     "@swmansion/icons": "npm:^0.0.1"
     "@types/react": "npm:~19.1.10"
     "@types/react-dom": "npm:~19.1.7"


### PR DESCRIPTION
This reverts commit 451eb504a1a84f6d5f79fc37e4d0e8d108acef4d.

## Description

`expo-example` on Android stopped working with
```
[Error: Exception in HostFunction: no non-static method "Lcom/swmansion/gesturehandler/react/RNGestureHandlerModule;.setReanimatedAvailable(Z)V"]

Code: NativeProxy.ts
  61 |   },
  62 |   setReanimatedAvailable: (isAvailable: boolean) => {
> 63 |     RNGestureHandlerModule.setReanimatedAvailable(isAvailable);
     |                                                  ^
  64 |   },
  65 | } as const;
  66 |
Call Stack
  setReanimatedAvailable (packages/react-native-gesture-handler/src/v3/NativeProxy.ts:63:50)
  <global> (packages/react-native-gesture-handler/src/handlers/gestures/reanimatedWrapper.ts:96:37)
  useAnimatedGesture (packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useAnimatedGesture.ts:105:35)
  GestureDetector (packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/index.tsx:87:65)
```
