### PR TITLE
[Android] Remove getChildInDrawingOrderAtIndex

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -624,7 +624,7 @@ class GestureHandlerOrchestrator(
 
     val childrenCount = viewGroup.childCount
     for (i in childrenCount - 1 downTo 0) {
-      val child = viewConfigHelper.getChildInDrawingOrderAtIndex(viewGroup, i)
+      val child = viewGroup.getChildAt(i)
       if (canReceiveEvents(child)) {
         val childPoint = tempPoint
         transformPointToChildViewCoords(coords[0], coords[1], viewGroup, child, childPoint)

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/HoverGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/HoverGestureHandler.kt
@@ -7,7 +7,6 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import com.swmansion.gesturehandler.react.RNGestureHandlerRootHelper
-import com.swmansion.gesturehandler.react.RNViewConfigurationHelper
 import com.swmansion.gesturehandler.react.events.eventbuilders.HoverGestureHandlerEventDataBuilder
 
 class HoverGestureHandler : GestureHandler() {
@@ -44,7 +43,7 @@ class HoverGestureHandler : GestureHandler() {
 
     if (rootView is ViewGroup) {
       for (i in 0 until rootView.childCount) {
-        val child = viewConfigHelper.getChildInDrawingOrderAtIndex(rootView, i)
+        val child = rootView.getChildAt(i)
         return isViewDisplayedOverAnother(view, other, child) ?: continue
       }
     }
@@ -144,9 +143,5 @@ class HoverGestureHandler : GestureHandler() {
     override fun create(context: Context?): HoverGestureHandler = HoverGestureHandler()
 
     override fun createEventBuilder(handler: HoverGestureHandler) = HoverGestureHandlerEventDataBuilder(handler)
-  }
-
-  companion object {
-    private val viewConfigHelper = RNViewConfigurationHelper()
   }
 }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/ViewConfigurationHelper.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/ViewConfigurationHelper.kt
@@ -5,6 +5,5 @@ import android.view.ViewGroup
 
 interface ViewConfigurationHelper {
   fun getPointerEventsConfigForView(view: View): PointerEventsConfig
-  fun getChildInDrawingOrderAtIndex(parent: ViewGroup, index: Int): View
   fun isViewClippingChildren(view: ViewGroup): Boolean
 }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNViewConfigurationHelper.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNViewConfigurationHelper.kt
@@ -38,12 +38,6 @@ class RNViewConfigurationHelper : ViewConfigurationHelper {
     }
   }
 
-  override fun getChildInDrawingOrderAtIndex(parent: ViewGroup, index: Int): View = if (parent is ReactViewGroup) {
-    parent.getChildAt(parent.getZIndexMappedChildIndex(index))
-  } else {
-    parent.getChildAt(index)
-  }
-
   override fun isViewClippingChildren(view: ViewGroup) = when {
     view.clipChildren -> true
     view is ReactScrollView -> view.overflow != "visible"


### PR DESCRIPTION
## Summary
  - Remove the `getChildInDrawingOrderAtIndex` abstraction from `ViewConfigurationHelper` and its implementation in `RNViewConfigurationHelper`
  - Inline `viewGroup.getChildAt(i)` at the two call sites (`GestureHandlerOrchestrator` and `HoverGestureHandler`)
  - `ReactViewGroup.getZIndexMappedChildIndex` is a legacy architecture API that has been a no-op (returns its input unchanged) and has been removed in https://github.com/facebook/react-native/pull/56717

  ## Test plan
  - Android build via `cd apps/basic-example && yarn android`