### PR TITLE
[Android] Unify `Pinch` and `Rotation` with respect to `iOS`

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
@@ -86,11 +86,11 @@ class PinchGestureHandler : GestureHandler() {
       this.focalPointY = point.y
     }
 
-    if (sourceEvent.actionMasked == MotionEvent.ACTION_UP && state != STATE_UNDETERMINED) {
-      if (state == STATE_ACTIVE) {
-        end()
-      } else {
-        fail()
+    if (sourceEvent.actionMasked == MotionEvent.ACTION_UP) {
+      when (state) {
+        STATE_UNDETERMINED -> cancel()
+        STATE_ACTIVE -> end()
+        else -> fail()
       }
     }
   }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
@@ -68,9 +68,13 @@ class PinchGestureHandler : GestureHandler() {
     }
 
     if (state == STATE_UNDETERMINED) {
-      initialize(event, sourceEvent)
-      begin()
+      if (sourceEvent.actionMasked == MotionEvent.ACTION_POINTER_DOWN) {
+        begin()
+      } else {
+        initialize(event, sourceEvent)
+      }
     }
+
     scaleGestureDetector?.onTouchEvent(sourceEvent)
     scaleGestureDetector?.let {
       val point = transformPoint(PointF(it.focusX, it.focusY))
@@ -78,7 +82,7 @@ class PinchGestureHandler : GestureHandler() {
       this.focalPointY = point.y
     }
 
-    if (sourceEvent.actionMasked == MotionEvent.ACTION_UP) {
+    if (sourceEvent.actionMasked == MotionEvent.ACTION_UP && state != STATE_UNDETERMINED) {
       if (state == STATE_ACTIVE) {
         end()
       } else {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
@@ -68,10 +68,14 @@ class PinchGestureHandler : GestureHandler() {
     }
 
     if (state == STATE_UNDETERMINED) {
-      if (sourceEvent.actionMasked == MotionEvent.ACTION_POINTER_DOWN) {
-        begin()
-      } else {
-        initialize(event, sourceEvent)
+      when (sourceEvent.actionMasked) {
+        MotionEvent.ACTION_DOWN -> {
+          initialize(event, sourceEvent)
+        }
+
+        MotionEvent.ACTION_POINTER_DOWN -> {
+          begin()
+        }
       }
     }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
@@ -79,8 +79,11 @@ class RotationGestureHandler : GestureHandler() {
 
     // ACTION_UP is already handled in rotationGestureDetector.onTouchEvent (and effectively in onRotationEnd)
     // if more than one pointer was used
-    if (sourceEvent.actionMasked == MotionEvent.ACTION_UP && state == STATE_BEGAN) {
-      fail()
+    if (sourceEvent.actionMasked == MotionEvent.ACTION_UP) {
+      when (state) {
+        STATE_UNDETERMINED -> cancel()
+        STATE_BEGAN -> fail()
+      }
     }
   }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
@@ -59,10 +59,14 @@ class RotationGestureHandler : GestureHandler() {
     }
 
     if (state == STATE_UNDETERMINED) {
-      if (sourceEvent.actionMasked == MotionEvent.ACTION_POINTER_DOWN) {
-        begin()
-      } else {
-        initialize(event, sourceEvent)
+      when (sourceEvent.actionMasked) {
+        MotionEvent.ACTION_DOWN -> {
+          initialize(event, sourceEvent)
+        }
+
+        MotionEvent.ACTION_POINTER_DOWN -> {
+          begin()
+        }
       }
     }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
@@ -59,9 +59,13 @@ class RotationGestureHandler : GestureHandler() {
     }
 
     if (state == STATE_UNDETERMINED) {
-      initialize(event, sourceEvent)
-      begin()
+      if (sourceEvent.actionMasked == MotionEvent.ACTION_POINTER_DOWN) {
+        begin()
+      } else {
+        initialize(event, sourceEvent)
+      }
     }
+
     rotationGestureDetector?.onTouchEvent(sourceEvent)
     rotationGestureDetector?.let {
       val point = transformPoint(PointF(it.anchorX, it.anchorY))


### PR DESCRIPTION
## Description

In `PInch` and `Rotation` handlers on Android, `onBegin` callback is triggered when the first pointer is placed on the handler. This is a mismatch between `iOS`, where it is required to have 2 pointers in order to fire `onBegin`. 

Since 2 pointers are more natural for `Pinch` and `Rotation` we decided to change `Android` behavior to match `iOS`

## Test plan

Tested on Transformations example and on the code below.

<details>
<summary>Test code</summary>

```tsx
import { StyleSheet, View } from 'react-native';
import {
  GestureDetector,
  GestureHandlerRootView,
  usePinchGesture,
  useRotationGesture,
} from 'react-native-gesture-handler';

export default function App() {
  const pinch = usePinchGesture({
    onBegin: () => {
      console.log('pinch began');
    },
    onActivate: () => {
      console.log('pinch activated');
    },
    onUpdate: () => {
      console.log('pinch updated');
    },
    onDeactivate: () => {
      console.log('pinch deactivated');
    },
    onFinalize: () => {
      console.log('pinch finalized');
    },
  });

  const rotation = useRotationGesture({
    onBegin: () => {
      console.log('rotation began');
    },
    onActivate: () => {
      console.log('rotation activated');
    },
    onUpdate: () => {
      console.log('rotation updated');
    },
    onDeactivate: () => {
      console.log('rotation deactivated');
    },
    onFinalize: () => {
      console.log('rotation finalized');
    },
  });

  return (
    <GestureHandlerRootView style={styles.root}>
      <GestureDetector gesture={pinch}>
        <View style={[styles.circle, styles.pinchCircle]} />
      </GestureDetector>
      <GestureDetector gesture={rotation}>
        <View style={[styles.circle, styles.rotationCircle]} />
      </GestureDetector>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  root: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    gap: 40,
  },
  circle: {
    width: 150,
    height: 150,
    borderRadius: 75,
  },
  pinchCircle: {
    backgroundColor: 'royalblue',
  },
  rotationCircle: {
    backgroundColor: 'tomato',
  },
});
```

</details>