### PR TITLE
Add rnrepo config to `expo-example`

### DIFF
--- a/apps/expo-example/rnrepo.config.json
+++ b/apps/expo-example/rnrepo.config.json
@@ -1,0 +1,6 @@
+{
+  "denyList": {
+    "android": ["react-native-gesture-handler"],
+    "ios": ["react-native-gesture-handler"]
+  }
+}


### PR DESCRIPTION
## Description

After merging #4141 our expo-example stopped working, throwing errors in Gesture Handler module on Android.

From Claude:

>1. RNRepo was supplying a stale prebuilt binary for expo-example
>
>apps/expo-example/android/app/build.gradle applies the RNRepo plugin unconditionally (unlike basic-example which gates it on CI=1). Because there was no rnrepo.config.json in apps/expo-example/, the denyList at the repo root wasn't found. RNRepo injected the prebuilt react-native-gesture-handler@2.29.0 binary, which predates the setReanimatedAvailable TurboModule binding and doesn't have it registered.

## Test plan

Run expo-example
