### PR TITLE
[General] Change `yieldsToNativeGestures` to `yieldsToContinuousGestures`

### DIFF
--- a/apps/common-app/src/new_api/components/swipeable/index.tsx
+++ b/apps/common-app/src/new_api/components/swipeable/index.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
-import { I18nManager, StyleSheet, Text, View } from 'react-native';
-import { FlatList, Pressable, RectButton } from 'react-native-gesture-handler';
+import { I18nManager, Platform, StyleSheet, Text, View } from 'react-native';
+import { FlatList, Pressable, Touchable } from 'react-native-gesture-handler';
 import type { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
 import ReanimatedSwipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
 import type { SharedValue } from 'react-native-reanimated';
@@ -19,14 +19,18 @@ type DataRow = {
 };
 
 const Row = ({ item }: { item: DataRow }) => (
-  // eslint-disable-next-line no-alert
-  <RectButton style={styles.rectButton} onPress={() => window.alert(item.from)}>
+  <Touchable
+    style={styles.rectButton}
+    // eslint-disable-next-line no-alert
+    onPress={() => window.alert(item.from)}
+    activeUnderlayOpacity={Platform.OS !== 'android' ? 0.1 : 0}
+    androidRipple={{}}>
     <Text style={styles.fromText}>{item.from}</Text>
     <Text numberOfLines={2} style={styles.messageText}>
       {item.message}
     </Text>
     <Text style={styles.dateText}>{item.when} ❭</Text>
-  </RectButton>
+  </Touchable>
 );
 
 const SwipeableRow = ({ item, index }: { item: DataRow; index: number }) => {

--- a/packages/docs-gesture-handler/docs/gestures/use-native-gesture.mdx
+++ b/packages/docs-gesture-handler/docs/gestures/use-native-gesture.mdx
@@ -115,13 +115,13 @@ disallowInterruption: boolean | SharedValue<boolean>;
 
 When `true`, this handler cancels all other gesture handlers when it activates.
 
-### yieldsToNativeGestures
+### yieldsToContinuousGestures
 
 ```ts
-yieldsToNativeGestures: boolean | SharedValue<boolean>;
+yieldsToContinuousGestures: boolean | SharedValue<boolean>;
 ```
 
-Composes with [`disallowInterruption`](#disallowinterruption). When both are `true`, this handler still cancels other gestures (such as `Pan` or `Tap`) on activation but allows other native gestures — for example a wrapping `ScrollView` — to interrupt it. No-op when `disallowInterruption` is `false`. Defaults to `false`.
+Composes with [`disallowInterruption`](#disallowinterruption). When both are `true`, this handler still cancels discrete gestures (`Tap`, `LongPress`, `Fling`) on activation but allows continuous gestures (`Pan`, `Pinch`, `Rotation`, `Native`, `Manual`, `Hover`) to interrupt it. No-op when `disallowInterruption` is `false`. Defaults to `false`.
 
 <BaseGestureConfig />
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -132,6 +132,11 @@ open class GestureHandler {
   var isAwaiting = false
   var shouldResetProgress = false
 
+  /**
+   * Whether the handler represents a continuous gesture rather than a discrete one.
+   */
+  open val isContinuous: Boolean = false
+
   open fun dispatchStateChange(newState: Int, prevState: Int) {
     onTouchEventListener?.onStateChange(this, newState, prevState)
   }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/HoverGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/HoverGestureHandler.kt
@@ -11,6 +11,8 @@ import com.swmansion.gesturehandler.react.RNViewConfigurationHelper
 import com.swmansion.gesturehandler.react.events.eventbuilders.HoverGestureHandlerEventDataBuilder
 
 class HoverGestureHandler : GestureHandler() {
+  override val isContinuous = true
+
   private var handler: Handler? = null
   private var finishRunnable = Runnable { finish() }
   var stylusData: StylusData = StylusData()

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/ManualGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/ManualGestureHandler.kt
@@ -5,6 +5,8 @@ import android.view.MotionEvent
 import com.swmansion.gesturehandler.react.events.eventbuilders.ManualGestureHandlerEventDataBuilder
 
 class ManualGestureHandler : GestureHandler() {
+  override val isContinuous = true
+
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
     if (state == STATE_UNDETERMINED) {
       begin()

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -20,6 +20,8 @@ import com.swmansion.gesturehandler.react.events.eventbuilders.NativeGestureHand
 import com.swmansion.gesturehandler.react.isScreenReaderOn
 
 class NativeViewGestureHandler : GestureHandler() {
+  override val isContinuous = true
+
   private var shouldActivateOnStart = false
 
   /**
@@ -32,10 +34,9 @@ class NativeViewGestureHandler : GestureHandler() {
 
   /**
    * Composes with [disallowInterruption]. When both are `true`, the handler still resists
-   * generic gesture peers (Pan, Tap, etc.) but yields to other [NativeViewGestureHandler] peers
-   * such as a wrapping ScrollView. No-op when [disallowInterruption] is `false`.
+   * discrete gesture peers but yields to continuous peers. No-op when [disallowInterruption] is `false`.
    */
-  var yieldsToNativeGestures = false
+  var yieldsToContinuousGestures = false
     private set
 
   private var hook: NativeViewGestureHandlerHook = defaultHook
@@ -52,7 +53,7 @@ class NativeViewGestureHandler : GestureHandler() {
     super.resetConfig()
     shouldActivateOnStart = DEFAULT_SHOULD_ACTIVATE_ON_START
     disallowInterruption = DEFAULT_DISALLOW_INTERRUPTION
-    yieldsToNativeGestures = DEFAULT_YIELDS_TO_NATIVE_GESTURES
+    yieldsToContinuousGestures = DEFAULT_YIELDS_TO_CONTINUOUS_GESTURES
     shouldCancelWhenOutside = DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE
   }
 
@@ -73,7 +74,7 @@ class NativeViewGestureHandler : GestureHandler() {
       // connection.
       if (handler.state == STATE_ACTIVE &&
         handler.disallowInterruption &&
-        !handler.yieldsToNativeGestures
+        !handler.yieldsToContinuousGestures
       ) {
         // other handler is active and it disallows interruption, we don't want to get into its way
         return false
@@ -98,13 +99,10 @@ class NativeViewGestureHandler : GestureHandler() {
 
   /**
    * Whether this handler permits [other] to take over the touch stream, given its
-   * `disallowInterruption` and `yieldsToNativeGestures` configuration.
+   * `disallowInterruption` and `yieldsToContinuousGestures` configuration.
    */
   fun canBeInterruptedBy(other: GestureHandler): Boolean = !disallowInterruption ||
-    (
-      yieldsToNativeGestures &&
-        (other is NativeViewGestureHandler || other is RNGestureHandlerRootHelper.RootViewGestureHandler)
-      )
+    (yieldsToContinuousGestures && other.isContinuous)
 
   override fun shouldBeginWithRecordedHandlers(recorded: List<GestureHandler>): Boolean =
     hook.shouldBeginWithRecordedHandlers(recorded, this)
@@ -226,8 +224,8 @@ class NativeViewGestureHandler : GestureHandler() {
       if (config.hasKey(KEY_DISALLOW_INTERRUPTION)) {
         handler.disallowInterruption = config.getBoolean(KEY_DISALLOW_INTERRUPTION)
       }
-      if (config.hasKey(KEY_YIELDS_TO_NATIVE_GESTURES)) {
-        handler.yieldsToNativeGestures = config.getBoolean(KEY_YIELDS_TO_NATIVE_GESTURES)
+      if (config.hasKey(KEY_YIELDS_TO_CONTINUOUS_GESTURES)) {
+        handler.yieldsToContinuousGestures = config.getBoolean(KEY_YIELDS_TO_CONTINUOUS_GESTURES)
       }
     }
 
@@ -236,7 +234,7 @@ class NativeViewGestureHandler : GestureHandler() {
     companion object {
       private const val KEY_SHOULD_ACTIVATE_ON_START = "shouldActivateOnStart"
       private const val KEY_DISALLOW_INTERRUPTION = "disallowInterruption"
-      private const val KEY_YIELDS_TO_NATIVE_GESTURES = "yieldsToNativeGestures"
+      private const val KEY_YIELDS_TO_CONTINUOUS_GESTURES = "yieldsToContinuousGestures"
     }
   }
 
@@ -244,7 +242,7 @@ class NativeViewGestureHandler : GestureHandler() {
     private const val DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE = true
     private const val DEFAULT_SHOULD_ACTIVATE_ON_START = false
     private const val DEFAULT_DISALLOW_INTERRUPTION = false
-    private const val DEFAULT_YIELDS_TO_NATIVE_GESTURES = false
+    private const val DEFAULT_YIELDS_TO_CONTINUOUS_GESTURES = false
 
     private fun tryIntercept(view: View, event: MotionEvent) = view is ViewGroup && view.onInterceptTouchEvent(event)
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
@@ -13,6 +13,8 @@ import com.swmansion.gesturehandler.core.GestureUtils.getLastPointerY
 import com.swmansion.gesturehandler.react.events.eventbuilders.PanGestureHandlerEventDataBuilder
 
 class PanGestureHandler(context: Context?) : GestureHandler() {
+  override val isContinuous = true
+
   var velocityX = 0f
     private set
   var velocityY = 0f

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
@@ -8,6 +8,8 @@ import com.swmansion.gesturehandler.react.events.eventbuilders.PinchGestureHandl
 import kotlin.math.abs
 
 class PinchGestureHandler : GestureHandler() {
+  override val isContinuous = true
+
   var scale = 0.0
     private set
   var velocity = 0.0

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
@@ -8,6 +8,8 @@ import com.swmansion.gesturehandler.react.events.eventbuilders.RotationGestureHa
 import kotlin.math.abs
 
 class RotationGestureHandler : GestureHandler() {
+  override val isContinuous = true
+
   private var rotationGestureDetector: RotationGestureDetector? = null
   var rotation = 0.0
     private set

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -66,6 +66,8 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
   }
 
   internal inner class RootViewGestureHandler(handlerTag: Int) : GestureHandler() {
+    override val isContinuous = true
+
     init {
       this.tag = handlerTag
     }

--- a/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
@@ -172,6 +172,11 @@ API_AVAILABLE(ios(13.4))
                                      withPointerType:_pointerType];
 }
 
+- (BOOL)isContinuous
+{
+  return YES;
+}
+
 @end
 
 #else
@@ -189,6 +194,11 @@ API_AVAILABLE(ios(13.4))
   }
 
   return self;
+}
+
+- (BOOL)isContinuous
+{
+  return YES;
 }
 
 - (void)bindToView:(RNGHUIView *)view

--- a/packages/react-native-gesture-handler/apple/Handlers/RNManualHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNManualHandler.m
@@ -135,4 +135,9 @@
   return self;
 }
 
+- (BOOL)isContinuous
+{
+  return YES;
+}
+
 @end

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -113,7 +113,7 @@
 @implementation RNNativeViewGestureHandler {
   BOOL _shouldActivateOnStart;
   BOOL _disallowInterruption;
-  BOOL _yieldsToNativeGestures;
+  BOOL _yieldsToContinuousGestures;
   RNGestureHandlerEventExtraData *_lastActiveExtraData;
 }
 
@@ -130,7 +130,7 @@
   [super updateConfig:config];
   _shouldActivateOnStart = [RCTConvert BOOL:config[@"shouldActivateOnStart"]];
   _disallowInterruption = [RCTConvert BOOL:config[@"disallowInterruption"]];
-  _yieldsToNativeGestures = [RCTConvert BOOL:config[@"yieldsToNativeGestures"]];
+  _yieldsToContinuousGestures = [RCTConvert BOOL:config[@"yieldsToContinuousGestures"]];
 }
 
 #if !TARGET_OS_OSX
@@ -241,14 +241,13 @@
 
   if (_disallowInterruption) {
     // When `disallowInterruption` is set we cancel all gesture handlers when this UIControl
-    // gets DOWN event. When `yieldsToNativeGestures` is also set we leave alone:
+    // gets DOWN event. When `yieldsToContinuousGestures` is also set we leave alone:
     //   - non-RNGH recognizers (e.g. UIScrollView's pan), so native containers can take over
-    //   - peer NativeViewGestureHandler recognizers (RNDummyGestureRecognizer), so wrapping
-    //     RNGH-managed scrollables/native handlers can still take over
+    //   - continuous RNGH recognizers, so other continuous gestures wrapping the touchable can still take over
     for (RNGHUITouch *touch in [event allTouches]) {
       for (UIGestureRecognizer *recognizer in [touch gestureRecognizers]) {
-        if (_yieldsToNativeGestures &&
-            (recognizer.gestureHandler == nil || [recognizer isKindOfClass:[RNDummyGestureRecognizer class]])) {
+        if (_yieldsToContinuousGestures &&
+            (recognizer.gestureHandler == nil || [recognizer.gestureHandler isContinuous])) {
           continue;
         }
 
@@ -357,6 +356,11 @@
   return [RNGestureHandlerEventExtraData forPointerInside:[self containsPointInView]
                                       withNumberOfTouches:1
                                           withPointerType:RNGestureHandlerMouse];
+}
+
+- (BOOL)isContinuous
+{
+  return YES;
 }
 
 @end

--- a/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
@@ -362,6 +362,11 @@
   return self;
 }
 
+- (BOOL)isContinuous
+{
+  return YES;
+}
+
 - (void)resetConfig
 {
   [super resetConfig];

--- a/packages/react-native-gesture-handler/apple/Handlers/RNPinchHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNPinchHandler.m
@@ -161,6 +161,11 @@
   return self;
 }
 
+- (BOOL)isContinuous
+{
+  return YES;
+}
+
 #if !TARGET_OS_TV
 
 #if TARGET_OS_OSX

--- a/packages/react-native-gesture-handler/apple/Handlers/RNRotationHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNRotationHandler.m
@@ -155,6 +155,11 @@
   return self;
 }
 
+- (BOOL)isContinuous
+{
+  return YES;
+}
+
 #if !TARGET_OS_TV
 
 #if TARGET_OS_OSX

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.h
@@ -137,6 +137,7 @@
 - (nonnull RNGHUIView *)findViewForEvents;
 - (BOOL)wantsToAttachDirectlyToView;
 - (BOOL)usesNativeOrVirtualDetector;
+- (BOOL)isContinuous;
 
 #if !TARGET_OS_OSX
 - (BOOL)isUIScrollViewPanGestureRecognizer:(nonnull UIGestureRecognizer *)gestureRecognizer;

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -848,4 +848,9 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   return NO;
 }
 
+- (BOOL)isContinuous
+{
+  return NO;
+}
+
 @end

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -138,7 +138,7 @@ export const Touchable = (props: TouchableProps) => {
     disableReanimated: true,
     shouldActivateOnStart: false,
     disallowInterruption: true,
-    yieldsToNativeGestures: true,
+    yieldsToContinuousGestures: true,
   });
 
   const rippleProps = shouldUseNativeRipple

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/NativeTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/NativeTypes.ts
@@ -23,16 +23,20 @@ export type NativeGestureNativeProperties = {
 
   /**
    * Composes with `disallowInterruption`. When both are `true`, the handler still
-   * resists generic gesture peers (Pan, Tap, etc.) but yields to other
-   * `NativeViewGestureHandler` peers such as a wrapping ScrollView. No-op when
-   * `disallowInterruption` is `false`.
+   * resists discrete gestures but yields to continuous gestures, so a wrapping
+   * gesture can take over the touch stream. No-op when `disallowInterruption` is
+   * `false`.
    */
-  yieldsToNativeGestures?: boolean;
+  yieldsToContinuousGestures?: boolean;
 };
 
 export const NativeHandlerNativeProperties = new Set<
   keyof NativeGestureNativeProperties
->(['shouldActivateOnStart', 'disallowInterruption', 'yieldsToNativeGestures']);
+>([
+  'shouldActivateOnStart',
+  'disallowInterruption',
+  'yieldsToContinuousGestures',
+]);
 
 export type NativeHandlerData = {
   pointerInside: boolean;

--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -1098,6 +1098,11 @@ export default abstract class GestureHandler implements IGestureHandler {
     this._name = value;
   }
 
+  /**
+   * Whether the handler represents a continuous gesture rather than a discrete one.
+   */
+  public readonly isContinuous: boolean = false;
+
   public getTrackedPointersID(): number[] {
     return this.tracker.trackedPointersIDs;
   }

--- a/packages/react-native-gesture-handler/src/web/handlers/HoverGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/HoverGestureHandler.ts
@@ -8,6 +8,8 @@ import GestureHandler from './GestureHandler';
 import type IGestureHandler from './IGestureHandler';
 
 export default class HoverGestureHandler extends GestureHandler {
+  public override readonly isContinuous = true;
+
   private stylusData: StylusData | undefined;
 
   public constructor(

--- a/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
@@ -22,6 +22,7 @@ export default interface IGestureHandler {
   readonly delegate: GestureHandlerDelegate<unknown, this>;
   readonly tracker: PointerTracker;
   readonly name: SingleGestureName;
+  readonly isContinuous: boolean;
   state: State;
   shouldCancelWhenOutside: boolean;
   shouldResetProgress: boolean;

--- a/packages/react-native-gesture-handler/src/web/handlers/ManualGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/ManualGestureHandler.ts
@@ -5,6 +5,8 @@ import GestureHandler from './GestureHandler';
 import type IGestureHandler from './IGestureHandler';
 
 export default class ManualGestureHandler extends GestureHandler {
+  public override readonly isContinuous = true;
+
   public constructor(
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>
   ) {

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -17,13 +17,15 @@ import GestureHandler from './GestureHandler';
 import type IGestureHandler from './IGestureHandler';
 
 export default class NativeViewGestureHandler extends GestureHandler {
+  public override readonly isContinuous = true;
+
   private buttonRole!: boolean;
   private switchRole!: boolean;
 
   // TODO: Implement logic for activation on start properly
   private shouldActivateOnStart = false;
   private disallowInterruption = false;
-  private yieldsToNativeGestures = false;
+  private yieldsToContinuousGestures = false;
 
   private startX = 0;
   private startY = 0;
@@ -68,8 +70,8 @@ export default class NativeViewGestureHandler extends GestureHandler {
     if (config.disallowInterruption !== undefined) {
       this.disallowInterruption = config.disallowInterruption;
     }
-    if (config.yieldsToNativeGestures !== undefined) {
-      this.yieldsToNativeGestures = config.yieldsToNativeGestures;
+    if (config.yieldsToContinuousGestures !== undefined) {
+      this.yieldsToContinuousGestures = config.yieldsToContinuousGestures;
     }
 
     const view = this.delegate.view as HTMLElement;
@@ -186,15 +188,14 @@ export default class NativeViewGestureHandler extends GestureHandler {
       handler instanceof NativeViewGestureHandler &&
       handler.state === State.ACTIVE &&
       handler.disallowsInterruption() &&
-      !handler.yieldsToOtherNativeGestures()
+      !handler.yieldsToContinuousGestures
     ) {
       return false;
     }
 
     const canBeInterrupted =
       !this.disallowInterruption ||
-      (this.yieldsToNativeGestures &&
-        handler instanceof NativeViewGestureHandler);
+      (this.yieldsToContinuousGestures && handler.isContinuous);
 
     if (
       this.state === State.ACTIVE &&
@@ -212,8 +213,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
   public override shouldBeCancelledByOther(handler: IGestureHandler): boolean {
     return (
       !this.disallowInterruption ||
-      (this.yieldsToNativeGestures &&
-        handler instanceof NativeViewGestureHandler)
+      (this.yieldsToContinuousGestures && handler.isContinuous)
     );
   }
 
@@ -223,10 +223,6 @@ export default class NativeViewGestureHandler extends GestureHandler {
 
   public disallowsInterruption(): boolean {
     return this.disallowInterruption;
-  }
-
-  public yieldsToOtherNativeGestures(): boolean {
-    return this.yieldsToNativeGestures;
   }
 
   public isButton(): boolean {

--- a/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
@@ -13,6 +13,8 @@ const DEFAULT_MAX_POINTERS = 10;
 const DEFAULT_MIN_DIST_SQ = DEFAULT_TOUCH_SLOP * DEFAULT_TOUCH_SLOP;
 
 export default class PanGestureHandler extends GestureHandler {
+  public override readonly isContinuous = true;
+
   public velocityX = 0;
   public velocityY = 0;
 

--- a/packages/react-native-gesture-handler/src/web/handlers/PinchGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PinchGestureHandler.ts
@@ -10,6 +10,8 @@ import GestureHandler from './GestureHandler';
 import type IGestureHandler from './IGestureHandler';
 
 export default class PinchGestureHandler extends GestureHandler {
+  public override readonly isContinuous = true;
+
   private scale = 1;
   private velocity = 0;
 

--- a/packages/react-native-gesture-handler/src/web/handlers/RotationGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/RotationGestureHandler.ts
@@ -11,6 +11,8 @@ import type IGestureHandler from './IGestureHandler';
 const ROTATION_RECOGNITION_THRESHOLD = Math.PI / 36;
 
 export default class RotationGestureHandler extends GestureHandler {
+  public override readonly isContinuous = true;
+
   private rotation = 0;
   private velocity = 0;
 

--- a/packages/react-native-gesture-handler/src/web/interfaces.ts
+++ b/packages/react-native-gesture-handler/src/web/interfaces.ts
@@ -88,7 +88,7 @@ export interface Config extends Record<string, ConfigArgs> {
   maxDeltaY?: number;
   shouldActivateOnStart?: boolean;
   disallowInterruption?: boolean;
-  yieldsToNativeGestures?: boolean;
+  yieldsToContinuousGestures?: boolean;
   direction?: Directions;
   enableTrackpadTwoFingerGesture?: boolean;
 }


### PR DESCRIPTION
## Description

Changes `yieldsToNativeGestures` to `yieldsToContinuousGestures`. Instead of allowing native gestures to take precedence, it allows all continuous gestures to do so.

## Test plan

Updated `Reanimated Swipeable` example to use `Touchable`
