### PR TITLE
[Web] Do not set `role` on non HTMLElement nodes

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/detectors/useNativeGestureRole.web.ts
+++ b/packages/react-native-gesture-handler/src/v3/detectors/useNativeGestureRole.web.ts
@@ -9,9 +9,9 @@ export function useNativeGestureRole(
   children: ReactNode
 ): void {
   useEffect(() => {
-    const child = viewRef.current?.firstChild as HTMLElement | undefined;
+    const child = viewRef.current?.firstChild;
 
-    if (!child) {
+    if (!(child instanceof HTMLElement)) {
       return;
     }
 


### PR DESCRIPTION
## Description

In Gesture Handler 3 it is possible to attach `GestureDetector` not only to `Views`, but also to `Text`. However, this crashes on `removeAttribute` method.

## Test plan

Nested text example
