### PR TITLE
[General] Update `Touchable` animation duration props

### DIFF
--- a/apps/common-app/App.tsx
+++ b/apps/common-app/App.tsx
@@ -160,7 +160,7 @@ export default function App() {
       <View style={styles.settings}>
         <Touchable
           androidRipple={{}}
-          activeUnderlayOpacity={Platform.OS !== 'android' ? 0.1 : 0}
+          underlayColor={Platform.OS === 'android' ? 'transparent' : 'black'}
           style={styles.settingsButton}
           onPress={() => {
             updateKeepSetting(!openLastExample);
@@ -182,7 +182,7 @@ export default function App() {
         </Touchable>
         <Touchable
           androidRipple={{}}
-          activeUnderlayOpacity={Platform.OS !== 'android' ? 0.1 : 0}
+          underlayColor={Platform.OS === 'android' ? 'transparent' : 'black'}
           style={styles.settingsButton}
           onPress={() => {
             updateVersionSetting(!showLegacyVersion);
@@ -222,7 +222,7 @@ export default function App() {
         disabled={disabled}
         style={[styles.button, disabled && styles.unavailableExample]}
         androidRipple={{}}
-        activeUnderlayOpacity={Platform.OS !== 'android' ? 0.1 : 0}
+        underlayColor={Platform.OS === 'android' ? 'transparent' : 'black'}
         onPress={() => onPressItem(name)}>
         <Text style={styles.text}>{name}</Text>
         {Platform.OS !== 'macos' && !disabled && (

--- a/apps/common-app/src/new_api/components/button_underlay/index.tsx
+++ b/apps/common-app/src/new_api/components/button_underlay/index.tsx
@@ -10,8 +10,7 @@ const UNDERLAY_PROPS = {
   underlayColor: 'red',
   activeUnderlayOpacity: 0.2,
   activeScale: 0.9,
-  pressAndHoldAnimationDuration: 200,
-  tapAnimationDuration: 100,
+  animationDruation: 100,
   rippleColor: 'transparent',
 } as const;
 

--- a/apps/common-app/src/new_api/components/touchable/index.tsx
+++ b/apps/common-app/src/new_api/components/touchable/index.tsx
@@ -147,6 +147,87 @@ export default function TouchableExample() {
         </View>
 
         <View style={styles.section}>
+          <Text style={styles.sectionHeader}>Animation timing</Text>
+          <Text>
+            Customize press and hover animation durations via the unified
+            `animationDuration` prop.
+          </Text>
+
+          <Text>Single number: applied to every phase.</Text>
+
+          <View style={styles.row}>
+            <TouchableWrapper
+              name="Snappy"
+              color={COLORS.DARK_PURPLE}
+              activeOpacity={0.3}
+              animationDuration={0}
+            />
+
+            <TouchableWrapper
+              name="Sluggish"
+              color={COLORS.WEB_BLUE}
+              activeOpacity={0.3}
+              animationDuration={600}
+            />
+          </View>
+
+          <Text>Object with top-level in / out applies to every category.</Text>
+
+          <View style={styles.row}>
+            <TouchableWrapper
+              name="Quick in / slow out"
+              color={COLORS.RED}
+              activeOpacity={0.3}
+              hoverOpacity={0.6}
+              animationDuration={{ in: 0, out: 600 }}
+            />
+          </View>
+
+          <Text>Per-category overrides — slower hover than tap.</Text>
+
+          <View style={styles.row}>
+            <TouchableWrapper
+              name="Slow hover"
+              color={COLORS.YELLOW}
+              activeOpacity={0.3}
+              hoverOpacity={0.5}
+              animationDuration={{
+                in: 50,
+                out: 100,
+                hover: { in: 400, out: 400 },
+              }}
+            />
+
+            <TouchableWrapper
+              name="Partial hover override"
+              color={COLORS.LIGHT_BLUE}
+              activeOpacity={0.3}
+              hoverOpacity={0.5}
+              animationDuration={{
+                in: 50,
+                out: 100,
+                hover: { in: 400 },
+              }}
+            />
+          </View>
+
+          <Text>All categories specified, no shared baseline.</Text>
+
+          <View style={styles.row}>
+            <TouchableWrapper
+              name="Fully custom"
+              color={COLORS.NAVY}
+              activeOpacity={0.3}
+              hoverOpacity={0.5}
+              animationDuration={{
+                tap: { in: 0, out: 250 },
+                hover: { in: 300, out: 300 },
+              }}
+            />
+          </View>
+        </View>
+
+        <View style={styles.section}>
           <Text style={styles.sectionHeader}>Android ripple</Text>
           <Text>Configurable ripple effect on Touchable component.</Text>
 
@@ -210,5 +291,6 @@ const styles = StyleSheet.create({
     color: 'white',
     fontSize: 14,
     fontWeight: '600',
+    textAlign: 'center',
   },
 });

--- a/packages/docs-gesture-handler/docs/components/touchable.mdx
+++ b/packages/docs-gesture-handler/docs/components/touchable.mdx
@@ -259,9 +259,9 @@ type AnimationDuration =
 
 Press and hover animation timing, in milliseconds. Defaults to 50ms for the in phase and 100ms for the out phase.
 
-Each animation has two phases — \`in\` (running while the pointer engages the component) and \`out\` (running after the pointer releases) — across two categories:
-- \`tap\` — applies to presses.
-- \`hover\` — pointer hover (web only).
+Each animation has two phases — `in` (running while the pointer engages the component) and `out` (running after the pointer releases) — across two categories:
+- `tap` — applies to presses.
+- `hover` — pointer hover (web only).
 
 Three input shapes are accepted:
 
@@ -271,7 +271,7 @@ Three input shapes are accepted:
 <Touchable animationDuration={200} />
 ```
 
-2. A baseline \`in\` / \`out\` with optional per-category overrides — categories that aren't specified inherit the baseline, and within a category any field left out also inherits from the baseline:
+2. A baseline `in` / `out` with optional per-category overrides — categories that aren't specified inherit the baseline, and within a category any field left out also inherits from the baseline:
 
 ```tsx
 <Touchable

--- a/packages/docs-gesture-handler/docs/components/touchable.mdx
+++ b/packages/docs-gesture-handler/docs/components/touchable.mdx
@@ -234,15 +234,65 @@ hoverUnderlayOpacity?: number;
 
 Defines the opacity of the underlay when the button is hovered. By default falls back to [`defaultUnderlayOpacity`](#defaultunderlayopacity).
 
-<Badges platforms={['web']}>
-### hoverAnimationDuration
-</Badges>
+### animationDuration
 
-```ts
-hoverAnimationDuration?: number;
+<CollapsibleCode 
+label="Show composed types definitions"
+expandedLabel="Hide composed types definitions"
+lineBounds={[0, 1]}
+src={`
+animationDuration?: AnimationDuration;
+
+type InOutDuration = { in: number; out: number };
+
+type AnimationDuration =
+  | number
+  | (InOutDuration & {
+      tap?: Partial<InOutDuration>;
+      hover?: Partial<InOutDuration>;
+    })
+  | {
+      tap: InOutDuration;
+      hover: InOutDuration;
+    };
+`}/>
+
+Press and hover animation timing, in milliseconds. Defaults to 50ms for the in phase and 100ms for the out phase.
+
+Each animation has two phases — \`in\` (running while the pointer engages the component) and \`out\` (running after the pointer releases) — across two categories:
+- \`tap\` — applies to presses.
+- \`hover\` — pointer hover (web only).
+
+Three input shapes are accepted:
+
+1. A single number applied to every phase of every category:
+
+```tsx
+<Touchable animationDuration={200} />
 ```
 
-Duration of the hover animation, in milliseconds. By default falls back to [`tapAnimationDuration`](#tapanimationduration).
+2. A baseline \`in\` / \`out\` with optional per-category overrides — categories that aren't specified inherit the baseline, and within a category any field left out also inherits from the baseline:
+
+```tsx
+<Touchable
+  animationDuration={{
+    in: 50,
+    out: 200,
+    hover: { in: 400 },
+  }}
+/>
+```
+
+3. Both categories specified explicitly (no baseline) — every field must be supplied:
+
+```tsx
+<Touchable
+  animationDuration={{
+    tap: { in: 0, out: 200 },
+    hover: { in: 300, out: 300 },
+  }}
+/>
+```
 
 ### underlayColor
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -269,16 +269,6 @@ class RNGestureHandlerButtonViewManager :
     view.isSoundEffectsEnabled = !touchSoundDisabled
   }
 
-  @ReactProp(name = "pressAndHoldAnimationInDuration")
-  override fun setPressAndHoldAnimationInDuration(view: ButtonViewGroup, value: Int) {
-    view.pressAndHoldAnimationInDuration = value
-  }
-
-  @ReactProp(name = "pressAndHoldAnimationOutDuration")
-  override fun setPressAndHoldAnimationOutDuration(view: ButtonViewGroup, value: Int) {
-    view.pressAndHoldAnimationOutDuration = value
-  }
-
   @ReactProp(name = "tapAnimationInDuration")
   override fun setTapAnimationInDuration(view: ButtonViewGroup, value: Int) {
     view.tapAnimationInDuration = if (value > 0) value else 0
@@ -366,10 +356,6 @@ class RNGestureHandlerButtonViewManager :
     var exclusive = true
     var tapAnimationInDuration: Int = 100
     var tapAnimationOutDuration: Int = 100
-    var pressAndHoldAnimationInDuration: Int = -1
-      get() = if (field < 0) tapAnimationInDuration else field
-    var pressAndHoldAnimationOutDuration: Int = -1
-      get() = if (field < 0) tapAnimationOutDuration else field
     var activeOpacity: Float = 1.0f
     var defaultOpacity: Float = 1.0f
     var activeScale: Float = 1.0f
@@ -572,26 +558,23 @@ class RNGestureHandlerButtonViewManager :
         pendingPressOut = null
       }
       pressInTimestamp = SystemClock.uptimeMillis()
-      animateTo(activeOpacity, activeScale, activeUnderlayOpacity, pressAndHoldAnimationInDuration.toLong())
+      animateTo(activeOpacity, activeScale, activeUnderlayOpacity, tapAnimationInDuration.toLong())
     }
 
     private fun animatePressOut() {
       pendingPressOut?.let { handler.removeCallbacks(it) }
-      val pressAndHoldInMs = pressAndHoldAnimationInDuration.toLong()
-      val pressAndHoldOutMs = pressAndHoldAnimationOutDuration.toLong()
       val tapInMs = tapAnimationInDuration.toLong()
       val tapOutMs = tapAnimationOutDuration.toLong()
       val elapsed = SystemClock.uptimeMillis() - pressInTimestamp
 
-      if (elapsed >= pressAndHoldInMs) {
-        animateTo(defaultOpacity, defaultScale, defaultUnderlayOpacity, pressAndHoldOutMs)
+      if (elapsed >= tapInMs) {
+        // Press-in animation fully finished — release with the configured out duration.
+        animateTo(defaultOpacity, defaultScale, defaultUnderlayOpacity, tapOutMs)
         // elapsed * 2 to ensure there is at least half of the tapAnimationOutDuration left for the animation to play
       } else if (elapsed * 2 >= tapOutMs) {
         animateTo(defaultOpacity, defaultScale, defaultUnderlayOpacity, elapsed)
       } else {
-        // Clamp to 0 because tapAnimationInDuration and tapAnimationOutDuration are independent —
-        // elapsed can exceed tapAnimationInDuration while still being below tapAnimationOutDuration / 2.
-        val remaining = (tapInMs - elapsed).coerceAtLeast(0)
+        val remaining = tapInMs - elapsed
         animateTo(activeOpacity, activeScale, activeUnderlayOpacity, remaining)
 
         val runnable = Runnable {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -269,14 +269,24 @@ class RNGestureHandlerButtonViewManager :
     view.isSoundEffectsEnabled = !touchSoundDisabled
   }
 
-  @ReactProp(name = "pressAndHoldAnimationDuration")
-  override fun setPressAndHoldAnimationDuration(view: ButtonViewGroup, pressAndHoldAnimationDuration: Int) {
-    view.pressAndHoldAnimationDuration = pressAndHoldAnimationDuration
+  @ReactProp(name = "pressAndHoldAnimationInDuration")
+  override fun setPressAndHoldAnimationInDuration(view: ButtonViewGroup, value: Int) {
+    view.pressAndHoldAnimationInDuration = value
   }
 
-  @ReactProp(name = "tapAnimationDuration")
-  override fun setTapAnimationDuration(view: ButtonViewGroup, tapAnimationDuration: Int) {
-    view.tapAnimationDuration = if (tapAnimationDuration > 0) tapAnimationDuration else 0
+  @ReactProp(name = "pressAndHoldAnimationOutDuration")
+  override fun setPressAndHoldAnimationOutDuration(view: ButtonViewGroup, value: Int) {
+    view.pressAndHoldAnimationOutDuration = value
+  }
+
+  @ReactProp(name = "tapAnimationInDuration")
+  override fun setTapAnimationInDuration(view: ButtonViewGroup, value: Int) {
+    view.tapAnimationInDuration = if (value > 0) value else 0
+  }
+
+  @ReactProp(name = "tapAnimationOutDuration")
+  override fun setTapAnimationOutDuration(view: ButtonViewGroup, value: Int) {
+    view.tapAnimationOutDuration = if (value > 0) value else 0
   }
 
   @ReactProp(name = "defaultOpacity")
@@ -354,9 +364,12 @@ class RNGestureHandlerButtonViewManager :
     var useBorderlessDrawable = false
 
     var exclusive = true
-    var tapAnimationDuration: Int = 100
-    var pressAndHoldAnimationDuration: Int = -1
-      get() = if (field < 0) tapAnimationDuration else field
+    var tapAnimationInDuration: Int = 100
+    var tapAnimationOutDuration: Int = 100
+    var pressAndHoldAnimationInDuration: Int = -1
+      get() = if (field < 0) tapAnimationInDuration else field
+    var pressAndHoldAnimationOutDuration: Int = -1
+      get() = if (field < 0) tapAnimationOutDuration else field
     var activeOpacity: Float = 1.0f
     var defaultOpacity: Float = 1.0f
     var activeScale: Float = 1.0f
@@ -559,27 +572,31 @@ class RNGestureHandlerButtonViewManager :
         pendingPressOut = null
       }
       pressInTimestamp = SystemClock.uptimeMillis()
-      animateTo(activeOpacity, activeScale, activeUnderlayOpacity, pressAndHoldAnimationDuration.toLong())
+      animateTo(activeOpacity, activeScale, activeUnderlayOpacity, pressAndHoldAnimationInDuration.toLong())
     }
 
     private fun animatePressOut() {
       pendingPressOut?.let { handler.removeCallbacks(it) }
-      val pressAndHoldMs = pressAndHoldAnimationDuration.toLong()
-      val tapMs = tapAnimationDuration.toLong()
+      val pressAndHoldInMs = pressAndHoldAnimationInDuration.toLong()
+      val pressAndHoldOutMs = pressAndHoldAnimationOutDuration.toLong()
+      val tapInMs = tapAnimationInDuration.toLong()
+      val tapOutMs = tapAnimationOutDuration.toLong()
       val elapsed = SystemClock.uptimeMillis() - pressInTimestamp
 
-      if (elapsed >= pressAndHoldMs) {
-        animateTo(defaultOpacity, defaultScale, defaultUnderlayOpacity, pressAndHoldMs)
-        // elapsed * 2 to ensure there is at least half of the tapAnimationDuration left for the animation to play
-      } else if (elapsed * 2 >= tapMs) {
+      if (elapsed >= pressAndHoldInMs) {
+        animateTo(defaultOpacity, defaultScale, defaultUnderlayOpacity, pressAndHoldOutMs)
+        // elapsed * 2 to ensure there is at least half of the tapAnimationOutDuration left for the animation to play
+      } else if (elapsed * 2 >= tapOutMs) {
         animateTo(defaultOpacity, defaultScale, defaultUnderlayOpacity, elapsed)
       } else {
-        val remaining = tapMs - elapsed
+        // Clamp to 0 because tapAnimationInDuration and tapAnimationOutDuration are independent —
+        // elapsed can exceed tapAnimationInDuration while still being below tapAnimationOutDuration / 2.
+        val remaining = (tapInMs - elapsed).coerceAtLeast(0)
         animateTo(activeOpacity, activeScale, activeUnderlayOpacity, remaining)
 
         val runnable = Runnable {
           pendingPressOut = null
-          animateTo(defaultOpacity, defaultScale, defaultUnderlayOpacity, tapMs)
+          animateTo(defaultOpacity, defaultScale, defaultUnderlayOpacity, tapOutMs)
         }
         pendingPressOut = runnable
         handler.postDelayed(runnable, remaining)

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -354,7 +354,7 @@ class RNGestureHandlerButtonViewManager :
     var useBorderlessDrawable = false
 
     var exclusive = true
-    var tapAnimationInDuration: Int = 100
+    var tapAnimationInDuration: Int = 50
     var tapAnimationOutDuration: Int = 100
     var activeOpacity: Float = 1.0f
     var defaultOpacity: Float = 1.0f

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.h
@@ -27,8 +27,10 @@
 @property (nonatomic) BOOL userEnabled;
 @property (nonatomic, assign) RNGestureHandlerPointerEvents pointerEvents;
 
-@property (nonatomic, assign) NSInteger pressAndHoldAnimationDuration;
-@property (nonatomic, assign) NSInteger tapAnimationDuration;
+@property (nonatomic, assign) NSInteger pressAndHoldAnimationInDuration;
+@property (nonatomic, assign) NSInteger pressAndHoldAnimationOutDuration;
+@property (nonatomic, assign) NSInteger tapAnimationInDuration;
+@property (nonatomic, assign) NSInteger tapAnimationOutDuration;
 @property (nonatomic, assign) CGFloat activeOpacity;
 @property (nonatomic, assign) CGFloat defaultOpacity;
 @property (nonatomic, assign) CGFloat activeScale;

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.h
@@ -27,8 +27,6 @@
 @property (nonatomic) BOOL userEnabled;
 @property (nonatomic, assign) RNGestureHandlerPointerEvents pointerEvents;
 
-@property (nonatomic, assign) NSInteger pressAndHoldAnimationInDuration;
-@property (nonatomic, assign) NSInteger pressAndHoldAnimationOutDuration;
 @property (nonatomic, assign) NSInteger tapAnimationInDuration;
 @property (nonatomic, assign) NSInteger tapAnimationOutDuration;
 @property (nonatomic, assign) CGFloat activeOpacity;

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -55,7 +55,7 @@
   _hitTestEdgeInsets = UIEdgeInsetsZero;
   _userEnabled = YES;
   _pointerEvents = RNGestureHandlerPointerEventsAuto;
-  _tapAnimationInDuration = 100;
+  _tapAnimationInDuration = 50;
   _tapAnimationOutDuration = 100;
   _activeOpacity = 1.0;
   _defaultOpacity = 1.0;

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -49,7 +49,8 @@
   dispatch_block_t _pendingPressOutBlock;
 }
 
-@synthesize pressAndHoldAnimationDuration = _pressAndHoldAnimationDuration;
+@synthesize pressAndHoldAnimationInDuration = _pressAndHoldAnimationInDuration;
+@synthesize pressAndHoldAnimationOutDuration = _pressAndHoldAnimationOutDuration;
 
 - (void)commonInit
 {
@@ -57,8 +58,10 @@
   _hitTestEdgeInsets = UIEdgeInsetsZero;
   _userEnabled = YES;
   _pointerEvents = RNGestureHandlerPointerEventsAuto;
-  _pressAndHoldAnimationDuration = -1;
-  _tapAnimationDuration = 100;
+  _pressAndHoldAnimationInDuration = -1;
+  _pressAndHoldAnimationOutDuration = -1;
+  _tapAnimationInDuration = 100;
+  _tapAnimationOutDuration = 100;
   _activeOpacity = 1.0;
   _defaultOpacity = 1.0;
   _activeScale = 1.0;
@@ -157,9 +160,14 @@
 }
 #endif
 
-- (NSInteger)pressAndHoldAnimationDuration
+- (NSInteger)pressAndHoldAnimationInDuration
 {
-  return _pressAndHoldAnimationDuration < 0 ? _tapAnimationDuration : _pressAndHoldAnimationDuration;
+  return _pressAndHoldAnimationInDuration < 0 ? _tapAnimationInDuration : _pressAndHoldAnimationInDuration;
+}
+
+- (NSInteger)pressAndHoldAnimationOutDuration
+{
+  return _pressAndHoldAnimationOutDuration < 0 ? _tapAnimationOutDuration : _pressAndHoldAnimationOutDuration;
 }
 
 - (void)setUnderlayColor:(RNGHColor *)underlayColor
@@ -310,9 +318,9 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
   }
   _pressInTimestamp = CACurrentMediaTime();
   RNGHUIView *target = self.animationTarget ?: self;
-  [self animateTarget:target toOpacity:_activeOpacity scale:_activeScale duration:self.pressAndHoldAnimationDuration];
+  [self animateTarget:target toOpacity:_activeOpacity scale:_activeScale duration:self.pressAndHoldAnimationInDuration];
   if (_activeUnderlayOpacity != _defaultUnderlayOpacity) {
-    [self animateUnderlayToOpacity:_activeUnderlayOpacity duration:self.pressAndHoldAnimationDuration];
+    [self animateUnderlayToOpacity:_activeUnderlayOpacity duration:self.pressAndHoldAnimationInDuration];
   }
 }
 
@@ -323,17 +331,18 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
   }
 
   NSTimeInterval elapsed = (CACurrentMediaTime() - _pressInTimestamp) * 1000.0;
-  NSInteger pressAndHoldAnimationDuration = self.pressAndHoldAnimationDuration;
+  NSInteger pressAndHoldAnimationInDuration = self.pressAndHoldAnimationInDuration;
+  NSInteger pressAndHoldAnimationOutDuration = self.pressAndHoldAnimationOutDuration;
 
-  if (elapsed >= pressAndHoldAnimationDuration) {
-    // Press-in animation fully finished, animate out in pressAndHoldAnimationDuration
+  if (elapsed >= pressAndHoldAnimationInDuration) {
+    // Press-in animation fully finished, animate out in pressAndHoldAnimationOutDuration
     RNGHUIView *target = self.animationTarget ?: self;
-    [self animateTarget:target toOpacity:_defaultOpacity scale:_defaultScale duration:pressAndHoldAnimationDuration];
+    [self animateTarget:target toOpacity:_defaultOpacity scale:_defaultScale duration:pressAndHoldAnimationOutDuration];
     if (_activeUnderlayOpacity != _defaultUnderlayOpacity) {
-      [self animateUnderlayToOpacity:_defaultUnderlayOpacity duration:pressAndHoldAnimationDuration];
+      [self animateUnderlayToOpacity:_defaultUnderlayOpacity duration:pressAndHoldAnimationOutDuration];
     }
-    // elapsed * 2 to ensure there is at least half of the minDuration left for the animation to play
-  } else if (elapsed * 2 >= _tapAnimationDuration) {
+    // elapsed * 2 to ensure there is at least half of the tapAnimationOutDuration left for the animation to play
+  } else if (elapsed * 2 >= _tapAnimationOutDuration) {
     // Past minimum but press-in animation still playing, animate out in elapsed time
     RNGHUIView *target = self.animationTarget ?: self;
     [self animateTarget:target toOpacity:_defaultOpacity scale:_defaultScale duration:elapsed];
@@ -341,8 +350,10 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
       [self animateUnderlayToOpacity:_defaultUnderlayOpacity duration:elapsed];
     }
   } else {
-    // Before minimum duration, finish press-in in remaining time then animate out in minDuration
-    NSTimeInterval remaining = _tapAnimationDuration - elapsed;
+    // Before minimum duration, finish press-in in remaining time then animate out in tapAnimationOutDuration.
+    // Clamp to 0 because tapAnimationInDuration and tapAnimationOutDuration are independent —
+    // elapsed can exceed tapAnimationInDuration while still being below tapAnimationOutDuration / 2.
+    NSTimeInterval remaining = MAX(0, _tapAnimationInDuration - elapsed);
 
     RNGHUIView *target = self.animationTarget ?: self;
     [self animateTarget:target toOpacity:_activeOpacity scale:_activeScale duration:remaining];
@@ -359,10 +370,10 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
         [strongSelf animateTarget:target
                         toOpacity:strongSelf->_defaultOpacity
                             scale:strongSelf->_defaultScale
-                         duration:strongSelf->_tapAnimationDuration];
+                         duration:strongSelf->_tapAnimationOutDuration];
         if (strongSelf->_activeUnderlayOpacity != strongSelf->_defaultUnderlayOpacity) {
           [strongSelf animateUnderlayToOpacity:strongSelf->_defaultUnderlayOpacity
-                                      duration:strongSelf->_tapAnimationDuration];
+                                      duration:strongSelf->_tapAnimationOutDuration];
         }
       }
     });

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -49,17 +49,12 @@
   dispatch_block_t _pendingPressOutBlock;
 }
 
-@synthesize pressAndHoldAnimationInDuration = _pressAndHoldAnimationInDuration;
-@synthesize pressAndHoldAnimationOutDuration = _pressAndHoldAnimationOutDuration;
-
 - (void)commonInit
 {
   _isTouchInsideBounds = NO;
   _hitTestEdgeInsets = UIEdgeInsetsZero;
   _userEnabled = YES;
   _pointerEvents = RNGestureHandlerPointerEventsAuto;
-  _pressAndHoldAnimationInDuration = -1;
-  _pressAndHoldAnimationOutDuration = -1;
   _tapAnimationInDuration = 100;
   _tapAnimationOutDuration = 100;
   _activeOpacity = 1.0;
@@ -159,16 +154,6 @@
   }
 }
 #endif
-
-- (NSInteger)pressAndHoldAnimationInDuration
-{
-  return _pressAndHoldAnimationInDuration < 0 ? _tapAnimationInDuration : _pressAndHoldAnimationInDuration;
-}
-
-- (NSInteger)pressAndHoldAnimationOutDuration
-{
-  return _pressAndHoldAnimationOutDuration < 0 ? _tapAnimationOutDuration : _pressAndHoldAnimationOutDuration;
-}
 
 - (void)setUnderlayColor:(RNGHColor *)underlayColor
 {
@@ -318,9 +303,9 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
   }
   _pressInTimestamp = CACurrentMediaTime();
   RNGHUIView *target = self.animationTarget ?: self;
-  [self animateTarget:target toOpacity:_activeOpacity scale:_activeScale duration:self.pressAndHoldAnimationInDuration];
+  [self animateTarget:target toOpacity:_activeOpacity scale:_activeScale duration:_tapAnimationInDuration];
   if (_activeUnderlayOpacity != _defaultUnderlayOpacity) {
-    [self animateUnderlayToOpacity:_activeUnderlayOpacity duration:self.pressAndHoldAnimationInDuration];
+    [self animateUnderlayToOpacity:_activeUnderlayOpacity duration:_tapAnimationInDuration];
   }
 }
 
@@ -331,15 +316,13 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
   }
 
   NSTimeInterval elapsed = (CACurrentMediaTime() - _pressInTimestamp) * 1000.0;
-  NSInteger pressAndHoldAnimationInDuration = self.pressAndHoldAnimationInDuration;
-  NSInteger pressAndHoldAnimationOutDuration = self.pressAndHoldAnimationOutDuration;
 
-  if (elapsed >= pressAndHoldAnimationInDuration) {
-    // Press-in animation fully finished, animate out in pressAndHoldAnimationOutDuration
+  if (elapsed >= _tapAnimationInDuration) {
+    // Press-in animation fully finished - release with the configured out duration.
     RNGHUIView *target = self.animationTarget ?: self;
-    [self animateTarget:target toOpacity:_defaultOpacity scale:_defaultScale duration:pressAndHoldAnimationOutDuration];
+    [self animateTarget:target toOpacity:_defaultOpacity scale:_defaultScale duration:_tapAnimationOutDuration];
     if (_activeUnderlayOpacity != _defaultUnderlayOpacity) {
-      [self animateUnderlayToOpacity:_defaultUnderlayOpacity duration:pressAndHoldAnimationOutDuration];
+      [self animateUnderlayToOpacity:_defaultUnderlayOpacity duration:_tapAnimationOutDuration];
     }
     // elapsed * 2 to ensure there is at least half of the tapAnimationOutDuration left for the animation to play
   } else if (elapsed * 2 >= _tapAnimationOutDuration) {
@@ -351,9 +334,7 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
     }
   } else {
     // Before minimum duration, finish press-in in remaining time then animate out in tapAnimationOutDuration.
-    // Clamp to 0 because tapAnimationInDuration and tapAnimationOutDuration are independent —
-    // elapsed can exceed tapAnimationInDuration while still being below tapAnimationOutDuration / 2.
-    NSTimeInterval remaining = MAX(0, _tapAnimationInDuration - elapsed);
+    NSTimeInterval remaining = _tapAnimationInDuration - elapsed;
 
     RNGHUIView *target = self.animationTarget ?: self;
     [self animateTarget:target toOpacity:_activeOpacity scale:_activeScale duration:remaining];

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
@@ -323,8 +323,6 @@ static RNGestureHandlerPointerEvents RCTPointerEventsToEnum(facebook::react::Poi
   }
 
   _buttonView.userEnabled = newProps.enabled;
-  _buttonView.pressAndHoldAnimationInDuration = newProps.pressAndHoldAnimationInDuration;
-  _buttonView.pressAndHoldAnimationOutDuration = newProps.pressAndHoldAnimationOutDuration;
   _buttonView.tapAnimationInDuration = newProps.tapAnimationInDuration > 0 ? newProps.tapAnimationInDuration : 0;
   _buttonView.tapAnimationOutDuration = newProps.tapAnimationOutDuration > 0 ? newProps.tapAnimationOutDuration : 0;
   _buttonView.activeOpacity = newProps.activeOpacity;

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
@@ -323,8 +323,10 @@ static RNGestureHandlerPointerEvents RCTPointerEventsToEnum(facebook::react::Poi
   }
 
   _buttonView.userEnabled = newProps.enabled;
-  _buttonView.pressAndHoldAnimationDuration = newProps.pressAndHoldAnimationDuration;
-  _buttonView.tapAnimationDuration = newProps.tapAnimationDuration > 0 ? newProps.tapAnimationDuration : 0;
+  _buttonView.pressAndHoldAnimationInDuration = newProps.pressAndHoldAnimationInDuration;
+  _buttonView.pressAndHoldAnimationOutDuration = newProps.pressAndHoldAnimationOutDuration;
+  _buttonView.tapAnimationInDuration = newProps.tapAnimationInDuration > 0 ? newProps.tapAnimationInDuration : 0;
+  _buttonView.tapAnimationOutDuration = newProps.tapAnimationOutDuration > 0 ? newProps.tapAnimationOutDuration : 0;
   _buttonView.activeOpacity = newProps.activeOpacity;
   _buttonView.defaultOpacity = newProps.defaultOpacity;
   _buttonView.activeScale = newProps.activeScale;

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -67,11 +67,40 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
   pressAndHoldAnimationDuration?: number | undefined;
 
   /**
+   * Duration of the press-in animation, in milliseconds, when the button
+   * is held down. Defaults to `pressAndHoldAnimationDuration` when not
+   * set (or set to any negative value).
+   */
+  pressAndHoldAnimationInDuration?: number | undefined;
+
+  /**
+   * Duration of the press-out animation, in milliseconds, when the
+   * button is released after the press-in animation completed. Defaults
+   * to `pressAndHoldAnimationDuration` when not set (or set to any
+   * negative value).
+   */
+  pressAndHoldAnimationOutDuration?: number | undefined;
+
+  /**
    * Minimum duration (in milliseconds) that the press animation must run
    * before the press-out animation is allowed to start. Ensures the pressed
    * state is visible on quick taps. Defaults to 100ms.
    */
   tapAnimationDuration?: number | undefined;
+
+  /**
+   * Minimum duration (in milliseconds) of the press-in animation on a
+   * quick tap. Defaults to `tapAnimationDuration` when not set (or set
+   * to any negative value).
+   */
+  tapAnimationInDuration?: number | undefined;
+
+  /**
+   * Minimum duration (in milliseconds) of the press-out animation on a
+   * quick tap. Defaults to `tapAnimationDuration` when not set (or set
+   * to any negative value).
+   */
+  tapAnimationOutDuration?: number | undefined;
 
   /**
    * Opacity applied to the button when it is pressed.
@@ -119,6 +148,22 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
    * `tapAnimationDuration` when not set (or set to any negative value).
    */
   hoverAnimationDuration?: number | undefined;
+
+  /**
+   * Web only.
+   *
+   * Duration of the hover-in animation, in milliseconds. Defaults to
+   * `hoverAnimationDuration` when not set (or set to any negative value).
+   */
+  hoverAnimationInDuration?: number | undefined;
+
+  /**
+   * Web only.
+   *
+   * Duration of the hover-out animation, in milliseconds. Defaults to
+   * `hoverAnimationDuration` when not set (or set to any negative value).
+   */
+  hoverAnimationOutDuration?: number | undefined;
 
   /**
    * Opacity applied to the button when it is not pressed.

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -61,7 +61,7 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
 
   /**
    * Minimum duration (in milliseconds) of the press-in animation on a
-   * quick tap. Defaults to 100ms.
+   * quick tap. Defaults to 50ms.
    */
   tapAnimationInDuration?: number | undefined;
 
@@ -113,7 +113,7 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
   /**
    * Web only.
    *
-   * Duration of the hover-in animation, in milliseconds. Defaults to 100ms.
+   * Duration of the hover-in animation, in milliseconds. Defaults to 50ms.
    */
   hoverAnimationInDuration?: number | undefined;
 

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -60,19 +60,6 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
   touchSoundDisabled?: boolean | undefined;
 
   /**
-   * Duration of the press-in animation, in milliseconds, when the button
-   * is held down. Defaults to 100ms.
-   */
-  pressAndHoldAnimationInDuration?: number | undefined;
-
-  /**
-   * Duration of the press-out animation, in milliseconds, when the
-   * button is released after the press-in animation completed. Defaults
-   * to 100ms.
-   */
-  pressAndHoldAnimationOutDuration?: number | undefined;
-
-  /**
    * Minimum duration (in milliseconds) of the press-in animation on a
    * quick tap. Defaults to 100ms.
    */

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -60,45 +60,27 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
   touchSoundDisabled?: boolean | undefined;
 
   /**
-   * Duration of the press-in animation when the button is held down, in
-   * milliseconds. Defaults to `tapAnimationDuration` when not set (or set
-   * to any negative value).
-   */
-  pressAndHoldAnimationDuration?: number | undefined;
-
-  /**
    * Duration of the press-in animation, in milliseconds, when the button
-   * is held down. Defaults to `pressAndHoldAnimationDuration` when not
-   * set (or set to any negative value).
+   * is held down. Defaults to 100ms.
    */
   pressAndHoldAnimationInDuration?: number | undefined;
 
   /**
    * Duration of the press-out animation, in milliseconds, when the
    * button is released after the press-in animation completed. Defaults
-   * to `pressAndHoldAnimationDuration` when not set (or set to any
-   * negative value).
+   * to 100ms.
    */
   pressAndHoldAnimationOutDuration?: number | undefined;
 
   /**
-   * Minimum duration (in milliseconds) that the press animation must run
-   * before the press-out animation is allowed to start. Ensures the pressed
-   * state is visible on quick taps. Defaults to 100ms.
-   */
-  tapAnimationDuration?: number | undefined;
-
-  /**
    * Minimum duration (in milliseconds) of the press-in animation on a
-   * quick tap. Defaults to `tapAnimationDuration` when not set (or set
-   * to any negative value).
+   * quick tap. Defaults to 100ms.
    */
   tapAnimationInDuration?: number | undefined;
 
   /**
    * Minimum duration (in milliseconds) of the press-out animation on a
-   * quick tap. Defaults to `tapAnimationDuration` when not set (or set
-   * to any negative value).
+   * quick tap. Defaults to 100ms.
    */
   tapAnimationOutDuration?: number | undefined;
 
@@ -144,24 +126,14 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
   /**
    * Web only.
    *
-   * Duration of the hover animation, in milliseconds. Defaults to
-   * `tapAnimationDuration` when not set (or set to any negative value).
-   */
-  hoverAnimationDuration?: number | undefined;
-
-  /**
-   * Web only.
-   *
-   * Duration of the hover-in animation, in milliseconds. Defaults to
-   * `hoverAnimationDuration` when not set (or set to any negative value).
+   * Duration of the hover-in animation, in milliseconds. Defaults to 100ms.
    */
   hoverAnimationInDuration?: number | undefined;
 
   /**
    * Web only.
    *
-   * Duration of the hover-out animation, in milliseconds. Defaults to
-   * `hoverAnimationDuration` when not set (or set to any negative value).
+   * Duration of the hover-out animation, in milliseconds. Defaults to 100ms.
    */
   hoverAnimationOutDuration?: number | undefined;
 

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
@@ -8,9 +8,12 @@ import { GestureLifecycleEvent } from '../web/tools/GestureLifecycleEvents';
 type ButtonProps = ViewProps & {
   ref?: React.Ref<React.ComponentRef<typeof View>>;
   enabled?: boolean;
-  pressAndHoldAnimationDuration?: number;
-  tapAnimationDuration?: number;
-  hoverAnimationDuration?: number;
+  pressAndHoldAnimationInDuration?: number;
+  pressAndHoldAnimationOutDuration?: number;
+  tapAnimationInDuration?: number;
+  tapAnimationOutDuration?: number;
+  hoverAnimationInDuration?: number;
+  hoverAnimationOutDuration?: number;
   activeOpacity?: number;
   activeScale?: number;
   activeUnderlayOpacity?: number;
@@ -26,9 +29,12 @@ type ButtonProps = ViewProps & {
 export const ButtonComponent = ({
   ref: externalRef,
   enabled = true,
-  pressAndHoldAnimationDuration: pressAndHoldAnimationDurationProp = -1,
-  tapAnimationDuration: tapAnimationDurationProp = 100,
-  hoverAnimationDuration: hoverAnimationDurationProp = -1,
+  pressAndHoldAnimationInDuration = 100,
+  pressAndHoldAnimationOutDuration = 100,
+  tapAnimationInDuration = 100,
+  tapAnimationOutDuration = 100,
+  hoverAnimationInDuration = 100,
+  hoverAnimationOutDuration = 100,
   activeOpacity = 1,
   activeScale = 1,
   activeUnderlayOpacity = 0,
@@ -43,17 +49,6 @@ export const ButtonComponent = ({
   children,
   ...rest
 }: ButtonProps) => {
-  const tapAnimationDuration =
-    tapAnimationDurationProp < 0 ? 0 : tapAnimationDurationProp;
-  const pressAndHoldAnimationDuration =
-    pressAndHoldAnimationDurationProp < 0
-      ? tapAnimationDuration
-      : pressAndHoldAnimationDurationProp;
-  const hoverAnimationDuration =
-    hoverAnimationDurationProp < 0
-      ? tapAnimationDuration
-      : hoverAnimationDurationProp;
-
   const hoverOpacity = hoverOpacityProp ?? defaultOpacity;
   const hoverScale = hoverScaleProp ?? defaultScale;
   const hoverUnderlayOpacity =
@@ -62,7 +57,7 @@ export const ButtonComponent = ({
   const [pressed, setPressed] = React.useState(false);
   const [hovered, setHovered] = React.useState(false);
   const [currentDuration, setCurrentDuration] = React.useState(
-    pressAndHoldAnimationDuration
+    pressAndHoldAnimationInDuration
   );
   const pressInTimestamp = React.useRef(0);
   const pressOutTimer = React.useRef<ReturnType<typeof setTimeout> | null>(
@@ -132,10 +127,10 @@ export const ButtonComponent = ({
         pressOutTimer.current = null;
       }
       pressInTimestamp.current = performance.now();
-      setCurrentDuration(pressAndHoldAnimationDuration);
+      setCurrentDuration(pressAndHoldAnimationInDuration);
       setPressed(true);
     },
-    [enabled, pressAndHoldAnimationDuration]
+    [enabled, pressAndHoldAnimationInDuration]
   );
 
   const pressOut = React.useCallback(
@@ -155,24 +150,31 @@ export const ButtonComponent = ({
       const elapsed = performance.now() - pressInTimestamp.current;
       pressInTimestamp.current = 0;
 
-      if (elapsed >= pressAndHoldAnimationDuration) {
-        setCurrentDuration(pressAndHoldAnimationDuration);
+      if (elapsed >= pressAndHoldAnimationInDuration) {
+        setCurrentDuration(pressAndHoldAnimationOutDuration);
         setPressed(false);
-        // elapsed * 2 to ensure there is at least half of the tapAnimationDuration left for the animation to play
-      } else if (elapsed * 2 >= tapAnimationDuration) {
+        // elapsed * 2 to ensure there is at least half of the tapAnimationOutDuration left for the animation to play
+      } else if (elapsed * 2 >= tapAnimationOutDuration) {
         setCurrentDuration(elapsed);
         setPressed(false);
       } else {
-        // Let the in-progress CSS press-in transition continue; schedule press-out after remaining time
-        const remaining = tapAnimationDuration - elapsed;
+        // Let the in-progress CSS press-in transition continue; schedule press-out after remaining time.
+        // Clamp to 0 because tapAnimationInDuration and tapAnimationOutDuration are independent —
+        // elapsed can exceed tapAnimationInDuration while still being below tapAnimationOutDuration / 2.
+        const remaining = Math.max(0, tapAnimationInDuration - elapsed);
         pressOutTimer.current = setTimeout(() => {
           pressOutTimer.current = null;
-          setCurrentDuration(tapAnimationDuration);
+          setCurrentDuration(tapAnimationOutDuration);
           setPressed(false);
         }, remaining);
       }
     },
-    [pressAndHoldAnimationDuration, tapAnimationDuration]
+    [
+      pressAndHoldAnimationInDuration,
+      pressAndHoldAnimationOutDuration,
+      tapAnimationInDuration,
+      tapAnimationOutDuration,
+    ]
   );
 
   const handlePointerEnter = React.useCallback(
@@ -182,11 +184,11 @@ export const ButtonComponent = ({
       }
       // Skip duration update while pressed so the press transition owns it.
       if (!pressed) {
-        setCurrentDuration(hoverAnimationDuration);
+        setCurrentDuration(hoverAnimationInDuration);
       }
       setHovered(true);
     },
-    [enabled, pressed, hoverAnimationDuration]
+    [enabled, pressed, hoverAnimationInDuration]
   );
 
   const handlePointerLeave = React.useCallback(
@@ -196,11 +198,11 @@ export const ButtonComponent = ({
         return;
       }
       if (!pressed) {
-        setCurrentDuration(hoverAnimationDuration);
+        setCurrentDuration(hoverAnimationOutDuration);
       }
       setHovered(false);
     },
-    [pressOut, pressed, hoverAnimationDuration]
+    [pressOut, pressed, hoverAnimationOutDuration]
   );
 
   // Mask hover at render rather than clearing the state. Avoids a state

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
@@ -8,8 +8,6 @@ import { GestureLifecycleEvent } from '../web/tools/GestureLifecycleEvents';
 type ButtonProps = ViewProps & {
   ref?: React.Ref<React.ComponentRef<typeof View>>;
   enabled?: boolean;
-  pressAndHoldAnimationInDuration?: number;
-  pressAndHoldAnimationOutDuration?: number;
   tapAnimationInDuration?: number;
   tapAnimationOutDuration?: number;
   hoverAnimationInDuration?: number;
@@ -29,8 +27,6 @@ type ButtonProps = ViewProps & {
 export const ButtonComponent = ({
   ref: externalRef,
   enabled = true,
-  pressAndHoldAnimationInDuration = 100,
-  pressAndHoldAnimationOutDuration = 100,
   tapAnimationInDuration = 100,
   tapAnimationOutDuration = 100,
   hoverAnimationInDuration = 100,
@@ -57,7 +53,7 @@ export const ButtonComponent = ({
   const [pressed, setPressed] = React.useState(false);
   const [hovered, setHovered] = React.useState(false);
   const [currentDuration, setCurrentDuration] = React.useState(
-    pressAndHoldAnimationInDuration
+    tapAnimationInDuration
   );
   const pressInTimestamp = React.useRef(0);
   const pressOutTimer = React.useRef<ReturnType<typeof setTimeout> | null>(
@@ -127,10 +123,10 @@ export const ButtonComponent = ({
         pressOutTimer.current = null;
       }
       pressInTimestamp.current = performance.now();
-      setCurrentDuration(pressAndHoldAnimationInDuration);
+      setCurrentDuration(tapAnimationInDuration);
       setPressed(true);
     },
-    [enabled, pressAndHoldAnimationInDuration]
+    [enabled, tapAnimationInDuration]
   );
 
   const pressOut = React.useCallback(
@@ -150,8 +146,9 @@ export const ButtonComponent = ({
       const elapsed = performance.now() - pressInTimestamp.current;
       pressInTimestamp.current = 0;
 
-      if (elapsed >= pressAndHoldAnimationInDuration) {
-        setCurrentDuration(pressAndHoldAnimationOutDuration);
+      if (elapsed >= tapAnimationInDuration) {
+        // Press-in animation fully finished - release with the configured out duration.
+        setCurrentDuration(tapAnimationOutDuration);
         setPressed(false);
         // elapsed * 2 to ensure there is at least half of the tapAnimationOutDuration left for the animation to play
       } else if (elapsed * 2 >= tapAnimationOutDuration) {
@@ -159,9 +156,7 @@ export const ButtonComponent = ({
         setPressed(false);
       } else {
         // Let the in-progress CSS press-in transition continue; schedule press-out after remaining time.
-        // Clamp to 0 because tapAnimationInDuration and tapAnimationOutDuration are independent —
-        // elapsed can exceed tapAnimationInDuration while still being below tapAnimationOutDuration / 2.
-        const remaining = Math.max(0, tapAnimationInDuration - elapsed);
+        const remaining = tapAnimationInDuration - elapsed;
         pressOutTimer.current = setTimeout(() => {
           pressOutTimer.current = null;
           setCurrentDuration(tapAnimationOutDuration);
@@ -169,12 +164,7 @@ export const ButtonComponent = ({
         }, remaining);
       }
     },
-    [
-      pressAndHoldAnimationInDuration,
-      pressAndHoldAnimationOutDuration,
-      tapAnimationInDuration,
-      tapAnimationOutDuration,
-    ]
+    [tapAnimationInDuration, tapAnimationOutDuration]
   );
 
   const handlePointerEnter = React.useCallback(

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
@@ -27,9 +27,9 @@ type ButtonProps = ViewProps & {
 export const ButtonComponent = ({
   ref: externalRef,
   enabled = true,
-  tapAnimationInDuration = 100,
+  tapAnimationInDuration = 50,
   tapAnimationOutDuration = 100,
-  hoverAnimationInDuration = 100,
+  hoverAnimationInDuration = 50,
   hoverAnimationOutDuration = 100,
   activeOpacity = 1,
   activeScale = 1,

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
@@ -19,8 +19,6 @@ interface NativeProps extends ViewProps {
     'box-none' | 'none' | 'box-only' | 'auto',
     'auto'
   >;
-  pressAndHoldAnimationInDuration?: WithDefault<Int32, -1>;
-  pressAndHoldAnimationOutDuration?: WithDefault<Int32, -1>;
   tapAnimationInDuration?: WithDefault<Int32, 100>;
   tapAnimationOutDuration?: WithDefault<Int32, 100>;
   activeOpacity?: WithDefault<Float, 1>;

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
@@ -19,8 +19,10 @@ interface NativeProps extends ViewProps {
     'box-none' | 'none' | 'box-only' | 'auto',
     'auto'
   >;
-  pressAndHoldAnimationDuration?: WithDefault<Int32, -1>;
-  tapAnimationDuration?: WithDefault<Int32, 100>;
+  pressAndHoldAnimationInDuration?: WithDefault<Int32, -1>;
+  pressAndHoldAnimationOutDuration?: WithDefault<Int32, -1>;
+  tapAnimationInDuration?: WithDefault<Int32, 100>;
+  tapAnimationOutDuration?: WithDefault<Int32, 100>;
   activeOpacity?: WithDefault<Float, 1>;
   activeScale?: WithDefault<Float, 1>;
   activeUnderlayOpacity?: WithDefault<Float, 0>;

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
@@ -19,7 +19,7 @@ interface NativeProps extends ViewProps {
     'box-none' | 'none' | 'box-only' | 'auto',
     'auto'
   >;
-  tapAnimationInDuration?: WithDefault<Int32, 100>;
+  tapAnimationInDuration?: WithDefault<Int32, 50>;
   tapAnimationOutDuration?: WithDefault<Int32, 100>;
   activeOpacity?: WithDefault<Float, 1>;
   activeScale?: WithDefault<Float, 1>;

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -25,6 +25,15 @@ export const Touchable = (props: TouchableProps) => {
     defaultUnderlayOpacity = 0,
     activeUnderlayOpacity = 0.105,
     defaultOpacity = 1,
+    tapAnimationDuration: tapAnimationDurationProp = 100,
+    pressAndHoldAnimationDuration: pressAndHoldAnimationDurationProp = -1,
+    hoverAnimationDuration: hoverAnimationDurationProp = -1,
+    tapAnimationInDuration: tapAnimationInDurationProp = -1,
+    tapAnimationOutDuration: tapAnimationOutDurationProp = -1,
+    pressAndHoldAnimationInDuration: pressAndHoldAnimationInDurationProp = -1,
+    pressAndHoldAnimationOutDuration: pressAndHoldAnimationOutDurationProp = -1,
+    hoverAnimationInDuration: hoverAnimationInDurationProp = -1,
+    hoverAnimationOutDuration: hoverAnimationOutDurationProp = -1,
     androidRipple,
     delayLongPress = 600,
     onLongPress,
@@ -37,6 +46,42 @@ export const Touchable = (props: TouchableProps) => {
     ref,
     ...rest
   } = props;
+
+  const tapAnimationDuration =
+    tapAnimationDurationProp < 0 ? 0 : tapAnimationDurationProp;
+  const tapAnimationInDuration =
+    tapAnimationInDurationProp < 0
+      ? tapAnimationDuration
+      : tapAnimationInDurationProp;
+  const tapAnimationOutDuration =
+    tapAnimationOutDurationProp < 0
+      ? tapAnimationDuration
+      : tapAnimationOutDurationProp;
+
+  const pressAndHoldAnimationInDuration =
+    pressAndHoldAnimationInDurationProp >= 0
+      ? pressAndHoldAnimationInDurationProp
+      : pressAndHoldAnimationDurationProp >= 0
+        ? pressAndHoldAnimationDurationProp
+        : tapAnimationInDuration;
+  const pressAndHoldAnimationOutDuration =
+    pressAndHoldAnimationOutDurationProp >= 0
+      ? pressAndHoldAnimationOutDurationProp
+      : pressAndHoldAnimationDurationProp >= 0
+        ? pressAndHoldAnimationDurationProp
+        : tapAnimationOutDuration;
+  const hoverAnimationInDuration =
+    hoverAnimationInDurationProp >= 0
+      ? hoverAnimationInDurationProp
+      : hoverAnimationDurationProp >= 0
+        ? hoverAnimationDurationProp
+        : tapAnimationInDuration;
+  const hoverAnimationOutDuration =
+    hoverAnimationOutDurationProp >= 0
+      ? hoverAnimationOutDurationProp
+      : hoverAnimationDurationProp >= 0
+        ? hoverAnimationDurationProp
+        : tapAnimationOutDuration;
 
   const shouldUseNativeRipple = isAndroid && androidRipple !== undefined;
 
@@ -161,7 +206,13 @@ export const Touchable = (props: TouchableProps) => {
         defaultOpacity={defaultOpacity}
         defaultUnderlayOpacity={defaultUnderlayOpacity}
         activeUnderlayOpacity={activeUnderlayOpacity}
-        underlayColor={underlayColor}>
+        underlayColor={underlayColor}
+        tapAnimationInDuration={tapAnimationInDuration}
+        tapAnimationOutDuration={tapAnimationOutDuration}
+        pressAndHoldAnimationInDuration={pressAndHoldAnimationInDuration}
+        pressAndHoldAnimationOutDuration={pressAndHoldAnimationOutDuration}
+        hoverAnimationInDuration={hoverAnimationInDuration}
+        hoverAnimationOutDuration={hoverAnimationOutDuration}>
         {children}
       </GestureHandlerButton>
     </NativeDetector>

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -5,6 +5,7 @@ import GestureHandlerButton from '../../../components/GestureHandlerButton';
 import { NativeDetector } from '../../detectors/NativeDetector';
 import { useNativeGesture } from '../../hooks';
 import type {
+  AnimationDuration,
   CallbackEventType,
   EndCallbackEventType,
   TouchableProps,
@@ -12,11 +13,52 @@ import type {
 
 const isAndroid = Platform.OS === 'android';
 const TRANSPARENT_RIPPLE = { rippleColor: 'transparent' as const };
+const DEFAULT_ANIMATION_DURATION_MS = 100;
 
 enum PointerState {
   UNKNOWN,
   INSIDE,
   OUTSIDE,
+}
+
+function resolveAnimationDuration(value: AnimationDuration | undefined) {
+  if (value === undefined) {
+    const d = DEFAULT_ANIMATION_DURATION_MS;
+    return {
+      tapAnimationInDuration: d,
+      tapAnimationOutDuration: d,
+      pressAndHoldAnimationInDuration: d,
+      pressAndHoldAnimationOutDuration: d,
+      hoverAnimationInDuration: d,
+      hoverAnimationOutDuration: d,
+    };
+  }
+
+  if (typeof value === 'number') {
+    return {
+      tapAnimationInDuration: value,
+      tapAnimationOutDuration: value,
+      pressAndHoldAnimationInDuration: value,
+      pressAndHoldAnimationOutDuration: value,
+      hoverAnimationInDuration: value,
+      hoverAnimationOutDuration: value,
+    };
+  }
+
+  // The union guarantees variant 2 supplies top-level `in`/`out`, variant 3
+  // supplies all three category objects — so per-category fallback to base is
+  // always defined for well-typed input; the 0 fallbacks here are unreachable.
+  const baseIn = 'in' in value ? value.in : 0;
+  const baseOut = 'out' in value ? value.out : 0;
+
+  return {
+    tapAnimationInDuration: value.tap?.in ?? baseIn,
+    tapAnimationOutDuration: value.tap?.out ?? baseOut,
+    pressAndHoldAnimationInDuration: value.pressAndHold?.in ?? baseIn,
+    pressAndHoldAnimationOutDuration: value.pressAndHold?.out ?? baseOut,
+    hoverAnimationInDuration: value.hover?.in ?? baseIn,
+    hoverAnimationOutDuration: value.hover?.out ?? baseOut,
+  };
 }
 
 export const Touchable = (props: TouchableProps) => {
@@ -25,15 +67,7 @@ export const Touchable = (props: TouchableProps) => {
     defaultUnderlayOpacity = 0,
     activeUnderlayOpacity = 0.105,
     defaultOpacity = 1,
-    tapAnimationDuration: tapAnimationDurationProp = 100,
-    pressAndHoldAnimationDuration: pressAndHoldAnimationDurationProp = -1,
-    hoverAnimationDuration: hoverAnimationDurationProp = -1,
-    tapAnimationInDuration: tapAnimationInDurationProp = -1,
-    tapAnimationOutDuration: tapAnimationOutDurationProp = -1,
-    pressAndHoldAnimationInDuration: pressAndHoldAnimationInDurationProp = -1,
-    pressAndHoldAnimationOutDuration: pressAndHoldAnimationOutDurationProp = -1,
-    hoverAnimationInDuration: hoverAnimationInDurationProp = -1,
-    hoverAnimationOutDuration: hoverAnimationOutDurationProp = -1,
+    animationDuration,
     androidRipple,
     delayLongPress = 600,
     onLongPress,
@@ -47,41 +81,7 @@ export const Touchable = (props: TouchableProps) => {
     ...rest
   } = props;
 
-  const tapAnimationDuration =
-    tapAnimationDurationProp < 0 ? 0 : tapAnimationDurationProp;
-  const tapAnimationInDuration =
-    tapAnimationInDurationProp < 0
-      ? tapAnimationDuration
-      : tapAnimationInDurationProp;
-  const tapAnimationOutDuration =
-    tapAnimationOutDurationProp < 0
-      ? tapAnimationDuration
-      : tapAnimationOutDurationProp;
-
-  const pressAndHoldAnimationInDuration =
-    pressAndHoldAnimationInDurationProp >= 0
-      ? pressAndHoldAnimationInDurationProp
-      : pressAndHoldAnimationDurationProp >= 0
-        ? pressAndHoldAnimationDurationProp
-        : tapAnimationInDuration;
-  const pressAndHoldAnimationOutDuration =
-    pressAndHoldAnimationOutDurationProp >= 0
-      ? pressAndHoldAnimationOutDurationProp
-      : pressAndHoldAnimationDurationProp >= 0
-        ? pressAndHoldAnimationDurationProp
-        : tapAnimationOutDuration;
-  const hoverAnimationInDuration =
-    hoverAnimationInDurationProp >= 0
-      ? hoverAnimationInDurationProp
-      : hoverAnimationDurationProp >= 0
-        ? hoverAnimationDurationProp
-        : tapAnimationInDuration;
-  const hoverAnimationOutDuration =
-    hoverAnimationOutDurationProp >= 0
-      ? hoverAnimationOutDurationProp
-      : hoverAnimationDurationProp >= 0
-        ? hoverAnimationDurationProp
-        : tapAnimationOutDuration;
+  const resolvedDurations = resolveAnimationDuration(animationDuration);
 
   const shouldUseNativeRipple = isAndroid && androidRipple !== undefined;
 
@@ -201,18 +201,13 @@ export const Touchable = (props: TouchableProps) => {
       <GestureHandlerButton
         {...rest}
         {...rippleProps}
+        {...resolvedDurations}
         ref={ref ?? null}
         enabled={!disabled}
         defaultOpacity={defaultOpacity}
         defaultUnderlayOpacity={defaultUnderlayOpacity}
         activeUnderlayOpacity={activeUnderlayOpacity}
-        underlayColor={underlayColor}
-        tapAnimationInDuration={tapAnimationInDuration}
-        tapAnimationOutDuration={tapAnimationOutDuration}
-        pressAndHoldAnimationInDuration={pressAndHoldAnimationInDuration}
-        pressAndHoldAnimationOutDuration={pressAndHoldAnimationOutDuration}
-        hoverAnimationInDuration={hoverAnimationInDuration}
-        hoverAnimationOutDuration={hoverAnimationOutDuration}>
+        underlayColor={underlayColor}>
         {children}
       </GestureHandlerButton>
     </NativeDetector>

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -22,6 +22,13 @@ enum PointerState {
   OUTSIDE,
 }
 
+// Clamp user-supplied durations to finite, non-negative milliseconds.
+// Negative, NaN, or Infinity values would produce invalid CSS transitions
+// on web and negative setTimeout delays in branch 3 of the press-out path.
+function sanitizeDuration(value: number): number {
+  return Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
 function resolveAnimationDuration(value: AnimationDuration | undefined) {
   if (value === undefined) {
     return {
@@ -33,11 +40,12 @@ function resolveAnimationDuration(value: AnimationDuration | undefined) {
   }
 
   if (typeof value === 'number') {
+    const sanitized = sanitizeDuration(value);
     return {
-      tapAnimationInDuration: value,
-      tapAnimationOutDuration: value,
-      hoverAnimationInDuration: value,
-      hoverAnimationOutDuration: value,
+      tapAnimationInDuration: sanitized,
+      tapAnimationOutDuration: sanitized,
+      hoverAnimationInDuration: sanitized,
+      hoverAnimationOutDuration: sanitized,
     };
   }
 
@@ -48,10 +56,10 @@ function resolveAnimationDuration(value: AnimationDuration | undefined) {
   const baseOut = 'out' in value ? value.out : 0;
 
   return {
-    tapAnimationInDuration: value.tap?.in ?? baseIn,
-    tapAnimationOutDuration: value.tap?.out ?? baseOut,
-    hoverAnimationInDuration: value.hover?.in ?? baseIn,
-    hoverAnimationOutDuration: value.hover?.out ?? baseOut,
+    tapAnimationInDuration: sanitizeDuration(value.tap?.in ?? baseIn),
+    tapAnimationOutDuration: sanitizeDuration(value.tap?.out ?? baseOut),
+    hoverAnimationInDuration: sanitizeDuration(value.hover?.in ?? baseIn),
+    hoverAnimationOutDuration: sanitizeDuration(value.hover?.out ?? baseOut),
   };
 }
 

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -27,8 +27,6 @@ function resolveAnimationDuration(value: AnimationDuration | undefined) {
     return {
       tapAnimationInDuration: d,
       tapAnimationOutDuration: d,
-      pressAndHoldAnimationInDuration: d,
-      pressAndHoldAnimationOutDuration: d,
       hoverAnimationInDuration: d,
       hoverAnimationOutDuration: d,
     };
@@ -38,15 +36,13 @@ function resolveAnimationDuration(value: AnimationDuration | undefined) {
     return {
       tapAnimationInDuration: value,
       tapAnimationOutDuration: value,
-      pressAndHoldAnimationInDuration: value,
-      pressAndHoldAnimationOutDuration: value,
       hoverAnimationInDuration: value,
       hoverAnimationOutDuration: value,
     };
   }
 
   // The union guarantees variant 2 supplies top-level `in`/`out`, variant 3
-  // supplies all three category objects — so per-category fallback to base is
+  // supplies both category objects — so per-category fallback to base is
   // always defined for well-typed input; the 0 fallbacks here are unreachable.
   const baseIn = 'in' in value ? value.in : 0;
   const baseOut = 'out' in value ? value.out : 0;
@@ -54,8 +50,6 @@ function resolveAnimationDuration(value: AnimationDuration | undefined) {
   return {
     tapAnimationInDuration: value.tap?.in ?? baseIn,
     tapAnimationOutDuration: value.tap?.out ?? baseOut,
-    pressAndHoldAnimationInDuration: value.pressAndHold?.in ?? baseIn,
-    pressAndHoldAnimationOutDuration: value.pressAndHold?.out ?? baseOut,
     hoverAnimationInDuration: value.hover?.in ?? baseIn,
     hoverAnimationOutDuration: value.hover?.out ?? baseOut,
   };

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -13,7 +13,8 @@ import type {
 
 const isAndroid = Platform.OS === 'android';
 const TRANSPARENT_RIPPLE = { rippleColor: 'transparent' as const };
-const DEFAULT_ANIMATION_DURATION_MS = 100;
+const DEFAULT_IN_DURATION_MS = 50;
+const DEFAULT_OUT_DURATION_MS = 100;
 
 enum PointerState {
   UNKNOWN,
@@ -23,12 +24,11 @@ enum PointerState {
 
 function resolveAnimationDuration(value: AnimationDuration | undefined) {
   if (value === undefined) {
-    const d = DEFAULT_ANIMATION_DURATION_MS;
     return {
-      tapAnimationInDuration: d,
-      tapAnimationOutDuration: d,
-      hoverAnimationInDuration: d,
-      hoverAnimationOutDuration: d,
+      tapAnimationInDuration: DEFAULT_IN_DURATION_MS,
+      tapAnimationOutDuration: DEFAULT_OUT_DURATION_MS,
+      hoverAnimationInDuration: DEFAULT_IN_DURATION_MS,
+      hoverAnimationOutDuration: DEFAULT_OUT_DURATION_MS,
     };
   }
 

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
@@ -20,8 +20,6 @@ type RippleProps = 'rippleColor' | 'rippleRadius' | 'borderless' | 'foreground';
 type DurationProps =
   | 'tapAnimationInDuration'
   | 'tapAnimationOutDuration'
-  | 'pressAndHoldAnimationInDuration'
-  | 'pressAndHoldAnimationOutDuration'
   | 'hoverAnimationInDuration'
   | 'hoverAnimationOutDuration';
 
@@ -31,9 +29,9 @@ type InOutDuration = { in: number; out: number };
  * Configuration for press / hover animation timing.
  *
  * - A single number applies to every phase of every category.
- * - An object with top-level `in` / `out` sets the baseline; any of `tap`,
- *   `hover`, `pressAndHold` may override it.
- * - Alternatively, all three categories may be specified explicitly without
+ * - An object with top-level `in` / `out` sets the baseline; `tap` and
+ *   `hover` may override it.
+ * - Alternatively, both categories may be specified explicitly without
  *   a top-level baseline.
  */
 export type AnimationDuration =
@@ -41,12 +39,10 @@ export type AnimationDuration =
   | (InOutDuration & {
       tap?: InOutDuration;
       hover?: InOutDuration;
-      pressAndHold?: InOutDuration;
     })
   | {
       tap: InOutDuration;
       hover: InOutDuration;
-      pressAndHold: InOutDuration;
     };
 
 export type TouchableProps = Omit<

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
@@ -57,7 +57,8 @@ export type TouchableProps = Omit<
     /**
      * Press and hover animation durations, in milliseconds. Pass a single
      * number to apply it to every phase, or an object to customize per phase
-     * and per category. Defaults to 100ms across the board.
+     * and per category. Defaults to 50ms for the in phase and 100ms for the
+     * out phase.
      */
     animationDuration?: AnimationDuration | undefined;
     /**

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
@@ -17,11 +17,52 @@ type PressableAndroidRippleConfig = {
 
 type RippleProps = 'rippleColor' | 'rippleRadius' | 'borderless' | 'foreground';
 
-export type TouchableProps = Omit<ButtonProps, RippleProps | 'enabled'> &
+type DurationProps =
+  | 'tapAnimationInDuration'
+  | 'tapAnimationOutDuration'
+  | 'pressAndHoldAnimationInDuration'
+  | 'pressAndHoldAnimationOutDuration'
+  | 'hoverAnimationInDuration'
+  | 'hoverAnimationOutDuration';
+
+type InOutDuration = { in: number; out: number };
+
+/**
+ * Configuration for press / hover animation timing.
+ *
+ * - A single number applies to every phase of every category.
+ * - An object with top-level `in` / `out` sets the baseline; any of `tap`,
+ *   `hover`, `pressAndHold` may override it.
+ * - Alternatively, all three categories may be specified explicitly without
+ *   a top-level baseline.
+ */
+export type AnimationDuration =
+  | number
+  | (InOutDuration & {
+      tap?: InOutDuration;
+      hover?: InOutDuration;
+      pressAndHold?: InOutDuration;
+    })
+  | {
+      tap: InOutDuration;
+      hover: InOutDuration;
+      pressAndHold: InOutDuration;
+    };
+
+export type TouchableProps = Omit<
+  ButtonProps,
+  RippleProps | 'enabled' | DurationProps
+> &
   Omit<
     BaseButtonProps,
     keyof RawButtonProps | 'onActiveStateChange' | 'onPress'
   > & {
+    /**
+     * Press and hover animation durations, in milliseconds. Pass a single
+     * number to apply it to every phase, or an object to customize per phase
+     * and per category. Defaults to 100ms across the board.
+     */
+    animationDuration?: AnimationDuration | undefined;
     /**
      * Configuration for the ripple effect on Android.
      */

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
@@ -30,15 +30,16 @@ type InOutDuration = { in: number; out: number };
  *
  * - A single number applies to every phase of every category.
  * - An object with top-level `in` / `out` sets the baseline; `tap` and
- *   `hover` may override it.
- * - Alternatively, both categories may be specified explicitly without
- *   a top-level baseline.
+ *   `hover` may override either side or both — any field left out
+ *   inherits the top-level value.
+ * - Alternatively, both categories may be specified in full without a
+ *   top-level baseline.
  */
 export type AnimationDuration =
   | number
   | (InOutDuration & {
-      tap?: InOutDuration;
-      hover?: InOutDuration;
+      tap?: Partial<InOutDuration>;
+      hover?: Partial<InOutDuration>;
     })
   | {
       tap: InOutDuration;


### PR DESCRIPTION
## Description

Updates the way animation duration is set on `Touchable`:
- removed `pressAndHold` since it was confusing to use
- removed individual `*animationDuration` props
- added a single `animationDuration` prop that:
  1. accepts a number (all animations have this duration)
  2. accepts a `{ in: number, out: number}` object with optional overrides
  3. accepts a `{ tap: {in, out}, hover: {in, out} }` object

## Test plan

Updated example
