### PR TITLE
[Web] Do not reset `role` on handler reset

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -306,6 +306,5 @@ export default class NativeViewGestureHandler extends GestureHandler {
   public override reset(): void {
     super.reset();
     this.lastActiveHandlerData = null;
-    this.role = null;
   }
 }


### PR DESCRIPTION
## Description

`reset` method in `Native` gesture sets `role` to `null`. This property is set in `init`, so reset leaves it as `null` throughout the gestures' lifecycle. This prevents `Native` gesture from activation, therefore `Pressable` worked only at first click.

`Role` is still reset on `detach`, for old API this should be safe, as the underlying view shouldn't be changed.

## Test plan

Tested on `Pressable` example
