### PR TITLE
feat(ios): publish open swipeable frame for native-stack pop arbitration

### DIFF
--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
@@ -1,7 +1,13 @@
 import type { ForwardedRef } from 'react';
-import { useCallback, useImperativeHandle, useMemo } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from 'react';
 import type { LayoutChangeEvent } from 'react-native';
-import { I18nManager, StyleSheet, View } from 'react-native';
+import { I18nManager, NativeModules, StyleSheet, View } from 'react-native';
 import Animated, {
   interpolate,
   measure,
@@ -31,6 +37,43 @@ const DEFAULT_DRAG_OFFSET = 10;
 const DEFAULT_ENABLE_TRACKING_TWO_FINGER_GESTURE = false;
 
 const Swipeable = (props: SwipeableProps) => {
+  const containerRef = useRef<View>(null);
+  const isOpenRef = useRef(false);
+  const swipeableRegistry = NativeModules.RNSSwipeableRegistry as
+    | {
+        setOpenSwipeableFrame?: (
+          x: number,
+          y: number,
+          width: number,
+          height: number
+        ) => void;
+        clearOpenSwipeable?: () => void;
+      }
+    | undefined;
+
+  const syncOpenSwipeableFrame = useCallback(() => {
+    if (!containerRef.current) {
+      return;
+    }
+    containerRef.current.measureInWindow((x, y, width, height) => {
+      swipeableRegistry?.setOpenSwipeableFrame?.(x, y, width, height);
+    });
+  }, [swipeableRegistry]);
+
+  const clearOpenSwipeableFrame = useCallback(() => {
+    swipeableRegistry?.clearOpenSwipeable?.();
+  }, [swipeableRegistry]);
+
+  const markOpen = useCallback(() => {
+    isOpenRef.current = true;
+    syncOpenSwipeableFrame();
+  }, [syncOpenSwipeableFrame]);
+
+  const markClosed = useCallback(() => {
+    isOpenRef.current = false;
+    clearOpenSwipeableFrame();
+  }, [clearOpenSwipeableFrame]);
+
   const {
     ref,
     leftThreshold,
@@ -154,8 +197,14 @@ const Swipeable = (props: SwipeableProps) => {
           fromValue > 0 ? SwipeDirection.LEFT : SwipeDirection.RIGHT
         );
       }
+
+      if (toValue !== 0) {
+        runOnJS(markOpen)();
+      } else {
+        runOnJS(markClosed)();
+      }
     },
-    [onSwipeableWillClose, onSwipeableWillOpen]
+    [markClosed, markOpen, onSwipeableWillClose, onSwipeableWillOpen]
   );
 
   const dispatchEndEvents = useCallback(
@@ -337,9 +386,20 @@ const Swipeable = (props: SwipeableProps) => {
   const onRowLayout = useCallback(
     ({ nativeEvent }: LayoutChangeEvent) => {
       rowWidth.value = nativeEvent.layout.width;
+      if (isOpenRef.current) {
+        syncOpenSwipeableFrame();
+      }
     },
-    [rowWidth]
+    [rowWidth, syncOpenSwipeableFrame]
   );
+
+  useEffect(() => {
+    return () => {
+      if (isOpenRef.current) {
+        clearOpenSwipeableFrame();
+      }
+    };
+  }, [clearOpenSwipeableFrame]);
 
   // As stated in `Dimensions.get` docstring, this function should be called on every render
   // since dimensions may change (e.g. orientation change)
@@ -523,6 +583,7 @@ const Swipeable = (props: SwipeableProps) => {
   const swipeableComponent = (
     <GestureDetector gesture={panGesture} touchAction="pan-y">
       <Animated.View
+        ref={containerRef}
         {...remainingProps}
         onLayout={onRowLayout}
         style={[styles.container, containerStyle]}>

--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
@@ -52,16 +52,26 @@ const Swipeable = (props: SwipeableProps) => {
     | undefined;
 
   const syncOpenSwipeableFrame = useCallback(() => {
-    if (!containerRef.current) {
+    const setOpenSwipeableFrame = swipeableRegistry?.setOpenSwipeableFrame;
+    if (!containerRef.current || !setOpenSwipeableFrame) {
       return;
     }
-    containerRef.current.measureInWindow((x, y, width, height) => {
-      swipeableRegistry?.setOpenSwipeableFrame?.(x, y, width, height);
-    });
+
+    containerRef.current.measureInWindow(
+      (x: number, y: number, width: number, height: number) => {
+        setOpenSwipeableFrame(x, y, width, height);
+      }
+    );
   }, [swipeableRegistry]);
 
+  // Current coordination stores one active open swipeable frame.
+  // Multi-open ownership scoping (token/reactTag) can be added in follow-up.
   const clearOpenSwipeableFrame = useCallback(() => {
-    swipeableRegistry?.clearOpenSwipeable?.();
+    const clearOpenSwipeable = swipeableRegistry?.clearOpenSwipeable;
+    if (!clearOpenSwipeable) {
+      return;
+    }
+    clearOpenSwipeable();
   }, [swipeableRegistry]);
 
   const markOpen = useCallback(() => {
@@ -369,6 +379,7 @@ const Swipeable = (props: SwipeableProps) => {
         showLeftProgress.value = 0;
         appliedTranslation.value = 0;
         rowState.value = 0;
+        runOnJS(markClosed)();
       },
     }),
     [


### PR DESCRIPTION
**Summary**
This PR updates ReanimatedSwipeable to publish open/close frame state to a native coordination module (RNSSwipeableRegistry) so native-stack gesture arbitration can distinguish:

swipe inside open swipeable -> close swipeable
swipe outside -> allow interactive pop
This is the RNGH companion to the react-native-screens change that reads this state in gestureRecognizerShouldBegin.

**Changes**
ReanimatedSwipeable.tsx
- add NativeModules.RNSSwipeableRegistry integration
- on open transition: mark open + report frame via measureInWindow
- on close transition: clear open swipeable state
- resync frame on layout while open
- clear state on unmount
- attach ref to root swipeable container for frame measurement

**Why**
With native-stack full-screen back gesture, native pop can win over swipeable close gesture.
Publishing swipeable active area to native enables deterministic arbitration at the native recognizer layer.

**Compatibility**
- Calls are optional-chained; if registry is unavailable, behavior remains unchanged.
- No API change in ReanimatedSwipeable props.

**Related**
- Related issue: [software-mansion/react-native-gesture-handler#4104](https://github.com/software-mansion/react-native-gesture-handler/issues/4104)
- Companion PR in react-native-screens: https://github.com/software-mansion/react-native-screens/pull/3989

**Test Plan**
-  Open swipeable row and swipe right starting inside row -> row closes
-  Swipe right starting outside row -> screen pops
-  With no row open -> normal behavior unchanged
-  Unmount/remount list screen -> no stale swipeable state leaks